### PR TITLE
Example script to store GFS RESTART backgrounds in R2D2

### DIFF
--- a/ush/r2d2/example_store_bkg.py
+++ b/ush/r2d2/example_store_bkg.py
@@ -16,6 +16,7 @@ if __name__ == "__main__":
         'end': '2021-12-21T18:00:00Z',
         'step': 'PT6H',
         'forecast_steps': ['PT6H'],
+        'file_type_list': ['fv_core.res', 'fv_srf_wnd.res', 'fv_tracer.res', 'phy_data', 'sfc_data'],
         'source_dir': '/work/noaa/stmp/rtreadon/comrot/prufsda/',
         'source_file_fmt': '{source_dir}/{dump}.{year}{month}{day}/{hour}/atmos/\
 RESTART_GES/$(valid_date).$(file_type).tile$(tile).nc',
@@ -25,6 +26,9 @@ RESTART_GES/$(valid_date).$(file_type).tile$(tile).nc',
         'database': 'shared',
         'dump': 'gdas',
         'experiment': 'oper_gdas',
+        'tile': [1, 2, 3, 4, 5, 6],
+        'user_date_format': '%Y%m%d.%H%M%S',
+        'fc_date_rendering': 'analysis',
     }
     yamlfile = os.path.join(os.getcwd(), 'store_gfs_bkg.yaml')
     with open(yamlfile, 'w') as f:
@@ -34,6 +38,8 @@ RESTART_GES/$(valid_date).$(file_type).tile$(tile).nc',
     config['model'] = 'gfs_metadata'
     config['source_file_fmt'] = '{source_dir}/{dump}.{year}{month}{day}/{hour}/atmos/\
 RESTART_GES/$(valid_date).$(file_type)'
+    config['file_type_list'] = ['coupler.res', 'fv_core.res.nc']
+    del config['tile']
     yamlfile = os.path.join(os.getcwd(), 'store_gfs_coupler.yaml')
     with open(yamlfile, 'w') as f:
         yaml.dump(config, f, sort_keys=False, default_flow_style=False)

--- a/ush/r2d2/example_store_bkg.py
+++ b/ush/r2d2/example_store_bkg.py
@@ -38,4 +38,3 @@ RESTART_GES/$(valid_date).coupler.res'
     with open(yamlfile, 'w') as f:
         yaml.dump(config, f, sort_keys=False, default_flow_style=False)
     store_bkg(yamlfile)
-

--- a/ush/r2d2/example_store_bkg.py
+++ b/ush/r2d2/example_store_bkg.py
@@ -33,7 +33,7 @@ RESTART_GES/$(valid_date).$(file_type).tile$(tile).nc',
     # replace gfs with gfs_metadata
     config['model'] = 'gfs_metadata'
     config['source_file_fmt'] = '{source_dir}/{dump}.{year}{month}{day}/{hour}/atmos/\
-RESTART_GES/$(valid_date).coupler.res'
+RESTART_GES/$(valid_date).$(file_type)'
     yamlfile = os.path.join(os.getcwd(), 'store_gfs_coupler.yaml')
     with open(yamlfile, 'w') as f:
         yaml.dump(config, f, sort_keys=False, default_flow_style=False)

