### PR TITLE
Add ioda-converters to build and add test for BUFR2IODA

### DIFF
--- a/.github/workflows/hera.yaml
+++ b/.github/workflows/hera.yaml
@@ -19,13 +19,3 @@ jobs:
       run: |
         echo "RT failed on NOAA RDHPCS Hera"
         exit 1
-    - name: Echo fail due to queued 
-      if: ${{ github.event.label.name == 'hera-RT' }}
-      run: |
-        echo "RT queued on NOAA RDHPCS Hera"
-        exit 1
-    - name: Echo fail due to running 
-      if: ${{ github.event.label.name == 'hera-RT-Running' }}
-      run: |
-        echo "RT running on NOAA RDHPCS Hera"
-        exit 1

--- a/.github/workflows/hera.yaml
+++ b/.github/workflows/hera.yaml
@@ -25,7 +25,7 @@ jobs:
         echo "RT queued on NOAA RDHPCS Hera"
         exit 1
     - name: Echo fail due to running 
-      if: ${{ github.event.label.name == 'hera-RT-running' }}
+      if: ${{ github.event.label.name == 'hera-RT-Running' }}
       run: |
         echo "RT running on NOAA RDHPCS Hera"
         exit 1

--- a/.github/workflows/orion.yaml
+++ b/.github/workflows/orion.yaml
@@ -19,13 +19,3 @@ jobs:
       run: |
         echo "RT failed on NOAA RDHPCS Orion"
         exit 1
-    - name: Echo fail due to queued 
-      if: ${{ github.event.label.name == 'orion-RT' }}
-      run: |
-        echo "RT queued on NOAA RDHPCS Orion"
-        exit 1
-    - name: Echo fail due to running 
-      if: ${{ github.event.label.name == 'orion-RT-running' }}
-      run: |
-        echo "RT running on NOAA RDHPCS Orion"
-        exit 1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ if(BUILD_GDASBUNDLE)
   ecbuild_bundle( PROJECT soca GIT "https://github.com/jcsda-internal/soca.git" UPDATE BRANCH develop )
 
 # Build IODA converters
-  option(BUILD_IODA_CONVERTERS "Build IODA Converters" OFF)
+  option(BUILD_IODA_CONVERTERS "Build IODA Converters" ON)
   if(BUILD_IODA_CONVERTERS)
     ecbuild_bundle( PROJECT iodaconv GIT "https://github.com/JCSDA-internal/ioda-converters.git" BRANCH develop UPDATE )
   endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -39,6 +39,7 @@ list(APPEND test_input
   ${PROJECT_SOURCE_DIR}/test/testinput/check_yaml_keys_test.yaml
   ${PROJECT_SOURCE_DIR}/test/testinput/generate_yaml.yaml
   ${PROJECT_SOURCE_DIR}/test/testinput/generate_yaml_include.yaml
+  ${PROJECT_SOURCE_DIR}/test/testinput/bufr_adpsfc.yaml
 )
 
 # create testinput dir
@@ -86,3 +87,6 @@ PROPERTIES
 
 # soca tests
 add_subdirectory(soca)
+
+# gdas atm tests
+add_subdirectory(atm)

