### PR TITLE
Create test r2d2 obs database for soca

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 ##### get test data from EMC FTP server
 # set URL and hash
 set(URL "https://ftp.emc.ncep.noaa.gov/static_files/public/GDASApp")
-set(SHA "75c4ce84028956c1ce050e07f70abc25c540492c3e1a40f6fa56d35182322e8e")
+set(SHA "2b547a5f489130edc240db04a08034d15787c15732871526b1873f0a27e491a4")
 string(SUBSTRING ${SHA} 0 6 SHORTSHA)
 set(TAR "gdasapp-fix-${SHORTSHA}.tgz")
 # download test files
@@ -21,6 +21,12 @@ file(ARCHIVE_EXTRACT INPUT ${CMAKE_CURRENT_BINARY_DIR}/${TAR}
 # list of test binary/data files to install
 list(APPEND test_data
   ${CMAKE_CURRENT_BINARY_DIR}/testdata/atminc_compress.nc4
+  ${CMAKE_CURRENT_BINARY_DIR}/testdata/adt.nc
+  ${CMAKE_CURRENT_BINARY_DIR}/testdata/sst.nc
+  ${CMAKE_CURRENT_BINARY_DIR}/testdata/sss.nc
+  ${CMAKE_CURRENT_BINARY_DIR}/testdata/prof.nc
+  ${CMAKE_CURRENT_BINARY_DIR}/testdata/icec.nc
+  ${CMAKE_CURRENT_BINARY_DIR}/testdata/icefb.nc
 )
 
 # install
@@ -78,5 +84,5 @@ PROPERTIES
          ENVIRONMENT "PYTHONPATH=${PROJECT_BINARY_DIR}/ush:$ENV{PYTHONPATH}"
 )
 
