### PR TITLE
Add Python Script to Translate Increments

### DIFF
--- a/.github/workflows/pynorms.yaml
+++ b/.github/workflows/pynorms.yaml
@@ -1,5 +1,5 @@
 name: Check Python Coding Norms
-on: [push, pull_request]
+on: [push]
 
 jobs:
   check_pynorms:

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -33,4 +33,4 @@ jobs:
     - name: Run ctest
       run: |
         cd $GITHUB_WORKSPACE/GDASApp/build
-        ctest
+        ctest -VV

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -1,5 +1,5 @@
 name: Run Unit Tests
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   ctests:

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -12,6 +12,7 @@ jobs:
       run: |
         pip install --upgrade pip
         pip install pycodestyle
+        pip install netCDF4
 
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -8,6 +8,11 @@ jobs:
 
     steps:
 
+    - name: Install dependencies
+      run: |
+        pip install --upgrade pip
+        pip install pycodestyle
+
     - name: Checkout
       uses: actions/checkout@v2
       with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 # ------------------------------------------------------------------------- #
 
 # Check for minimim cmake requirement
-cmake_minimum_required( VERSION 3.12 FATAL_ERROR )
+cmake_minimum_required( VERSION 3.20 FATAL_ERROR )
 
 find_package(ecbuild 3.5 REQUIRED HINTS ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/../ecbuild)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.20)
 
 # set the project name
 project(GDASApp)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,41 @@