--- a/ush/r2d2/example_store_bkg.py
+++ b/ush/r2d2/example_store_bkg.py
@@ -1,0 +1,41 @@
+import os
+from solo.configuration import Configuration
+import ufsda.r2d2
+import yaml
+
+
+def store_bkg(yamlfile):
+    config = Configuration(yamlfile)
+    ufsda.r2d2.store(config)
+
+
+if __name__ == "__main__":
+    # first create dict of config for UFS RESTART files
+    config = {
+        'start': '2021-12-21T00:00:00Z',
+        'end': '2021-12-21T18:00:00Z',
+        'step': 'PT6H',
+        'forecast_steps': ['PT6H'],
+        'source_dir': '/work/noaa/stmp/rtreadon/comrot/prufsda/',
+        'source_file_fmt': '{source_dir}/{dump}.{year}{month}{day}/{hour}/atmos/\
+RESTART_GES/$(valid_date).$(file_type).tile$(tile).nc',
+        'type': 'fc',
+        'model': 'gfs',
+        'resolution': 'c96',
+        'database': 'shared',
+        'dump': 'gdas',
+        'experiment': 'oper_gdas',
+    }
+    yamlfile = os.path.join(os.getcwd(), 'store_gfs_bkg.yaml')
+    with open(yamlfile, 'w') as f:
+        yaml.dump(config, f, sort_keys=False, default_flow_style=False)
+    store_bkg(yamlfile)
+    # replace gfs with gfs_metadata
+    config['model'] = 'gfs_metadata'
+    config['source_file_fmt'] = '{source_dir}/{dump}.{year}{month}{day}/{hour}/atmos/\
+RESTART_GES/$(valid_date).coupler.res'
+    yamlfile = os.path.join(os.getcwd(), 'store_gfs_coupler.yaml')
+    with open(yamlfile, 'w') as f:
+        yaml.dump(config, f, sort_keys=False, default_flow_style=False)
+    store_bkg(yamlfile)
+

--- a/ush/ufsda/r2d2.py
+++ b/ush/ufsda/r2d2.py
@@ -2,7 +2,6 @@ import r2d2
 from solo.configuration import Configuration
 from solo.date import date_sequence, Hour
 