-# soca regression tests
+# soca tests
 add_subdirectory(soca)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -62,11 +62,11 @@ add_test(NAME test_gdasapp_check_yaml_keys
          WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/)
 # test to ensure all YAML in repo is valid YAML
 add_test(NAME test_gdasapp_check_valid_yaml
-         COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/test/check_valid_yaml.py ${PROJECT_SOURCE_DIR} 
+         COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/test/check_valid_yaml.py ${PROJECT_SOURCE_DIR}
          WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/)
 # test for ush/jediinc2fv3.py
 add_test(NAME test_gdasapp_jedi_increment_to_fv3
-         COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/ush/jediinc2fv3.py ${PROJECT_BINARY_DIR}/test/testdata/atminc_compress.nc4 ${PROJECT_BINARY_DIR}/test/testoutput/fv_increment.nc 
+         COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/ush/jediinc2fv3.py ${PROJECT_BINARY_DIR}/test/testdata/atminc_compress.nc4 ${PROJECT_BINARY_DIR}/test/testoutput/fv_increment.nc
          WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/)
 # test for YAML generation from a template
 add_test(NAME test_gdasapp_generate_yaml
@@ -77,3 +77,6 @@ set_tests_properties(
 PROPERTIES
          ENVIRONMENT "PYTHONPATH=${PROJECT_BINARY_DIR}/ush:$ENV{PYTHONPATH}"
 )
+
+# soca regression tests
+add_subdirectory(soca)

--- a/test/soca/CMakeLists.txt
+++ b/test/soca/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Create a test R2D2 database
 # ---------------------------
 set( OBS_DIR ${PROJECT_BINARY_DIR}/test/testdata )
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/obs)
 ecbuild_add_test(
       TARGET    test_gdasapp_soca_obsdb
       TYPE      SCRIPT

--- a/test/soca/CMakeLists.txt
+++ b/test/soca/CMakeLists.txt
@@ -21,8 +21,13 @@ endforeach(FILENAME)
 
 # Create a test R2D2 database
 # ---------------------------
-add_test(
-      NAME    test_gdasapp_soca_obsdb
-      COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/test/soca/create_obsdb.py
-      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/obs
+set( WRK_DIR ${CMAKE_CURRENT_BINARY_DIR}/obs )
+ecbuild_add_test(
+      TARGET    test_gdasapp_soca_obsdb
+      TYPE      SCRIPT
+      COMMAND   ${Python3_EXECUTABLE}
+      ARGS      ${PROJECT_SOURCE_DIR}/test/soca/create_obsdb.py
+      WORKING_DIRECTORY ${WRK_DIR}
+      ENVIRONMENT
+        WRK_DIR=${WRK_DIR}
 )

--- a/test/soca/CMakeLists.txt
+++ b/test/soca/CMakeLists.txt
@@ -1,33 +1,12 @@
-# Get marine observations from soca.
-# ----------------------------------
-set( soca_obs
-  Data/Obs/adt.nc
-  Data/Obs/icec.nc
-  Data/Obs/icefb.nc
-  Data/Obs/prof.nc
-  Data/Obs/sss.nc
-  Data/Obs/sst.nc
-)
-
-# Symlink observations
-# --------------------
-file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/obs)
-foreach(FILENAME ${soca_obs})
-  get_filename_component(filename ${FILENAME} NAME )
-  execute_process( COMMAND ${CMAKE_COMMAND} -E create_symlink
-           ${PROJECT_SOURCE_DIR}/soca/test/${FILENAME}
-           ${CMAKE_CURRENT_BINARY_DIR}/obs/${filename} )
-endforeach(FILENAME)
-
 # Create a test R2D2 database
 # ---------------------------
-set( WRK_DIR ${CMAKE_CURRENT_BINARY_DIR}/obs )
+set( OBS_DIR ${PROJECT_BINARY_DIR}/test/testdata )
 ecbuild_add_test(
       TARGET    test_gdasapp_soca_obsdb
       TYPE      SCRIPT
       COMMAND   ${Python3_EXECUTABLE}
       ARGS      ${PROJECT_SOURCE_DIR}/test/soca/create_obsdb.py
-      WORKING_DIRECTORY ${WRK_DIR}
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/obs
       ENVIRONMENT
-        WRK_DIR=${WRK_DIR}
+        OBS_DIR=${OBS_DIR}
 )

--- a/test/soca/CMakeLists.txt
+++ b/test/soca/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Get marine observations from soca.
+# ----------------------------------
+set( soca_obs
+  Data/Obs/adt.nc
+  Data/Obs/icec.nc
+  Data/Obs/icefb.nc
+  Data/Obs/prof.nc
+  Data/Obs/sss.nc
+  Data/Obs/sst.nc
+)
+
+# Symlink observations
+# --------------------
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/obs)
+foreach(FILENAME ${soca_obs})
+  get_filename_component(filename ${FILENAME} NAME )
+  execute_process( COMMAND ${CMAKE_COMMAND} -E create_symlink
+           ${PROJECT_SOURCE_DIR}/soca/test/${FILENAME}
+           ${CMAKE_CURRENT_BINARY_DIR}/obs/${filename} )
+endforeach(FILENAME)
+
+# Create a test R2D2 database
+# ---------------------------
+add_test(
+      NAME    test_gdasapp_soca_obsdb
+      COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/test/soca/create_obsdb.py
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/obs
+)

--- a/test/soca/create_obsdb.py
+++ b/test/soca/create_obsdb.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import argparse
 import os
+import shutil
 from r2d2 import store
 from solo.configuration import Configuration
 from solo.date import date_sequence
@@ -57,13 +58,13 @@ if __name__ == "__main__":
     os.environ['R2D2_CONFIG'] = 'r2d2_config_test.yaml'
 
     # Change the obs file format
