### PR TITLE
Update Orion modulefile to use new python venv

### DIFF
--- a/modulefiles/GDAS/orion.lua
+++ b/modulefiles/GDAS/orion.lua
@@ -1,4 +1,4 @@
--- NOAA HPC Orion Modulefile for UFS-DA
+-- NOAA HPC Orion Modulefile for GDASApp 
 help([[
 ]])
 
@@ -11,19 +11,50 @@ setenv('JEDI_OPT', jedi_opt)
 local jedi_core = pathJoin(jedi_opt, 'modulefiles/core')
 prepend_path("MODULEPATH", jedi_core)
 
-load('jedi/intel-impi')
+prepend_path("MODULEPATH", '/work2/noaa/da/python/opt/modulefiles/stack')
 
+load("cmake/3.18.1")
+load("git/2.28.0")
+load("git-lfs/2.13.2")
+
+load("jedi-intel/2020.2")
+load("mkl/2020.2")
+load("szip/2.1.1")
+load("zlib/1.2.11")
+load("udunits/2.2.28")
+load("gsl_lite/0.37.0")
+load("jedi-impi/2020.2")
+
+load("hdf5/1.12.0")
+load("pnetcdf/1.12.1")
+load("netcdf/4.7.4")
+
+load("boost-headers/1.68.0")
+load("eigen/3.3.7")
+load("bufr/noaa-emc-11.5.0")
+load("pybind11/2.7.0")
+load("nccmp/1.8.7.0")
+load("pio/2.5.1-debug")
+
+load("ecbuild/ecmwf-3.6.1")
+load("eckit/ecmwf-1.16.0")
+load("fckit/ecmwf-0.9.2")
+load("atlas/ecmwf-0.24.1")
+
+load("hpc")
+load("miniconda3")
+load("gdasapp")
+
+setenv("CC","mpiicc")
+setenv("FC","mpiifort")
+setenv("CXX","mpiicpc")
 local mpiexec = '/opt/slurm/bin/srun'
 local mpinproc = '-n'
 setenv('MPIEXEC_EXEC', mpiexec)
 setenv('MPIEXEC_NPROC', mpinproc)
 
--- add R2D2 and SOLO to PYTHONPATH
-prepend_path("PYTHONPATH", "/work2/noaa/da/cmartin/UFSDA/python/local/lib/python3.9/site-packages")
--- add R2D2 to path
-prepend_path("PATH", "/work2/noaa/da/cmartin/UFSDA/python/local/bin")
 
 whatis("Name: ".. pkgName)
 whatis("Version: " .. pkgVersion)
-whatis("Category: UFS-DA")
-whatis("Description: Load JEDI-Stack for UFS-DA")
+whatis("Category: GDASApp")
+whatis("Description: Load all libraries needed for GDASApp")


### PR DESCRIPTION
Update the Orion modulefile to 1) load each library/module explicitly rather than the JEDI metamodule and 2) load a GDASApp python virtual environment.

A later PR will do the same for Hera once I have set up the venv there.

@guillaumevernieres please ensure when these modules are loaded that soca r2d2 scripts work as intended. I *think* the correct commits were checked out by pip when the env was installed.