-fv3files = ['fv_core.res', 'fv_srf_wnd.res', 'fv_tracer.res', 'phy_data', 'sfc_data']
 possible_args = [
     'provider', 'experiment', 'database', 'type', 'file_type',
     'resolution', 'model', 'user_date_format', 'fc_date_rendering', 'tile',

--- a/ush/ufsda/r2d2.py
+++ b/ush/ufsda/r2d2.py
@@ -2,47 +2,86 @@ import r2d2
 from solo.configuration import Configuration
 from solo.date import date_sequence, Hour
 
+fv3files = ['fv_core.res', 'fv_srf_wnd.res', 'fv_tracer.res', 'phy_data', 'sfc_data']
 
 def store(config):
     times = date_sequence(config.start, config.end, config.step)
-    obs_types = config.obs_types
-    provider = config.provider
+    obs_types = config.get('obs_types', ['dummy'])
+    provider = config.get('provider', None)
     experiment = config.experiment
     database = config.database
     type = config.type
     file_type = config.get('file_type', None)
     source_dir = config.source_dir
     source_file_fmt = config.source_file_fmt
-    step = config.step
+    step = config.get('step', 'PT6H')
+    fcst_steps = config.get('forecast_steps', ['PT6H'])
     dump = config.get('dump', 'gdas')
+    resolution = config.get('resolution', 'c768')
+    model = config.get('model', 'gfs')
+    user_date_format = config.get('user_date_format', '%Y%m%d.%H%M%S')
+    fc_date_rendering = config.get('fc_date_rendering', 'analysis')
+    tiles = config.get('tiles', [1, 2, 3, 4, 5, 6])
+    file_type_list = config.get('file_type_list', fv3files)
 
     for time in times:
         year = Hour(time).format('%Y')
         month = Hour(time).format('%m')
         day = Hour(time).format('%d')
         hour = Hour(time).format('%H')
-        for obs_type in obs_types:
-            if type == 'bc':
+        if type in ['bc', 'ob']:
+            for obs_type in obs_types:
+                if type == 'bc':
+                    r2d2.store(
+                        provider=provider,
+                        type=type,
+                        file_type=file_type,
+                        experiment=experiment,
+                        database=database,
+                        date=time,
+                        obs_type=obs_type,
+                        source_file=eval(f"f'{source_file_fmt}'"),
+                        ignore_missing=True,
+                    )
+                else:
+                    r2d2.store(
+                        provider=provider,
+                        type=type,
+                        experiment=experiment,
+                        database=database,
+                        date=time,
+                        obs_type=obs_type,
+                        time_window=step,
+                        source_file=eval(f"f'{source_file_fmt}'"),
+                        ignore_missing=True,
+                    )
+        elif type == 'fc':
+            if model == 'gfs_metadata':
                 r2d2.store(
-                    provider=provider,
                     type=type,
-                    file_type=file_type,
+                    model=model,
                     experiment=experiment,
-                    database=database,
                     date=time,
-                    obs_type=obs_type,
+                    step=fcst_steps,
+                    resolution=resolution,
+                    user_date_format=user_date_format,
+                    fc_date_rendering=fc_date_rendering,
+                    database=database,
+                    file_type=['coupler.res', 'fv_core.res.nc'],
                     source_file=eval(f"f'{source_file_fmt}'"),
-                    ignore_missing=True,
                 )
             else:
                 r2d2.store(
-                    provider=provider,
                     type=type,
+                    model=model,
                     experiment=experiment,
-                    database=database,
                     date=time,
-                    obs_type=obs_type,
-                    time_window=step,
+                    step=fcst_steps,
+                    resolution=resolution,
+                    user_date_format=user_date_format,
+                    fc_date_rendering=fc_date_rendering,
+                    database=database,
+                    file_type=file_type_list,
+                    tile=tiles,
                     source_file=eval(f"f'{source_file_fmt}'"),
-                    ignore_missing=True,
                 )

--- a/ush/ufsda/r2d2.py
+++ b/ush/ufsda/r2d2.py
@@ -15,6 +15,7 @@ def store(config):
     for arg in config.keys():
         if arg in possible_args:
             kwargs[arg] = config[arg]
+    type = config.type
     times = date_sequence(config.start, config.end, config.step)
     dump = config.get('dump', 'gdas')
     source_dir = config['source_dir']

--- a/ush/ufsda/r2d2.py
+++ b/ush/ufsda/r2d2.py
@@ -3,86 +3,38 @@ from solo.configuration import Configuration
 from solo.date import date_sequence, Hour
 
 fv3files = ['fv_core.res', 'fv_srf_wnd.res', 'fv_tracer.res', 'phy_data', 'sfc_data']
+possible_args = [
+    'obs_types', 'provider', 'experiment', 'database', 'type', 'file_type',
+    'resolution', 'model', 'user_date_format', 'fc_date_rendering', 'tile',
+]
 
 
 def store(config):
+    kwargs = {}
+    kwargs['ignore_missing'] = True
+    for arg in config.keys():
+        if arg in possible_args:
+            kwargs[arg] = config[arg]
     times = date_sequence(config.start, config.end, config.step)
-    obs_types = config.get('obs_types', ['dummy'])
-    provider = config.get('provider', None)
-    experiment = config.experiment
-    database = config.database
-    type = config.type
-    file_type = config.get('file_type', None)
-    source_dir = config.source_dir
-    source_file_fmt = config.source_file_fmt
-    step = config.get('step', 'PT6H')
-    fcst_steps = config.get('forecast_steps', ['PT6H'])
     dump = config.get('dump', 'gdas')
-    resolution = config.get('resolution', 'c768')
-    model = config.get('model', 'gfs')
-    user_date_format = config.get('user_date_format', '%Y%m%d.%H%M%S')
-    fc_date_rendering = config.get('fc_date_rendering', 'analysis')
-    tiles = config.get('tiles', [1, 2, 3, 4, 5, 6])
-    file_type_list = config.get('file_type_list', fv3files)
+    source_dir = config['source_dir']
+    source_file_fmt = config['source_file_fmt']
 
     for time in times:
         year = Hour(time).format('%Y')
         month = Hour(time).format('%m')
         day = Hour(time).format('%d')
         hour = Hour(time).format('%H')
+        kwargs['date'] = time
         if type in ['bc', 'ob']:
+            if type == 'ob':
+                kwargs['time_window'] = config['step']
             for obs_type in obs_types:
-                if type == 'bc':
-                    r2d2.store(
-                        provider=provider,
-                        type=type,
-                        file_type=file_type,
-                        experiment=experiment,
-                        database=database,
-                        date=time,
-                        obs_type=obs_type,
-                        source_file=eval(f"f'{source_file_fmt}'"),
-                        ignore_missing=True,
-                    )
-                else:
-                    r2d2.store(
-                        provider=provider,
-                        type=type,
-                        experiment=experiment,
-                        database=database,
-                        date=time,
-                        obs_type=obs_type,
-                        time_window=step,
-                        source_file=eval(f"f'{source_file_fmt}'"),
-                        ignore_missing=True,
-                    )
-        elif type == 'fc':
-            if model == 'gfs_metadata':
-                r2d2.store(
-                    type=type,
-                    model=model,
-                    experiment=experiment,
-                    date=time,
-                    step=fcst_steps,
-                    resolution=resolution,
-                    user_date_format=user_date_format,
-                    fc_date_rendering=fc_date_rendering,
-                    database=database,
-                    file_type=['coupler.res', 'fv_core.res.nc'],
-                    source_file=eval(f"f'{source_file_fmt}'"),
-                )
-            else:
-                r2d2.store(
-                    type=type,
-                    model=model,
-                    experiment=experiment,
-                    date=time,
-                    step=fcst_steps,
-                    resolution=resolution,
-                    user_date_format=user_date_format,
-                    fc_date_rendering=fc_date_rendering,
-                    database=database,
-                    file_type=file_type_list,
-                    tile=tiles,
-                    source_file=eval(f"f'{source_file_fmt}'"),
-                )
+                kwargs['source_file'] = eval(f"f'{source_file_fmt}'"),
+                kwargs['obs_type'] = obs_type
+                r2d2.store(**kwargs)
+        else:
+            kwargs['file_type'] = config.file_type_list
+            kwargs['step'] = config['forecast_steps']
+            kwargs['source_file'] = eval(f"f'{source_file_fmt}'"),
+            r2d2.store(**kwargs)

--- a/ush/ufsda/r2d2.py
+++ b/ush/ufsda/r2d2.py
@@ -4,6 +4,7 @@ from solo.date import date_sequence, Hour
 
 fv3files = ['fv_core.res', 'fv_srf_wnd.res', 'fv_tracer.res', 'phy_data', 'sfc_data']
 
+
 def store(config):
     times = date_sequence(config.start, config.end, config.step)
     obs_types = config.get('obs_types', ['dummy'])

--- a/ush/ufsda/r2d2.py
+++ b/ush/ufsda/r2d2.py
@@ -4,7 +4,7 @@ from solo.date import date_sequence, Hour
 
 fv3files = ['fv_core.res', 'fv_srf_wnd.res', 'fv_tracer.res', 'phy_data', 'sfc_data']
 possible_args = [
-    'obs_types', 'provider', 'experiment', 'database', 'type', 'file_type',
+    'provider', 'experiment', 'database', 'type', 'file_type',
     'resolution', 'model', 'user_date_format', 'fc_date_rendering', 'tile',
 ]
 
@@ -20,6 +20,7 @@ def store(config):
     dump = config.get('dump', 'gdas')
     source_dir = config['source_dir']
     source_file_fmt = config['source_file_fmt']
+    obs_types = config['obs_types']
 
     for time in times:
         year = Hour(time).format('%Y')


### PR DESCRIPTION
This PR adds an example script that copies GFS C96 backgrounds from @RussTreadon-NOAA and puts them in my R2D2 shared database. 

It also makes some changes to the `ufsda/r2d2` python `store` general function to handle backgrounds in addition to obs and bias correction coefficients.