-    os.system('cp -L adt.nc adt_j3_20180415.nc4')
-    os.system('cp -L sst.nc sst_noaa19_l3u_20180415.nc4')
-    os.system('cp -L sss.nc sss_smap_20180415.nc4')
-    os.system('cp -L prof.nc temp_profile_fnmoc_20180415.nc4')
-    os.system('cp -L prof.nc salt_profile_fnmoc_20180415.nc4')
-    os.system('cp -L icec.nc icec_EMC_20180415.nc4')
-    os.system('cp -L icefb.nc icefb_GDR_20180415.nc4')
+    shutil.copyfile('adt.nc', 'adt_j3_20180415.nc4', follow_symlinks=True)
+    shutil.copyfile('sst.nc', 'sst_noaa19_l3u_20180415.nc4', follow_symlinks=True)
+    shutil.copyfile('sss.nc', 'sss_smap_20180415.nc4', follow_symlinks=True)
+    shutil.copyfile('prof.nc', 'temp_profile_fnmoc_20180415.nc4', follow_symlinks=True)
+    shutil.copyfile('prof.nc', 'salt_profile_fnmoc_20180415.nc4', follow_symlinks=True)
+    shutil.copyfile('icec.nc', 'icec_EMC_20180415.nc4', follow_symlinks=True)
+    shutil.copyfile('icefb.nc', 'icefb_GDR_20180415.nc4', follow_symlinks=True)
 
     # Create the test R2D2 database
     obsstore = {'start': '20180415',

--- a/test/soca/create_obsdb.py
+++ b/test/soca/create_obsdb.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+import argparse
+import os
+from r2d2 import store
+from solo.configuration import Configuration
+from solo.date import date_sequence
+import yaml
+
+
+def store_obs(yaml_file):
+    config = Configuration(yaml_file)
+    dates = date_sequence(config.start, config.end, config.step)
+    obs_types = config.obs_types
+    provider = config.provider
+    experiment = config.experiment
+    database = config.database
+    type = config.type
+    source_dir = config.source_dir
+    step = config.step
+
+    for date in dates:
+        day = str(date).split('T')[0]
+        year = day[0:4]
+        month = day[4:6]
+        day = day[6:8]
+        for obs_type in obs_types:
+            obs_prefix = obs_type.split('_')[0]
+            store(
+                provider=provider,
+                type=type,
+                experiment=experiment,
+                database=database,
+                date=date,
+                obs_type=obs_type,
+                time_window=step,
+                source_file=f'{source_dir}/{obs_type}_{year}{month}{day}.nc4',
+                ignore_missing=True,
+            )
+
+
+if __name__ == "__main__":
+
+    # Set the R2D2_CONFIG environement variable
+    r2d2_config = {'databases': {'archive': {'bucket': 'archive.jcsda',
+                                             'cache_fetch': True,
+                                             'class': 'S3DB'},
+                                 'local': {'cache_fetch': False,
+                                           'class': 'LocalDB',
+                                           'root': './r2d2-local/'},
+                                 'shared': {'cache_fetch': False,
+                                            'class': 'LocalDB',
+                                            'root': './r2d2-shared/'}},
+                   'fetch_order': ['local'],
+                   'store_order': ['shared', 'local', 'archive']}
+    f = open('r2d2_config_test.yaml', 'w')
+    yaml.dump(r2d2_config, f, sort_keys=False, default_flow_style=False)
+    os.environ['R2D2_CONFIG'] = 'r2d2_config_test.yaml'
+
+    # Change the obs file format
+    os.system('cp -L adt.nc adt_j3_20180415.nc4')
+    os.system('cp -L sst.nc sst_noaa19_l3u_20180415.nc4')
+    os.system('cp -L sss.nc sss_smap_20180415.nc4')
+    os.system('cp -L prof.nc temp_profile_fnmoc_20180415.nc4')
+    os.system('cp -L prof.nc salt_profile_fnmoc_20180415.nc4')
+    os.system('cp -L icec.nc icec_EMC_20180415.nc4')
+    os.system('cp -L icefb.nc icefb_GDR_20180415.nc4')
+
+    # Create the test R2D2 database
+    obsstore = {'start': '20180415',
+                'end': '20180415',
+                'step': 'P1D',
+                'source_dir': '.',
+                'type': 'ob',
+                'database': 'shared',
+                'provider': 'gdasapp',
+                'experiment': 'soca',
+                'obs_types': ['adt_j3',
+                              'sst_noaa19_l3u',
+                              'sss_smap',
+                              'temp_profile_fnmoc',
+                              'salt_profile_fnmoc',
+                              'icec_EMC',
+                              'icefb_GDR']}
+    f = open('store_obs.yaml', 'w')
+    yaml.dump(obsstore, f, sort_keys=False, default_flow_style=False)
+    store_obs('store_obs.yaml')

--- a/test/soca/create_obsdb.py
+++ b/test/soca/create_obsdb.py
@@ -58,13 +58,14 @@ if __name__ == "__main__":
     os.environ['R2D2_CONFIG'] = 'r2d2_config_test.yaml'
 
     # Change the obs file format
-    shutil.copyfile('adt.nc', 'adt_j3_20180415.nc4', follow_symlinks=True)
-    shutil.copyfile('sst.nc', 'sst_noaa19_l3u_20180415.nc4', follow_symlinks=True)
-    shutil.copyfile('sss.nc', 'sss_smap_20180415.nc4', follow_symlinks=True)
-    shutil.copyfile('prof.nc', 'temp_profile_fnmoc_20180415.nc4', follow_symlinks=True)
-    shutil.copyfile('prof.nc', 'salt_profile_fnmoc_20180415.nc4', follow_symlinks=True)
-    shutil.copyfile('icec.nc', 'icec_EMC_20180415.nc4', follow_symlinks=True)
-    shutil.copyfile('icefb.nc', 'icefb_GDR_20180415.nc4', follow_symlinks=True)
+    wrk = os.getenv('WRK_DIR')
+    shutil.copyfile(os.path.join(wrk, 'adt.nc'), 'adt_j3_20180415.nc4', follow_symlinks=True)
+    shutil.copyfile(os.path.join(wrk, 'sst.nc'), 'sst_noaa19_l3u_20180415.nc4', follow_symlinks=True)
+    shutil.copyfile(os.path.join(wrk, 'sss.nc'), 'sss_smap_20180415.nc4', follow_symlinks=True)
+    shutil.copyfile(os.path.join(wrk, 'prof.nc'), 'temp_profile_fnmoc_20180415.nc4', follow_symlinks=True)
+    shutil.copyfile(os.path.join(wrk, 'prof.nc'), 'salt_profile_fnmoc_20180415.nc4', follow_symlinks=True)
+    shutil.copyfile(os.path.join(wrk, 'icec.nc'), 'icec_EMC_20180415.nc4', follow_symlinks=True)
+    shutil.copyfile(os.path.join(wrk, 'icefb.nc'), 'icefb_GDR_20180415.nc4', follow_symlinks=True)
 
     # Create the test R2D2 database
     obsstore = {'start': '20180415',

--- a/test/soca/create_obsdb.py
+++ b/test/soca/create_obsdb.py
@@ -58,14 +58,14 @@ if __name__ == "__main__":
     os.environ['R2D2_CONFIG'] = 'r2d2_config_test.yaml'
 
     # Change the obs file format
-    wrk = os.getenv('WRK_DIR')
-    shutil.copyfile(os.path.join(wrk, 'adt.nc'), 'adt_j3_20180415.nc4', follow_symlinks=True)
-    shutil.copyfile(os.path.join(wrk, 'sst.nc'), 'sst_noaa19_l3u_20180415.nc4', follow_symlinks=True)
-    shutil.copyfile(os.path.join(wrk, 'sss.nc'), 'sss_smap_20180415.nc4', follow_symlinks=True)
-    shutil.copyfile(os.path.join(wrk, 'prof.nc'), 'temp_profile_fnmoc_20180415.nc4', follow_symlinks=True)
-    shutil.copyfile(os.path.join(wrk, 'prof.nc'), 'salt_profile_fnmoc_20180415.nc4', follow_symlinks=True)
-    shutil.copyfile(os.path.join(wrk, 'icec.nc'), 'icec_EMC_20180415.nc4', follow_symlinks=True)
-    shutil.copyfile(os.path.join(wrk, 'icefb.nc'), 'icefb_GDR_20180415.nc4', follow_symlinks=True)
+    obsdir = os.getenv('OBS_DIR')
+    shutil.copyfile(os.path.join(obsdir, 'adt.nc'), 'adt_j3_20180415.nc4', follow_symlinks=True)
+    shutil.copyfile(os.path.join(obsdir, 'sst.nc'), 'sst_noaa19_l3u_20180415.nc4', follow_symlinks=True)
+    shutil.copyfile(os.path.join(obsdir, 'sss.nc'), 'sss_smap_20180415.nc4', follow_symlinks=True)
+    shutil.copyfile(os.path.join(obsdir, 'prof.nc'), 'temp_profile_fnmoc_20180415.nc4', follow_symlinks=True)
+    shutil.copyfile(os.path.join(obsdir, 'prof.nc'), 'salt_profile_fnmoc_20180415.nc4', follow_symlinks=True)
+    shutil.copyfile(os.path.join(obsdir, 'icec.nc'), 'icec_EMC_20180415.nc4', follow_symlinks=True)
+    shutil.copyfile(os.path.join(obsdir, 'icefb.nc'), 'icefb_GDR_20180415.nc4', follow_symlinks=True)
 
     # Create the test R2D2 database
     obsstore = {'start': '20180415',


### PR DESCRIPTION
Add a test that grabs test observations from the soca repo and create a shared r2d2 database.
- fixes #27 