-add_test(NAME test_check_yaml_keys
+##### get test data from EMC FTP server
+# set URL and hash
+set(URL "https://ftp.emc.ncep.noaa.gov/static_files/public/GDASApp")
+set(SHA "a85becadf39e43fbedb8444cc5a3c4d6331452df")
+string(SUBSTRING ${SHA} 0 6 SHORTSHA)
+set(TAR "gdasapp-fix-${SHORTSHA}.tgz")
+# download test files
+file(DOWNLOAD
+  ${URL}/${TAR}
+  ${CMAKE_CURRENT_BINARY_DIR}/${TAR}
+  INACTIVITY_TIMEOUT 30
+  TIMEOUT 90
+  SHOW_PROGRESS
+  STATUS status
+  EXPECTED_HASH SHA256=${SHA}
+  )
+# Extract downloaded tarball.
+file(ARCHIVE_EXTRACT INPUT ${TAR})
+
+# list of test files to install
+list(APPEND test_data
+  ${CMAKE_CURRENT_BINARY_DIR}/testdata/atminc_compress.nc4
+)
+
+# install
+install(FILES ${test_data}
+        DESTINATION "test/testdata")
+
+##### unit tests
+# test for python coding norms
+add_test(NAME GDASApp_check_python_norms
+         COMMAND pycodestyle -v --config ./.pycodestyle .
+         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+# test for ush/check_yaml_keys.py
+add_test(NAME GDASApp_check_yaml_keys
          COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/ush/check_yaml_keys.py ${PROJECT_SOURCE_DIR}/test/testinput/check_yaml_keys_ref.yaml ${PROJECT_SOURCE_DIR}/test/testinput/check_yaml_keys_test.yaml
+         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/)
+# test for ush/jediinc2fv3.py
+add_test(NAME GDASApp_jedi_increment_to_fv3
+         COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/ush/jediinc2fv3.py ${PROJECT_BINARY_DIR}/test/testdata/atminc_compress.nc4 ${PROJECT_BINARY_DIR}/test/testdata/fv_increment.nc 
          WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 ##### get test data from EMC FTP server
 # set URL and hash
 set(URL "https://ftp.emc.ncep.noaa.gov/static_files/public/GDASApp")
-set(SHA "a85becadf39e43fbedb8444cc5a3c4d6331452df")
+set(SHA "75c4ce84028956c1ce050e07f70abc25c540492c3e1a40f6fa56d35182322e8e")
 string(SUBSTRING ${SHA} 0 6 SHORTSHA)
 set(TAR "gdasapp-fix-${SHORTSHA}.tgz")
 # download test files

--- a/ush/jediinc2fv3.py
+++ b/ush/jediinc2fv3.py
@@ -22,49 +22,51 @@ vardict = {
 
 
 def jedi_inc_to_fv3(FV3JEDIinc, FV3inc):
-    assert os.path.exists(FV3JEDIinc), f"File {FV3JEDIinc} not found."
-    assert os.path.exists(FV3JEDIinc), f"File {FV3JEDIinc} not found."
     # open netCDF files
-    with nc.Dataset(FV3JEDIinc) as ncin, nc.Dataset(FV3inc, "w", format="NETCDF4") as ncout:
-        # copy over dimensions
-        for name, dimension in ncin.dimensions.items():
-            if name == 'time':
-                continue
-            elif name == 'edge':
-                nameout = 'ilev'
-            else:
-                nameout = name
-            ncout.createDimension(nameout,
-                                  (len(dimension) if not dimension.isunlimited() else None))
-        # some global attributes
-        ncout.source = 'jediinc2fv3.py'
-        ncout.comment = 'Increment produced by FV3-JEDI and modified for use by FV3 read'
-        # create all the dummy vertical coordinate variables
-        nlevs = len(ncin.dimensions['lev'])
-        pfull = range(1, nlevs+1)
-        phalf = range(1, nlevs+2)
-        levvar = ncout.createVariable('lev', 'f4', ('lev'))
-        levvar[:] = pfull
-        pfullvar = ncout.createVariable('pfull', 'f4', ('lev'))
-        pfullvar[:] = pfull
-        ilevvar = ncout.createVariable('ilev', 'f4', ('ilev'))
-        ilevvar[:] = phalf
-        hyaivar = ncout.createVariable('hyai', 'f4', ('ilev'))
-        hyaivar[:] = phalf
-        hybivar = ncout.createVariable('hybi', 'f4', ('ilev'))
-        hybivar[:] = phalf
-        # rename and change dimensionality of fields
-        for name, variable in ncin.variables.items():
-            if len(variable.dimensions) == 4:
-                dimsout = variable.dimensions[1:]
-            else:
-                dimsout = variable.dimensions
-            if name in vardict:
-                x = ncout.createVariable(vardict[name], 'f4', dimsout)
-                if len(variable.dimensions) == 4:
-                    ncout[vardict[name]][:] = ncin[name][0, ...]
-                else:
-                    ncout[vardict[name]][:] = ncin[name][:]
+    try:
+		with nc.Dataset(FV3JEDIinc) as ncin, nc.Dataset(FV3inc, "w", format="NETCDF4") as ncout:
+			# copy over dimensions
+			for name, dimension in ncin.dimensions.items():
+				if name == 'time':
+					continue
+				elif name == 'edge':
+					nameout = 'ilev'
+				else:
+					nameout = name
+				ncout.createDimension(nameout,
+									  (len(dimension) if not dimension.isunlimited() else None))
+			# some global attributes
+			ncout.source = 'jediinc2fv3.py'
+			ncout.comment = 'Increment produced by FV3-JEDI and modified for use by FV3 read'
+			# create all the dummy vertical coordinate variables
+			nlevs = len(ncin.dimensions['lev'])
+			pfull = range(1, nlevs+1)
+			phalf = range(1, nlevs+2)
+			levvar = ncout.createVariable('lev', 'f4', ('lev'))
+			levvar[:] = pfull
+			pfullvar = ncout.createVariable('pfull', 'f4', ('lev'))
+			pfullvar[:] = pfull
+			ilevvar = ncout.createVariable('ilev', 'f4', ('ilev'))
+			ilevvar[:] = phalf
+			hyaivar = ncout.createVariable('hyai', 'f4', ('ilev'))
+			hyaivar[:] = phalf
+			hybivar = ncout.createVariable('hybi', 'f4', ('ilev'))
+			hybivar[:] = phalf
+			# rename and change dimensionality of fields
+			for name, variable in ncin.variables.items():
+				if len(variable.dimensions) == 4:
+					dimsout = variable.dimensions[1:]
+				else:
+					dimsout = variable.dimensions
+				if name in vardict:
+					x = ncout.createVariable(vardict[name], 'f4', dimsout)
+					if len(variable.dimensions) == 4:
+						ncout[vardict[name]][:] = ncin[name][0, ...]
+					else:
+						ncout[vardict[name]][:] = ncin[name][:]
+	except FileNotFoundError as e:
+	    print(e)
+	    raise
 
 
 if __name__ == "__main__":

--- a/ush/jediinc2fv3.py
+++ b/ush/jediinc2fv3.py
@@ -62,7 +62,7 @@ def jedi_inc_to_fv3(FV3JEDIinc, FV3inc):
             if name in vardict:
                 x = ncout.createVariable(vardict[name], 'f4', dimsout)
                 if len(variable.dimensions) == 4:
-                    ncout[vardict[name]][:] = ncin[name][0,...]
+                    ncout[vardict[name]][:] = ncin[name][0, ...]
                 else:
                     ncout[vardict[name]][:] = ncin[name][:]
 

--- a/ush/jediinc2fv3.py
+++ b/ush/jediinc2fv3.py
@@ -24,49 +24,49 @@ vardict = {
 def jedi_inc_to_fv3(FV3JEDIinc, FV3inc):
     # open netCDF files
     try:
-		with nc.Dataset(FV3JEDIinc) as ncin, nc.Dataset(FV3inc, "w", format="NETCDF4") as ncout:
-			# copy over dimensions
-			for name, dimension in ncin.dimensions.items():
-				if name == 'time':
-					continue
-				elif name == 'edge':
-					nameout = 'ilev'
-				else:
-					nameout = name
-				ncout.createDimension(nameout,
-									  (len(dimension) if not dimension.isunlimited() else None))
-			# some global attributes
-			ncout.source = 'jediinc2fv3.py'
-			ncout.comment = 'Increment produced by FV3-JEDI and modified for use by FV3 read'
-			# create all the dummy vertical coordinate variables
-			nlevs = len(ncin.dimensions['lev'])
-			pfull = range(1, nlevs+1)
-			phalf = range(1, nlevs+2)
-			levvar = ncout.createVariable('lev', 'f4', ('lev'))
-			levvar[:] = pfull
-			pfullvar = ncout.createVariable('pfull', 'f4', ('lev'))
-			pfullvar[:] = pfull
-			ilevvar = ncout.createVariable('ilev', 'f4', ('ilev'))
-			ilevvar[:] = phalf
-			hyaivar = ncout.createVariable('hyai', 'f4', ('ilev'))
-			hyaivar[:] = phalf
-			hybivar = ncout.createVariable('hybi', 'f4', ('ilev'))
-			hybivar[:] = phalf
-			# rename and change dimensionality of fields
-			for name, variable in ncin.variables.items():
-				if len(variable.dimensions) == 4:
-					dimsout = variable.dimensions[1:]
-				else:
-					dimsout = variable.dimensions
-				if name in vardict:
-					x = ncout.createVariable(vardict[name], 'f4', dimsout)
-					if len(variable.dimensions) == 4:
-						ncout[vardict[name]][:] = ncin[name][0, ...]
-					else:
-						ncout[vardict[name]][:] = ncin[name][:]
-	except FileNotFoundError as e:
-	    print(e)
-	    raise
+        with nc.Dataset(FV3JEDIinc) as ncin, nc.Dataset(FV3inc, "w", format="NETCDF4") as ncout:
+            # copy over dimensions
+            for name, dimension in ncin.dimensions.items():
+                if name == 'time':
+                    continue
+                elif name == 'edge':
+                    nameout = 'ilev'
+                else:
+                    nameout = name
+                ncout.createDimension(nameout,
+                                      (len(dimension) if not dimension.isunlimited() else None))
+            # some global attributes
+            ncout.source = 'jediinc2fv3.py'
+            ncout.comment = 'Increment produced by FV3-JEDI and modified for use by FV3 read'
+            # create all the dummy vertical coordinate variables
+            nlevs = len(ncin.dimensions['lev'])
+            pfull = range(1, nlevs+1)
+            phalf = range(1, nlevs+2)
+            levvar = ncout.createVariable('lev', 'f4', ('lev'))
+            levvar[:] = pfull
+            pfullvar = ncout.createVariable('pfull', 'f4', ('lev'))
+            pfullvar[:] = pfull
+            ilevvar = ncout.createVariable('ilev', 'f4', ('ilev'))
+            ilevvar[:] = phalf
+            hyaivar = ncout.createVariable('hyai', 'f4', ('ilev'))
+            hyaivar[:] = phalf
+            hybivar = ncout.createVariable('hybi', 'f4', ('ilev'))
+            hybivar[:] = phalf
+            # rename and change dimensionality of fields
+            for name, variable in ncin.variables.items():
+                if len(variable.dimensions) == 4:
+                    dimsout = variable.dimensions[1:]
+                else:
+                    dimsout = variable.dimensions
+                if name in vardict:
+                    x = ncout.createVariable(vardict[name], 'f4', dimsout)
+                    if len(variable.dimensions) == 4:
+                        ncout[vardict[name]][:] = ncin[name][0, ...]
+                    else:
+                        ncout[vardict[name]][:] = ncin[name][:]
+    except FileNotFoundError as e:
+        print(e)
+        raise
 
 
 if __name__ == "__main__":

--- a/ush/jediinc2fv3.py
+++ b/ush/jediinc2fv3.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# translate FV3-JEDI increment to FV3 readable format
+import argparse
+import netCDF4 as nc
+import os
+
+vardict = {
+    'ua': 'u_inc',
+    'va': 'v_inc',
+    'delp': 'delp_inc',
+    'DELP': 'delp_inc',
+    'delz': 'delz_inc',
+    'T': 'T_inc',
+    'sphum': 'sphum_inc',
+    'liq_wat': 'liq_wat_inc',
+    'o3mr': 'o3mr_inc',
+    'ice_wat': 'icmr_inc',
+    'lat': 'lat',
+    'lon': 'lon',
+}
+
+
+def jedi_inc_to_fv3(FV3JEDIinc, FV3inc):
+    assert os.path.exists(FV3JEDIinc), f"File {FV3JEDIinc} not found."
+    assert os.path.exists(FV3JEDIinc), f"File {FV3JEDIinc} not found."
+    # open netCDF files
+    with nc.Dataset(FV3JEDIinc) as ncin, nc.Dataset(FV3inc, "w", format="NETCDF4") as ncout:
+        # copy over dimensions
+        for name, dimension in ncin.dimensions.items():
+            if name == 'time':
+                continue
+            elif name == 'edge':
+                nameout = 'ilev'
+            else:
+                nameout = name
+            ncout.createDimension(nameout,
+                                  (len(dimension) if not dimension.isunlimited() else None))
+        # some global attributes
+        ncout.source = 'jediinc2fv3.py'
+        ncout.comment = 'Increment produced by FV3-JEDI and modified for use by FV3 read'
+        # create all the dummy vertical coordinate variables
+        pfull = range(1,128)
+        phalf = range(1,129)
+        levvar = ncout.createVariable('lev', 'f4', ('lev'))
+        levvar[:] = pfull
+        pfullvar = ncout.createVariable('pfull', 'f4', ('lev'))
+        pfullvar[:] = pfull
+        ilevvar = ncout.createVariable('ilev', 'f4', ('ilev'))
+        ilevvar[:] = phalf
+        hyaivar = ncout.createVariable('hyai', 'f4', ('ilev'))
+        hyaivar[:] = phalf
+        hybivar = ncout.createVariable('hybi', 'f4', ('ilev'))
+        hybivar[:] = phalf
+        # rename and change dimensionality of fields
+        for name, variable in ncin.variables.items():
+            if name in vardict:
+                print(name, vardict[name], variable.datatype, variable.dimensions)
+                #x = ncout.createVariable(vardict[name], variable.datatype, dimsout)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument('FV3JEDIincrement', type=str, help='Input FV3-JEDI LatLon Increment File')
+    parser.add_argument('FV3increment', type=str, help='Output FV3 Increment File')
+    args = parser.parse_args()
+    jedi_inc_to_fv3(args.FV3JEDIincrement, args.FV3increment)


### PR DESCRIPTION
This PR:
- Adds a python script that can 'translate' FV3-JEDI LatLon increments to current FV3 format
- Makes the ctest run in CI only with pull requests
- Adds a capability to download 'fix files' from EMC FTP server
- Adds a unit test to test the increment script

Note: I have NOT tested the output file yet with the model, but it 'looks' like it should work.