### PR TITLE
Generalize single cycle script to also work for hofx

### DIFF
--- a/parm/atm/hofx/hofx_nomodel.yaml
+++ b/parm/atm/hofx/hofx_nomodel.yaml
@@ -5,11 +5,11 @@ state:
   datapath: $(BKG_DIR)
   filetype: fms restart
   datetime: $(BKG_ISOTIME)
-  filename_core: $(BKG_YYYYMMDDpHHMMSS).fv_core.res.nc
-  filename_trcr: $(BKG_YYYYMMDDpHHMMSS).fv_tracer.res.nc
-  filename_sfcd: $(BKG_YYYYMMDDpHHMMSS).sfc_data.nc
-  filename_sfcw: $(BKG_YYYYMMDDpHHMMSS).fv_srf_wnd.res.nc
-  filename_cplr: $(BKG_YYYYMMDDpHHMMSS).coupler.res
+  filename_core: $(BKG_YYYYmmddHHMMSS).fv_core.res.nc
+  filename_trcr: $(BKG_YYYYmmddHHMMSS).fv_tracer.res.nc
+  filename_sfcd: $(BKG_YYYYmmddHHMMSS).sfc_data.nc
+  filename_sfcw: $(BKG_YYYYmmddHHMMSS).fv_srf_wnd.res.nc
+  filename_cplr: $(BKG_YYYYmmddHHMMSS).coupler.res
   state variables: [ua,va,t,delp,sphum,ice_wat,liq_wat,o3mr,phis,
                     slmsk,sheleg,tsea,vtype,stype,vfrac,stc,smc,snwdph,
                     u_srf,v_srf,f10m]

--- a/parm/atm/hofx/hofx_nomodel.yaml
+++ b/parm/atm/hofx/hofx_nomodel.yaml
@@ -1,0 +1,16 @@
+window begin: '$(ATM_WINDOW_BEGIN)'
+window length: $(ATM_WINDOW_LENGTH)
+geometry: $(GEOM_BKG)
+state:
+  datapath: $(BKG_DIR)
+  filetype: fms restart
+  datetime: $(BKG_ISOTIME)
+  filename_core: $(BKG_YYYYMMDDpHHMMSS).fv_core.res.nc
+  filename_trcr: $(BKG_YYYYMMDDpHHMMSS).fv_tracer.res.nc
+  filename_sfcd: $(BKG_YYYYMMDDpHHMMSS).sfc_data.nc
+  filename_sfcw: $(BKG_YYYYMMDDpHHMMSS).fv_srf_wnd.res.nc
+  filename_cplr: $(BKG_YYYYMMDDpHHMMSS).coupler.res
+  state variables: [ua,va,t,delp,sphum,ice_wat,liq_wat,o3mr,phis,
+                    slmsk,sheleg,tsea,vtype,stype,vfrac,stc,smc,snwdph,
+                    u_srf,v_srf,f10m]
+observations: $<< $(OBS_LIST)

--- a/parm/atm/variational/3dvar_dripcg.yaml
+++ b/parm/atm/variational/3dvar_dripcg.yaml
@@ -8,11 +8,11 @@ cost function:
     datapath: $(BKG_DIR)
     filetype: fms restart
     datetime: $(BKG_ISOTIME)
-    filename_core: $(BKG_YYYYMMDDpHHMMSS).fv_core.res.nc
-    filename_trcr: $(BKG_YYYYMMDDpHHMMSS).fv_tracer.res.nc
-    filename_sfcd: $(BKG_YYYYMMDDpHHMMSS).sfc_data.nc
-    filename_sfcw: $(BKG_YYYYMMDDpHHMMSS).fv_srf_wnd.res.nc
-    filename_cplr: $(BKG_YYYYMMDDpHHMMSS).coupler.res
+    filename_core: $(BKG_YYYYmmddHHMMSS).fv_core.res.nc
+    filename_trcr: $(BKG_YYYYmmddHHMMSS).fv_tracer.res.nc
+    filename_sfcd: $(BKG_YYYYmmddHHMMSS).sfc_data.nc
+    filename_sfcw: $(BKG_YYYYmmddHHMMSS).fv_srf_wnd.res.nc
+    filename_cplr: $(BKG_YYYYmmddHHMMSS).coupler.res
     state variables: [ua,va,t,delp,sphum,ice_wat,liq_wat,o3mr,phis,
                       slmsk,sheleg,tsea,vtype,stype,vfrac,stc,smc,snwdph,
                       u_srf,v_srf,f10m]

--- a/ush/run_fv3jedi_exe.py
+++ b/ush/run_fv3jedi_exe.py
@@ -85,8 +85,8 @@ def run_fv3jedi_exe(yamlconfig):
     gdasfix = executable_subconfig['gdas_fix_root']
     ufsda.stage.gdas_fix(gdasfix, workdir, var_config)
     # link executable