--- a/test/atm/CMakeLists.txt
+++ b/test/atm/CMakeLists.txt
@@ -1,0 +1,13 @@
+# tests that can run without needing all JEDI components
+
+# tests that require the full build
+if(BUILD_GDASBUNDLE)
+
+  # link input file from iodaconv to test directory
+  file(CREATE_LINK ${PROJECT_BINARY_DIR}/iodaconv/test/testinput/gdas.t06z.adpsfc.tm00.bufr_d ${PROJECT_BINARY_DIR}/test/testdata/gdas.t06z.adpsfc.tm00.bufr_d 
+  # test convert BUFR to IODA
+  add_test(NAME test_gdasapp_convert_bufr_adpsfc
+           COMMAND ${PROJECT_BINARY_DIR}/bin/bufr2ioda.x ${PROJECT_BINARY_DIR}/test/testinput/bufr_adpsfc.yaml
+           WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/)
+
+endif(BUILD_GDASBUNDLE)

--- a/test/atm/CMakeLists.txt
+++ b/test/atm/CMakeLists.txt
@@ -4,7 +4,7 @@
 if(BUILD_GDASBUNDLE)
 
   # link input file from iodaconv to test directory
-  file(COPY ${PROJECT_SOURCE_DIR}/iodaconv/test/testinput/gdas.t06z.adpsfc.tm00.bufr_d ${PROJECT_BINARY_DIR}/test/testdata/gdas.t06z.adpsfc.tm00.bufr_d) 
+  file(COPY ${PROJECT_SOURCE_DIR}/iodaconv/test/testinput/gdas.t06z.adpsfc.tm00.bufr_d DESTINATION ${PROJECT_BINARY_DIR}/test/testdata/) 
   # test convert BUFR to IODA
   add_test(NAME test_gdasapp_convert_bufr_adpsfc
            COMMAND ${PROJECT_BINARY_DIR}/bin/bufr2ioda.x ${PROJECT_BINARY_DIR}/test/testinput/bufr_adpsfc.yaml

--- a/test/atm/CMakeLists.txt
+++ b/test/atm/CMakeLists.txt
@@ -4,7 +4,7 @@
 if(BUILD_GDASBUNDLE)
 
   # link input file from iodaconv to test directory
-  file(CREATE_LINK ${PROJECT_BINARY_DIR}/iodaconv/test/testinput/gdas.t06z.adpsfc.tm00.bufr_d ${PROJECT_BINARY_DIR}/test/testdata/gdas.t06z.adpsfc.tm00.bufr_d) 
+  file(COPY ${PROJECT_BINARY_DIR}/iodaconv/test/testinput/gdas.t06z.adpsfc.tm00.bufr_d ${PROJECT_BINARY_DIR}/test/testdata/gdas.t06z.adpsfc.tm00.bufr_d) 
   # test convert BUFR to IODA
   add_test(NAME test_gdasapp_convert_bufr_adpsfc
            COMMAND ${PROJECT_BINARY_DIR}/bin/bufr2ioda.x ${PROJECT_BINARY_DIR}/test/testinput/bufr_adpsfc.yaml

--- a/test/atm/CMakeLists.txt
+++ b/test/atm/CMakeLists.txt
@@ -4,7 +4,7 @@
 if(BUILD_GDASBUNDLE)
 
   # link input file from iodaconv to test directory
-  file(COPY ${PROJECT_BINARY_DIR}/iodaconv/test/testinput/gdas.t06z.adpsfc.tm00.bufr_d ${PROJECT_BINARY_DIR}/test/testdata/gdas.t06z.adpsfc.tm00.bufr_d) 
+  file(CREATE_LINK ${PROJECT_SOURCE_DIR}/iodaconv/test/testinput/gdas.t06z.adpsfc.tm00.bufr_d ${PROJECT_BINARY_DIR}/test/testdata/gdas.t06z.adpsfc.tm00.bufr_d SYMBOLIC) 
   # test convert BUFR to IODA
   add_test(NAME test_gdasapp_convert_bufr_adpsfc
            COMMAND ${PROJECT_BINARY_DIR}/bin/bufr2ioda.x ${PROJECT_BINARY_DIR}/test/testinput/bufr_adpsfc.yaml

--- a/test/atm/CMakeLists.txt
+++ b/test/atm/CMakeLists.txt
@@ -4,7 +4,7 @@
 if(BUILD_GDASBUNDLE)
 
   # link input file from iodaconv to test directory
-  file(CREATE_LINK ${PROJECT_BINARY_DIR}/iodaconv/test/testinput/gdas.t06z.adpsfc.tm00.bufr_d ${PROJECT_BINARY_DIR}/test/testdata/gdas.t06z.adpsfc.tm00.bufr_d 
+  file(CREATE_LINK ${PROJECT_BINARY_DIR}/iodaconv/test/testinput/gdas.t06z.adpsfc.tm00.bufr_d ${PROJECT_BINARY_DIR}/test/testdata/gdas.t06z.adpsfc.tm00.bufr_d) 
   # test convert BUFR to IODA
   add_test(NAME test_gdasapp_convert_bufr_adpsfc
            COMMAND ${PROJECT_BINARY_DIR}/bin/bufr2ioda.x ${PROJECT_BINARY_DIR}/test/testinput/bufr_adpsfc.yaml

--- a/test/atm/CMakeLists.txt
+++ b/test/atm/CMakeLists.txt
@@ -4,7 +4,7 @@
 if(BUILD_GDASBUNDLE)
 
   # link input file from iodaconv to test directory
-  file(COPY ${PROJECT_SOURCE_DIR}/iodaconv/test/testinput/gdas.t06z.adpsfc.tm00.bufr_d DESTINATION ${PROJECT_BINARY_DIR}/test/testdata/) 
+  file(CREATE_LINK ${PROJECT_SOURCE_DIR}/iodaconv/test/testinput/gdas.t06z.adpsfc.tm00.bufr_d ${PROJECT_BINARY_DIR}/test/testdata/gdas.t06z.adpsfc.tm00.bufr_d SYMBOLIC)
   # test convert BUFR to IODA
   add_test(NAME test_gdasapp_convert_bufr_adpsfc
            COMMAND ${PROJECT_BINARY_DIR}/bin/bufr2ioda.x ${PROJECT_BINARY_DIR}/test/testinput/bufr_adpsfc.yaml

--- a/test/atm/CMakeLists.txt
+++ b/test/atm/CMakeLists.txt
@@ -4,7 +4,7 @@
 if(BUILD_GDASBUNDLE)
 
   # link input file from iodaconv to test directory
-  file(CREATE_LINK ${PROJECT_SOURCE_DIR}/iodaconv/test/testinput/gdas.t06z.adpsfc.tm00.bufr_d ${PROJECT_BINARY_DIR}/test/testdata/gdas.t06z.adpsfc.tm00.bufr_d SYMBOLIC) 
+  file(COPY ${PROJECT_SOURCE_DIR}/iodaconv/test/testinput/gdas.t06z.adpsfc.tm00.bufr_d ${PROJECT_BINARY_DIR}/test/testdata/gdas.t06z.adpsfc.tm00.bufr_d) 
   # test convert BUFR to IODA
   add_test(NAME test_gdasapp_convert_bufr_adpsfc
            COMMAND ${PROJECT_BINARY_DIR}/bin/bufr2ioda.x ${PROJECT_BINARY_DIR}/test/testinput/bufr_adpsfc.yaml

--- a/test/testinput/bufr_adpsfc.yaml
+++ b/test/testinput/bufr_adpsfc.yaml
@@ -1,8 +1,3 @@
-# (C) Copyright 2020 NOAA/NWS/NCEP/EMC
-#
-# This software is licensed under the terms of the Apache Licence Version 2.0
-# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-
 observations:
   - obs space:
       name: bufr

--- a/test/testinput/bufr_adpsfc.yaml
+++ b/test/testinput/bufr_adpsfc.yaml
@@ -2,7 +2,7 @@ observations:
   - obs space:
       name: bufr
 
-      obsdatain: "./testinput/gdas.t06z.adpsfc.tm00.bufr_d"
+      obsdatain: "./testdata/gdas.t06z.adpsfc.tm00.bufr_d"
 
       mnemonicSets:
         - mnemonics: [YEAR, MNTH, DAYS, HOUR, MINU, WMOB, WMOS]

--- a/test/testinput/bufr_adpsfc.yaml
+++ b/test/testinput/bufr_adpsfc.yaml
@@ -1,0 +1,168 @@
+# (C) Copyright 2020 NOAA/NWS/NCEP/EMC
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+
+observations:
+  - obs space:
+      name: bufr
+
+      obsdatain: "./testinput/gdas.t06z.adpsfc.tm00.bufr_d"
+
+      mnemonicSets:
+        - mnemonics: [YEAR, MNTH, DAYS, HOUR, MINU, WMOB, WMOS]
+        - mnemonics: [CLAT, CLON]
+        - mnemonics: [SELV, PRES, PMSL, WDIR, WSPD, TMDB, TMDP]
+        - mnemonics: [RCHR, RCMI]
+
+      exports:
+        variables:
+          timestamp:
+            datetime:
+              year: YEAR
+              month: MNTH
+              day: DAYS
+              hour: HOUR
+              minute: MINU
+
+          WMOBlock:
+            mnemonic: WMOB
+
+          WMOStation:
+            mnemonic: WMOS
+
+          longitude:
+            mnemonic: CLON
+
+          latitude:
+            mnemonic: CLAT
+
+          pressureAir:
+            mnemonic: PRES
+
+          pressureMeanSeaLevel:
+            mnemonic: PMSL
+
+          stationElevation:
+            mnemonic: SELV
+
+          temperatureAir:
+            mnemonic: TMDB
+
+          temperatureDewpoint:
+            mnemonic: TMDP
+
+          windDirection:
+            mnemonic: WDIR
+
+          windSpeed:
+            mnemonic: WSPD
+
+          hourofreceipt:
+            mnemonic: RCHR
+
+          minuteofreceipt:
+            mnemonic: RCMI
+
+    ioda:
+      backend: netcdf
+      obsdataout: "./testoutput/gdas.t06z.adpsfc.tm00.nc"
+
+      dimensions:
+        - name: "nlocs"
+          size: variables/latitude.nrows
+
+      variables:
+        - name: "dateTime@MetaData"
+          source: variables/timestamp
+          dimensions: [ "nlocs" ]
+          longName: "dateTime"
+          units: "seconds since 1970-01-01T00:00:00Z"
+
+        - name: "WMOBlock@MetaData"
+          source: variables/WMOBlock
+          dimensions: [ "nlocs" ]
+          longName: "WMO_BLOCK_NUMBER"
+          units: ""
+
+        - name: "WMOStation@MetaData"
+          source: variables/WMOStation
+          dimensions: [ "nlocs" ]
+          longName: "WMO_STATION_NUMBER"
+          units: ""
+
+        - name: "latitude@MetaData"
+          source: variables/latitude
+          dimensions: ["nlocs"]
+          longName: "LATITUDE (COARSE ACCURACY)"
+          units: "degrees_north"
+          range: [-90, 90]
+
+        - name: "longitude@MetaData"
+          source: variables/longitude
+          dimensions: ["nlocs"]
+          longName: "LONGITUDE (COARSE ACCURACY)"
+          units: "degrees_east"
+          range: [-180, 180]
+
+        - name: "stationElevation@MetaData"
+          coordinates: "longitude latitude"
+          source: variables/stationElevation
+          dimensions: ["nlocs"]
+          longName: "HEIGHT OF STATION"
+          units: "Meter"
+
+        - name: "pressureAir@ObsValue"
+          coordinates: "longitude latitude"
+          source: variables/pressureAir
+          dimensions: ["nlocs"]
+          longName: "PRESSURE"
+          units: "Pa"
+
+        - name: "pressureMeanSeaLevel@ObsValue"
+          coordinates: "longitude latitude"
+          source: variables/pressureMeanSeaLevel
+          dimensions: ["nlocs"]
+          longName: "PRESSURE REDUCED TO MSL"
+          units: "Pa"
+
+        - name: "temperatureAir@ObsValue"
+          source: variables/temperatureAir
+          dimensions: ["nlocs"]
+          longName: "TEMPERATURE/DRY BULB TEMPERATURE"
+          units: "K"
+
+        - name: "temperatureDewpoint@ObsValue"
+          coordinates: "longitude latitude"
+          source: variables/temperatureDewpoint
+          dimensions: ["nlocs"]
+          longName: "DEW POINT TEMPERATURE"
+          units: "K"
+
+        - name: "windDirection@ObsValue"
+          coordinates: "longitude latitude"
+          source: variables/windDirection
+          dimensions: ["nlocs"]
+          longName: "WIND DIRECTION"
+          units: "Degrees True"
+
+        - name: "windSpeed@ObsValue"
+          coordinates: "longitude latitude"
+          source: variables/windSpeed
+          dimensions: ["nlocs"]
+          longName: "WIND SPEED"
+          units: "METERS/SECOND"
+
+        - name: "hourofreceipt@MetaData"
+          coordinates: "longitude latitude"
+          source: variables/hourofreceipt
+          dimensions: ["nlocs"]
+          longName: "HOUR   - TIME OF RECEIPT"
+          units: "HOUR"
+
+        - name: "minuteofreceipt@MetaData"
+          coordinates: "longitude latitude"
+          source: variables/minuteofreceipt
+          dimensions: ["nlocs"]
+          longName: "MINUTE  - TIME OF RECEIPT"
+          units: "MINUTE"


### PR DESCRIPTION
Closes #31

This PR adds the `iodaconv` repo to the full GDASApp bundle build.

Also, a new unit test is added if the bundle is built that will test the BUFR2IODA.x software and convert a BUFR file to IODA netCDF format.