### PR TITLE
Bring in changes/new script to populate R2D2

### DIFF
--- a/ush/r2d2/example_store_bkg.py
+++ b/ush/r2d2/example_store_bkg.py
@@ -12,17 +12,17 @@ def store_bkg(yamlfile):
 if __name__ == "__main__":
     # first create dict of config for UFS RESTART files
     config = {
-        'start': '2021-12-21T00:00:00Z',
-        'end': '2021-12-21T18:00:00Z',
+        'start': '2021-12-25T00:00:00Z',
+        'end': '2021-12-27T00:00:00Z',
         'step': 'PT6H',
         'forecast_steps': ['PT6H'],
         'file_type_list': ['fv_core.res', 'fv_srf_wnd.res', 'fv_tracer.res', 'phy_data', 'sfc_data'],
-        'source_dir': '/work/noaa/stmp/rtreadon/comrot/prufsda/',
-        'source_file_fmt': '{source_dir}/{dump}.{year}{month}{day}/{hour}/atmos/\
-RESTART_GES/$(valid_date).$(file_type).tile$(tile).nc',
+        'source_dir': '/work2/noaa/da/rtreadon/data/',
+        'source_file_fmt': '{source_dir}/enkf{dump}.{year}{month}{day}/{hour}/atmos/\
+mem001/RESTART/$(valid_date).$(file_type).tile$(tile).nc',
         'type': 'fc',
         'model': 'gfs',
-        'resolution': 'c96',
+        'resolution': 'c384',
         'database': 'shared',
         'dump': 'gdas',
         'experiment': 'oper_gdas',
@@ -36,8 +36,8 @@ RESTART_GES/$(valid_date).$(file_type).tile$(tile).nc',
     store_bkg(yamlfile)
     # replace gfs with gfs_metadata
     config['model'] = 'gfs_metadata'
-    config['source_file_fmt'] = '{source_dir}/{dump}.{year}{month}{day}/{hour}/atmos/\
-RESTART_GES/$(valid_date).$(file_type)'
+    config['source_file_fmt'] = '{source_dir}/enkf{dump}.{year}{month}{day}/{hour}/atmos/\
+mem001/RESTART/$(valid_date).$(file_type)'
     config['file_type_list'] = ['coupler.res', 'fv_core.res.nc']
     del config['tile']
     yamlfile = os.path.join(os.getcwd(), 'store_gfs_coupler.yaml')

--- a/ush/r2d2/proc_ops2r2d2.sh
+++ b/ush/r2d2/proc_ops2r2d2.sh
@@ -1,0 +1,279 @@
+#!/bin/bash
+diagroot=/work2/noaa/stmp/cmartin/obs/
+extract="NO"
+iodaconv="NO"
+satbiasconv="NO"
+r2d2store_obs="NO"
+r2d2store_bc="YES"
+startdate=2021122100
+enddate=2021123118
+dump="gdas"
+HOMEgdas=/work2/noaa/da/cmartin/GDASApp/work/GDASApp
+machine="orion"
+
+#---------------------------------------------------------------
+# do not modify below here
+#---------------------------------------------------------------
+
+# load runtime env
+#---------------------------------------------------------------
+module purge
+module use $HOMEgdas/modulefiles
+module load GDAS/$machine
+
+# extract from tar files
+#---------------------------------------------------------------
+if [ $extract = "YES" ]; then
+  diags="oznstat cnvstat radstat"
+  nowdate=$startdate
+  while test $nowdate -le $enddate ; do
+    echo "Extracting $nowdate"
+    nowpdy=${nowdate::8}; nowcyc=${nowdate:8}
+    diagdir=$diagroot/${dump}.$nowpdy/$nowcyc/atmos/
+    cd $diagdir
+    for d in $diags; do
+      tar xvf ${dump}.t??z.$d
+    done
+    for f in $(ls diag*gz); do
+      gunzip -f $f
+      rm -rf $f
+    done
+    mkdir -p diags
+    rm -rf diag*anl*
+    mv diag*ges* diags/.
+    nowdate=$(date -d "$nowpdy $nowcyc + 6 hour" +%Y%m%d%H)
+  done
+fi
+
+# run ioda converters
+#---------------------------------------------------------------
+convertpy=$HOMEgdas/build/bin/proc_gsi_ncdiag.py
+combinepy=$HOMEgdas/build/bin/combine_obsspace.py
+export PYTHONPATH=$PYTHONPATH:$HOMEgdas/build/lib/python3.7/pyioda
+
+if [ $iodaconv = "YES" ]; then
+  nowdate=$startdate
+  while test $nowdate -le $enddate ; do
+    echo "Converting obs to IODA for $nowdate"
+    nowpdy=${nowdate::8}; nowcyc=${nowdate:8}
+    diagdir=$diagroot/${dump}.$nowpdy/$nowcyc/atmos/
+    cd $diagdir
+    mkdir -p $diagdir/ioda
+    $convertpy -o $diagdir/ioda $diagdir/diags
+    $combinepy -i $diagdir/ioda/sfc_*.nc4 -o $diagdir/ioda/sfc_obs_"$nowdate".nc4
+    $combinepy -i $diagdir/ioda/sfcship_*.nc4 -o $diagdir/ioda/sfcship_obs_"$nowdate".nc4
+    $combinepy -i $diagdir/ioda/sondes_*.nc4 -o $diagdir/ioda/sondes_obs_"$nowdate".nc4
+    $combinepy -i $diagdir/ioda/aircraft_*.nc4 -o $diagdir/ioda/aircraft_obs_"$nowdate".nc4
+    nowdate=$(date -d "$nowpdy $nowcyc + 6 hour" +%Y%m%d%H)
+  done
+fi
+
+# run satbias converters
+#---------------------------------------------------------------
+satbiaspy=$HOMEgdas/ush/run_satbias_conv.py
+if [ $satbiasconv = "YES" ]; then
+  # python script runs over all period
+  nowdate=$startdate
+  nowpdy=${nowdate::8}; nowcyc=${nowdate:8}
+  prevdate=$(date -d "$nowpdy $nowcyc - 6 hour" +%Y-%m-%dT%H)
+  lastpdy=${enddate::8}; lastcyc=${enddate:8}
+  lastprevdate=$(date -d "$lastpdy $lastcyc - 6 hour" +%Y-%m-%dT%H)
+  # create YAML file
+  cd $diagroot
+  cat > $diagroot/run_satbias_conv.yaml << EOF
+start time: $prevdate:00:00Z
+end time: $lastprevdate:00:00Z
+assim_freq: 6
+gsi_bc_root: $diagroot
+ufo_bc_root: $diagroot/satbias
+work_root: $diagroot/work
+satbias2ioda: $HOMEgdas/build/bin/satbias2ioda.x
+dump: $dump
+EOF
+  $satbiaspy --config $diagroot/run_satbias_conv.yaml
+fi
+
+# store with r2d2
+#---------------------------------------------------------------
+r2d2storepy=$HOMEgdas/ush/r2d2/r2d2_store.py
+export PYTHONPATH=$PYTHONPATH:$HOMEgdas/ush
+
+if [ $r2d2store_obs = "YES" ]; then
+  cd $diagroot
+  nowpdy=${startdate::8}; nowcyc=${startdate:8}
+  firstdate=$(date -d "$nowpdy $nowcyc" +%Y-%m-%dT%H)
+  nowpdy=${enddate::8}; nowcyc=${enddate:8}
+  lastdate=$(date -d "$nowpdy $nowcyc" +%Y-%m-%dT%H)
+  cat > $diagroot/r2d2_store_obs.yaml << EOF
+start: ${firstdate}:00:00Z
+end: ${lastdate}:00:00Z
+step: PT6H
+source_dir: $diagroot
+source_file_fmt: '{source_dir}/{dump}.{year}{month}{day}/{hour}/atmos/ioda/{obs_type}_obs_{year}{month}{day}{hour}.nc4'
+type: ob
+database: shared
+provider: ncdiag
+experiment: oper_$dump
+obs_types:
+  - aircraft
+  - amsua_metop-a
+  - amsua_metop-b
+  - amsua_metop-c
+  - amsua_n15
+  - amsua_n18
+  - amsua_n19
+  - atms_n20
+  - atms_npp
+  - avhrr3_metop-a
+  - avhrr3_n18
+  - cris-fsr_n20
+  - cris-fsr_npp
+  - gome_metop-a
+  - gome_metop-b
+  - hirs4_metop-a
+  - hirs4_n19
+  - iasi_metop-a
+  - iasi_metop-b
+  - mhs_metop-a
+  - mhs_metop-b
+  - mhs_metop-c
+  - mhs_n19
+  - omi_aura
+  - ompsnp_npp
+  - ompstc8_npp
+  - rass_tv
+  #- saphir_meghat
+  - satwind
+  - sbuv2_n19
+  - scatwind
+  - seviri_m08
+  - seviri_m11
+  - sfc
+  - sfcship
+  - sondes
+  - ssmis_f17
+  - ssmis_f18
+  - sst
+  - vadwind
+  #- windprof
+EOF
+  $r2d2storepy --config $diagroot/r2d2_store_obs.yaml
+fi
+
+if [ $r2d2store_bc = "YES" ]; then
+  cd $diagroot
+  nowpdy=${startdate::8}; nowcyc=${startdate:8}
+  firstdate=$(date -d "$nowpdy $nowcyc - 6 hour" +%Y-%m-%dT%H)
+  nowpdy=${enddate::8}; nowcyc=${enddate:8}
+  lastdate=$(date -d "$nowpdy $nowcyc - 6 hour" +%Y-%m-%dT%H)
+  cat > $diagroot/r2d2_store_satbias.yaml << EOF
+start: ${firstdate}:00:00Z
+end: ${lastdate}:00:00Z
+step: PT6H
+source_dir: $diagroot
+source_file_fmt: '{source_dir}/satbias/{dump}.{year}{month}{day}/{hour}/atmos/{obs_type}_satbias.nc4'
+type: bc
+database: shared
+provider: gsi
+filetype: satbias
+experiment: oper_$dump
+obs_types:
+  - aircraft
+  - amsua_metop-a
+  - amsua_metop-b
+  - amsua_metop-c
+  - amsua_n15
+  - amsua_n18
+  - amsua_n19
+  - atms_n20
+  - atms_npp
+  - avhrr3_metop-a
+  - avhrr3_n18
+  - cris-fsr_n20
+  - cris-fsr_npp
+  - gome_metop-a
+  - gome_metop-b
+  - hirs4_metop-a
+  - hirs4_n19
+  - iasi_metop-a
+  - iasi_metop-b
+  - mhs_metop-a
+  - mhs_metop-b
+  - mhs_metop-c
+  - mhs_n19
+  - omi_aura
+  - ompsnp_npp
+  - ompstc8_npp
+  - rass_tv
+  #- saphir_meghat
+  - satwind
+  - sbuv2_n19
+  - scatwind
+  - seviri_m08
+  - seviri_m11
+  - sfc
+  - sfcship
+  - sondes
+  - ssmis_f17
+  - ssmis_f18
+  - sst
+  - vadwind
+  #- windprof
+EOF
+  $r2d2storepy --config $diagroot/r2d2_store_satbias.yaml
+  cat > $diagroot/r2d2_store_tlapse.yaml << EOF
+start: ${firstdate}:00:00Z
+end: ${lastdate}:00:00Z
+step: PT6H
+source_dir: $diagroot
+source_file_fmt: '{source_dir}/satbias/{dump}.{year}{month}{day}/{hour}/atmos/{obs_type}_tlapmean.txt'
+type: bc
+database: shared
+provider: gsi
+filetype: tlapse
+experiment: oper_$dump
+obs_types:
+  - aircraft
+  - amsua_metop-a
+  - amsua_metop-b
+  - amsua_metop-c
+  - amsua_n15
+  - amsua_n18
+  - amsua_n19
+  - atms_n20
+  - atms_npp
+  - avhrr3_metop-a
+  - avhrr3_n18
+  - cris-fsr_n20
+  - cris-fsr_npp
+  - gome_metop-a
+  - gome_metop-b
+  - hirs4_metop-a
+  - hirs4_n19
+  - iasi_metop-a
+  - iasi_metop-b
+  - mhs_metop-a
+  - mhs_metop-b
+  - mhs_metop-c
+  - mhs_n19
+  - omi_aura
+  - ompsnp_npp
+  - ompstc8_npp
+  - rass_tv
+  #- saphir_meghat
+  - satwind
+  - sbuv2_n19
+  - scatwind
+  - seviri_m08
+  - seviri_m11
+  - sfc
+  - sfcship
+  - sondes
+  - ssmis_f17
+  - ssmis_f18
+  - sst
+  - vadwind
+  #- windprof
+EOF
+  $r2d2storepy --config $diagroot/r2d2_store_tlapse.yaml
+fi

--- a/ush/r2d2/proc_ops2r2d2.sh
+++ b/ush/r2d2/proc_ops2r2d2.sh
@@ -175,7 +175,7 @@ source_file_fmt: '{source_dir}/satbias/{dump}.{year}{month}{day}/{hour}/atmos/{o
 type: bc
 database: shared
 provider: gsi
-filetype: satbias
+file_type: satbias
 experiment: oper_$dump
 obs_types:
   - aircraft
@@ -230,7 +230,7 @@ source_file_fmt: '{source_dir}/satbias/{dump}.{year}{month}{day}/{hour}/atmos/{o
 type: bc
 database: shared
 provider: gsi
-filetype: tlapse
+file_type: tlapse
 experiment: oper_$dump
 obs_types:
   - aircraft

--- a/ush/r2d2/r2d2_store.py
+++ b/ush/r2d2/r2d2_store.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+import argparse
+from solo.configuration import Configuration
+import ufsda.r2d2
+
+if __name__ == "__main__":
+    # get input config file
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-c', '--config', type=str, help='Input YAML Configuration', required=True)
+    args = parser.parse_args()
+    config = Configuration(args.config)
+    ufsda.r2d2.store(config)

--- a/ush/ufsda/r2d2.py
+++ b/ush/ufsda/r2d2.py
@@ -1,6 +1,7 @@
 import r2d2
+import re
 from solo.configuration import Configuration
-from solo.date import date_sequence, Hour
+from solo.date import date_sequence, Hour, DateIncrement
 
 possible_args = [
     'provider', 'experiment', 'database', 'type', 'file_type',
@@ -20,6 +21,7 @@ def store(config):
     source_dir = config['source_dir']
     source_file_fmt = config['source_file_fmt']
     obs_types = config.get('obs_types', None)
+    assim_freq = int(re.sub("[^0-9]", "", config.step))
 
     for time in times:
         year = Hour(time).format('%Y')
@@ -27,8 +29,10 @@ def store(config):
         day = Hour(time).format('%d')
         hour = Hour(time).format('%H')
         inputs['date'] = time
+        window_begin = Hour(time) - DateIncrement(f'PT{assim_freq/2}H')
         if r2d2_type in ['bc', 'ob']:
             if r2d2_type == 'ob':
+                inputs['date'] = window_begin
                 inputs['time_window'] = config['step']
             for obs_type in obs_types:
                 inputs['source_file'] = eval(f"f'{source_file_fmt}'"),


### PR DESCRIPTION
The following is in this PR:

- change to the example background store script to store C384 backgrounds from @RussTreadon-NOAA in my shared R2D2 database
- a bugfix to the `r2d2.store` function in `ufsda` that shifts the date to window begin to conform to R2D2's date convention that is not compatible with NCEP's convention
- a very simple `r2d2_store.py` script that can store based on input YAML

Additionally, the main purpose of this PR is an omnibus shell script, `proc_opsr2d2.sh`.
This script will (depending on `= 'YES'`):
- Extract diags from `oznstat`, `cnvstat`, `radstat` files in a `$ROTDIR` like path
- Run ioda converters on these GSI ncdiags
- Run satbias converter on operational GSI abias files
- Store obs and bc files with R2D2

I have used this script to populate `/work2/noaa/da/cmartin/GDASApp/R2D2_SHARED/` with bc files and obs for analysis cycles for the period from 2021-12-21 00z through 2021-12-31 18z.