-    baseexe = os.path.basename(executable_subconfig['exe_path'])
-    ufsda.disk_utils.symlink(executable_subconfig['exe_path'], os.path.join(workdir, baseexe))
+    baseexe = os.path.basename(executable_subconfig['executable'])
+    ufsda.disk_utils.symlink(executable_subconfig['executable'], os.path.join(workdir, baseexe))
     # create output directories
     ufsda.disk_utils.mkdir(os.path.join(workdir, 'diags'))
     if app_mode in ['variational']:

--- a/ush/run_fv3jedi_exe.py
+++ b/ush/run_fv3jedi_exe.py
@@ -18,6 +18,13 @@ def run_fv3jedi_exe(yamlconfig):
         logging.info(f'Loading configuration from {yamlconfig}')
     except Exception as e:
         logging.error(f'Error occurred when attempting to load: {yamlconfig}, error: {e}')
+    # check if the specified app mode is valid
+    app_mode = all_config_dict['GDASApp mode']
+    supported_app_modes = ['hofx', 'variational']
+    if app_mode not in supported_app_modes:
+        raise KeyError(f"'{app_mode}' not supported. " +
+                       "Current GDASApp modes supported are: " +
+                       f"{' | '.join(supported_app_modes)}")
     # create working directory
     workdir = all_config_dict['working directory']
     try:
@@ -30,9 +37,6 @@ def run_fv3jedi_exe(yamlconfig):
     sys.path.append(ufsda_path)
     import ufsda
     # compute config for YAML for executable
-    app_mode = all_config_dict['GDASApp mode']
-    if app_mode not in ['hofx', 'variational']:
-        raise KeyError(f"{app_mode} not supported")
     executable_subconfig = all_config_dict['executable options']
     valid_time = executable_subconfig['valid_time']
     h = re.findall('PT(\\d+)H', executable_subconfig['atm_window_length'])[0]

--- a/ush/run_jedi_exe.py
+++ b/ush/run_jedi_exe.py
@@ -9,7 +9,7 @@ import sys
 import yaml
 
 
-def run_fv3jedi_exe(yamlconfig):
+def run_jedi_exe(yamlconfig):
     logging.basicConfig(format='%(asctime)s:%(levelname)s:%(message)s', level=logging.INFO, datefmt='%Y-%m-%d %H:%M:%S')
     # open YAML file to get config
     try:
@@ -108,4 +108,4 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('-c', '--config', type=str, help='Input YAML Configuration', required=True)
     args = parser.parse_args()
-    run_fv3jedi_exe(args.config)
+    run_jedi_exe(args.config)

--- a/ush/ufsda/misc_utils.py
+++ b/ush/ufsda/misc_utils.py
@@ -23,7 +23,7 @@ def isTrue(str_in):
     return status
 
 
-def create_batch_job(job_config, working_dir, exe_path, yaml_path):
+def create_batch_job(job_config, working_dir, executable, yaml_path):
     """
     create a batch job submission shell script
     """
@@ -49,7 +49,7 @@ cd {working_dir}
 """
         f.write(commands)
         if scheduler[job_config['machine']] == 'slurm':
-            f.write(f"srun -n $SLURM_NTASKS {exe_path} {yaml_path}\n")
+            f.write(f"srun -n $SLURM_NTASKS {executable} {yaml_path}\n")
     logging.info(f"Wrote batch submission script to {batch_script}")
     return batch_script
 

--- a/ush/ufsda/misc_utils.py
+++ b/ush/ufsda/misc_utils.py
@@ -32,18 +32,22 @@ def create_batch_job(job_config, working_dir, exe_path, yaml_path):
     with open(batch_script, 'w') as f:
         f.write('#!/bin/bash\n')
         if scheduler[job_config['machine']] == 'slurm':
-            f.write('#SBATCH -J GDASApp\n')
-            f.write('#SBATCH -o GDASApp.o%J\n')
-            f.write(f"#SBATCH -A {job_config['account']}\n")
-            f.write(f"#SBATCH -q {job_config['queue']}\n")
-            f.write(f"#SBATCH -p {job_config['partition']}\n")
-            f.write(f"#SBATCH --ntasks={job_config['ntasks']}\n")
-            f.write(f"#SBATCH --cpus-per-task={job_config['cpus-per-task']}\n")
-            f.write(f"#SBATCH --exclusive\n")
-            f.write(f"#SBATCH -t {job_config['walltime']}\n")
-        f.write(f"module use {job_config['modulepath']}\n")
-        f.write(f"module load GDAS/{job_config['machine']}\n")
-        f.write(f"cd {working_dir}\n")
+            sbatch = f"""#SBATCH -J GDASApp
+#SBATCH -o GDASApp.o%J
+#SBATCH -A {job_config['account']}
+#SBATCH -q {job_config['queue']}
+#SBATCH -p {job_config['partition']}
+#SBATCH --ntasks={job_config['ntasks']}
+#SBATCH --cpus-per-task={job_config['cpus-per-task']}
+#SBATCH --exclusive
+#SBATCH -t {job_config['walltime']}"""
+            f.write(sbatch)
+        commands = f"""
+module use {job_config['modulepath']}
+module load GDAS/{job_config['machine']}
+cd {working_dir}
+"""
+        f.write(commands)
         if scheduler[job_config['machine']] == 'slurm':
             f.write(f"srun -n $SLURM_NTASKS {exe_path} {yaml_path}\n")
     logging.info(f"Wrote batch submission script to {batch_script}")

--- a/ush/ufsda/misc_utils.py
+++ b/ush/ufsda/misc_utils.py
@@ -43,6 +43,7 @@ def create_batch_job(job_config, working_dir, executable, yaml_path):
 #SBATCH -t {job_config['walltime']}"""
             f.write(sbatch)
         commands = f"""
+module purge
 module use {job_config['modulepath']}
 module load GDAS/{job_config['machine']}
 cd {working_dir}

--- a/ush/ufsda/yamltools.py
+++ b/ush/ufsda/yamltools.py
@@ -125,10 +125,10 @@ def calc_time_vars(config):
                                                     "%Y-%m-%dT%H:%M:%SZ")
     else:
         raise KeyError("Neither $(valid_time) nor ${PDY}${cyc} defined")
-    config['YYYYMMDDpHHMMSS'] = valid_time_obj.strftime('%Y%m%d.%H%M%S')
+    config['YYYYmmddHHMMSS'] = valid_time_obj.strftime('%Y%m%d.%H%M%S')
     # for now bkg_time == valid_time, will change for fgat
     bkg_time_obj = valid_time_obj
-    config['BKG_YYYYMMDDpHHMMSS'] = bkg_time_obj.strftime('%Y%m%d.%H%M%S')
+    config['BKG_YYYYmmddHHMMSS'] = bkg_time_obj.strftime('%Y%m%d.%H%M%S')
     config['BKG_ISOTIME'] = bkg_time_obj.strftime('%Y-%m-%dT%H:%M:%SZ')
     if 'assim_freq' in os.environ:
         config['ATM_WINDOW_LENGTH'] = f"PT{os.environ['assim_freq']}H"

--- a/ush/ufsda/yamltools.py
+++ b/ush/ufsda/yamltools.py
@@ -48,7 +48,9 @@ def parse_config(input_config_dict, template=None, clean=True):
     if config_out.get('atm', True):
         config_out = atmanl_case(config_out)
     config_out.pop('atm', None)  # pop out boolean variable that will cause issues later
-    # do a first round of includes first
+    # do a first round of substitutions first
+    config_out = replace_vars(config_out)
+    # now do a first round of includes
     config_out = include_yaml(config_out)
     # pull common key values out to top layer
     config_out = pop_out_common(config_out)


### PR DESCRIPTION
Closes #43 

This PR generalizes the work done in #42 to allow for a user to run just H(x) instead of the entire variational application.

It also simplifies the SLURM batch script generation to use multi-line strings where appropriate.

The sample YAML changes slightly from #42, see:

```
working directory: /work2/noaa/stmp/cmartin/gdas_single_test_hofx
GDASApp home: /work2/noaa/da/cmartin/GDASApp/work/GDASApp
GDASApp mode: hofx
executable options:
  obs_yaml_dir: /work2/noaa/da/cmartin/GDASApp/work/GDASApp/parm/atm/obs/config
  yaml_template: /work2/noaa/da/cmartin/GDASApp/work/GDASApp/parm/atm/hofx/hofx_nomodel.yaml
  exe_path: /work2/noaa/da/cmartin/GDASApp/work/GDASApp/build/bin/fv3jedi_hofx_nomodel.x
  obs_list: /work2/noaa/da/cmartin/GDASApp/work/GDASApp/parm/atm/obs/lists/gdas_prototype.yaml
  gdas_fix_root: /work2/noaa/da/cmartin/GDASApp/fix
  atm: true
  layout_x: 1
  layout_y: 1
  atm_window_length: PT6H
  valid_time: 2021-12-21T06:00:00Z
  dump: gdas
  case: C96
  levs: 128
job options:
  machine: orion
  account: da-cpu
  queue: debug
  partition: debug
  walltime: '10:00'
  ntasks: 6
  cpus-per-task: 1
  modulepath: /work2/noaa/da/cmartin/GDASApp/work/GDASApp/modulefiles
```

Note that some entries are optional for hofx compared to var, and there is now a `GDASApp mode`, it is now `executable options` instead of `analysis options`, and `yaml_template` instead of `var_yaml`, and `exe_path` is new to point to the exe to use at runtime.