### PR TITLE
Updates to cycle GDASApp in global-workflow

### DIFF
--- a/parm/atm/obs/config/amsua_n19.yaml
+++ b/parm/atm/obs/config/amsua_n19.yaml
@@ -40,7 +40,7 @@ obs bias:
     step size: 1.0e-4
     largest analysis variance: 10000.0
     prior:
-      input file: $(BIAS_IN_DIR)/$(BIAS_PREFIX)amsua_n19.satbias.$(BIAS_DATE).nc4
+      input file: $(BIAS_IN_DIR)/$(BIAS_PREFIX)amsua_n19.satbias_cov.$(BIAS_DATE).nc4
       inflation:
         ratio: 1.1
         ratio for small dataset: 2.0

--- a/scripts/exgdas_global_atmos_analysis_prep.py
+++ b/scripts/exgdas_global_atmos_analysis_prep.py
@@ -41,3 +41,4 @@ config = ufsda.misc_utils.get_env_config(component='atm')
 
 # use R2D2 to stage obs and bias correction coefficient files
 ufsda.stage.atm_obs(config)
+ufsda.stage.bias_obs(config)

--- a/scripts/exgdas_global_atmos_analysis_run.sh
+++ b/scripts/exgdas_global_atmos_analysis_run.sh
@@ -86,11 +86,7 @@ $NLN ${COMIN_GES}/RESTART $DATA/bkg
 ################################################################################
 # link fix files to $DATA
 # static B
-if [ $DOHYBVAR = "YES" ]; then
-  CASE_BERROR=${CASE_BERROR:-${CASE_ENKF:-$CASE}}
-else
-  CASE_BERROR=${CASE_BERROR:-$CASE}
-fi
+CASE_BERROR=${CASE_BERROR:-${CASE_ANL:-$CASE}}
 $NLN $FV3JEDI_FIX/bump/$CASE_BERROR/ $DATA/berror
 
 # vertical coordinate
@@ -125,6 +121,7 @@ export err=$?; err_chk
 atminc_jedi=`ls $DATA/anl/atminc_latlon*`
 atminc_fv3=$COMOUT/${CDUMP}.${cycle}.atminc.nc
 $INCPY $atminc_jedi $atminc_fv3
+export err=$?; err_chk
 
 ################################################################################
 # Create log file noting creating of analysis increment file
@@ -133,8 +130,8 @@ echo "$CDUMP $CDATE atminc and tiled sfcanl done at `date`" > $COMOUT/${CDUMP}.$
 ################################################################################
 # Copy diags and YAML to $COMOUT
 cp -r $DATA/fv3jedi_var.yaml $COMOUT/${CDUMP}.${cycle}.fv3jedi_var.yaml
-cp -rf $DATA/diags $COMOUT/diags
-cp -rf $DATA/bc $COMOUT/bc
+cp -rf $DATA/diags $COMOUT/
+cp -rf $DATA/bc $COMOUT/
 
 ################################################################################
 set +x

--- a/ush/get_obs_list.py
+++ b/ush/get_obs_list.py
@@ -26,8 +26,9 @@ def get_obs_list(yamlconfig, outputfile):
             outf.write(f"{obsdatain}\n")
             if 'obs bias' in ob.keys():
                 biasin = ob['obs bias']['input file']
-                lapsein = biasin.replace('satbias', 'tlapse').replace('nc4', 'txt')
-                outf.write(f"{biasin}\n{lapsein}\n")
+                satcovin = biasin.replace('satbias', 'satbias_cov')
+                lapsein = satcovin.replace('satbias_cov', 'tlapse').replace('nc4', 'txt')
+                outf.write(f"{biasin}\n{satcovin}\n{lapsein}\n")
 
 
 if __name__ == "__main__":

--- a/ush/jediinc2fv3.py
+++ b/ush/jediinc2fv3.py
@@ -11,6 +11,7 @@ vardict = {
     'delp': 'delp_inc',
     'DELP': 'delp_inc',
     'delz': 'delz_inc',
+    't': 'T_inc',
     'T': 'T_inc',
     'sphum': 'sphum_inc',
     'liq_wat': 'liq_wat_inc',

--- a/ush/run_jedi_exe.py
+++ b/ush/run_jedi_exe.py
@@ -58,7 +58,8 @@ def run_jedi_exe(yamlconfig):
         'fv3jedi_fieldset_dir': os.path.join(workdir, 'Data', 'fieldsets'),
         'ANL_DIR': os.path.join(workdir, 'anl'),
         'fv3jedi_staticb_dir': os.path.join(workdir, 'berror'),
-        'BIAS_DIR': os.path.join(workdir, 'obs'),
+        'BIAS_IN_DIR': os.path.join(workdir, 'obs'),
+        'BIAS_OUT_DIR': os.path.join(workdir, 'bc'),
         'CRTM_COEFF_DIR': os.path.join(workdir, 'crtm'),
         'BIAS_PREFIX': f"{executable_subconfig['dump']}.t{gcyc}z.",
         'BIAS_DATE': f"{gdate}",
@@ -71,6 +72,7 @@ def run_jedi_exe(yamlconfig):
         'prev_valid_time': f"{prev_cycle.strftime('%Y-%m-%dT%H:%M:%SZ')}",
         'atm_window_length': executable_subconfig['atm_window_length'],
         'CASE': executable_subconfig['case'],
+        'CASE_ANL': executable_subconfig.get('case_anl', executable_subconfig['case']),
         'CASE_ENKF': executable_subconfig.get('case_enkf', executable_subconfig['case']),
         'DOHYBVAR': executable_subconfig.get('dohybvar', False),
         'LEVS': str(executable_subconfig['levs']),
@@ -95,6 +97,7 @@ def run_jedi_exe(yamlconfig):
     ufsda.disk_utils.mkdir(os.path.join(workdir, 'diags'))
     if app_mode in ['variational']:
         ufsda.disk_utils.mkdir(os.path.join(workdir, 'anl'))
+        ufsda.disk_utils.mkdir(os.path.join(workdir, 'bc'))
     # generate job submission script
     job_script = ufsda.misc_utils.create_batch_job(all_config_dict['job options'],
                                                    workdir,

--- a/ush/ufsda/archive.py
+++ b/ush/ufsda/archive.py
@@ -35,16 +35,26 @@ def atm_diags(config):
         r2d2_config['source_file_fmt'] = input_file.replace('.nc4', '_0000.nc4')
         r2d2_config['obs_types'] = [ob['obs space']['name']]
         ufsda.r2d2.store(r2d2_config)
-        # get bias files if needed
+        # store bias files
         if 'obs bias' in ob.keys():
             r2d2_config['type'] = 'bc'
             r2d2_config['provider'] = 'gsi'
             r2d2_config['start'] = config['valid_time']
             r2d2_config['end'] = config['valid_time']
+
+            # store satbias
             r2d2_config['file_type'] = 'satbias'
             target_file = ob['obs bias']['output file']
             r2d2_config['source_file_fmt'] = target_file
             ufsda.r2d2.store(r2d2_config)
+
+            # store satbias_cov
+            r2d2_config['file_type'] = 'satbias_cov'
+            target_file = target_file.replace('satbias', 'satbias_cov')
+            r2d2_config['source_file_fmt'] = target_file
+            ufsda.r2d2.store(r2d2_config)
+
+            # store tlapse
             r2d2_config['file_type'] = 'tlapse'
             target_file = target_file.replace('satbias', 'tlapse')
             target_file = target_file.replace('nc4', 'txt')

--- a/ush/ufsda/misc_utils.py
+++ b/ush/ufsda/misc_utils.py
@@ -94,7 +94,7 @@ def get_env_config(component='atm'):
     }
     # some keys we can pull directly from the environment
     env_keys = [
-        'CASE', 'CASE_ENKF', 'DOHYBVAR', 'LEVS', 'OBS_YAML_DIR', 'OBS_LIST',
+        'CASE', 'CASE_ANL', 'CASE_ENKF', 'DOHYBVAR', 'LEVS', 'OBS_YAML_DIR', 'OBS_LIST',
     ]
     for key in env_keys:
         config[key] = os.environ[key]

--- a/ush/ufsda/stage.py
+++ b/ush/ufsda/stage.py
@@ -133,37 +133,23 @@ def bias_obs(config):
             r2d2_config['file_type'] = 'satbias'
             target_file = ob['obs bias']['input file']
             r2d2_config['target_file_fmt'] = target_file
-            print(f"config is {config}")
-            try:
-                r2d2_config['experiment'] = config['experiment']
-                ufsda.r2d2.fetch(r2d2_config)
-            except:
-                r2d2_config['experiment'] = 'oper_gdas'
-                ufsda.r2d2.fetch(r2d2_config)
+            r2d2_config['experiment'] = config.get('experiment', 'oper_gdas')
+            ufsda.r2d2.fetch(r2d2_config)
 
             # fetch satbias_cov
             r2d2_config['file_type'] = 'satbias_cov'
             target_file = target_file.replace('satbias', 'satbias_cov')
             r2d2_config['target_file_fmt'] = target_file
-            try:
-                r2d2_config['experiment'] = config['experiment']
-                ufsda.r2d2.fetch(r2d2_config)
-            except:
-                r2d2_config['experiment'] = 'oper_gdas'
-                ufsda.r2d2.fetch(r2d2_config)
+            r2d2_config['experiment'] = config.get('experiment', 'oper_gdas')
+            ufsda.r2d2.fetch(r2d2_config)
 
             # fetch tlapse
             r2d2_config['file_type'] = 'tlapse'
             target_file = target_file.replace('satbias_cov', 'tlapse')
             target_file = target_file.replace('nc4', 'txt')
             r2d2_config['target_file_fmt'] = target_file
-            try:
-                r2d2_config['experiment'] = config['experiment']
-                ufsda.r2d2.fetch(r2d2_config)
-            except:
-                r2d2_config['experiment'] = 'oper_gdas'
-                ufsda.r2d2.fetch(r2d2_config)
-
+            r2d2_config['experiment'] = 'oper_gdas'
+            ufsda.r2d2.fetch(r2d2_config)
 
 def gdas_single_cycle(config):
     # grab backgrounds first

--- a/ush/ufsda/stage.py
+++ b/ush/ufsda/stage.py
@@ -104,6 +104,7 @@ def atm_obs(config):
         r2d2_config['obs_types'] = [ob['obs space']['name']]
         ufsda.r2d2.fetch(r2d2_config)
 
+
 def bias_obs(config):
     # fetch bias files
     r2d2_config = {
@@ -150,6 +151,7 @@ def bias_obs(config):
             r2d2_config['target_file_fmt'] = target_file
             r2d2_config['experiment'] = 'oper_gdas'
             ufsda.r2d2.fetch(r2d2_config)
+
 
 def gdas_single_cycle(config):
     # grab backgrounds first

--- a/ush/ufsda/stage.py
+++ b/ush/ufsda/stage.py
@@ -6,7 +6,7 @@ import shutil
 import datetime as dt
 import ufsda
 
-__all__ = ['atm_background', 'atm_obs', 'gdas_fix', 'gdas_single_cycle']
+__all__ = ['atm_background', 'atm_obs', 'bias_obs', 'gdas_fix', 'gdas_single_cycle']
 
 
 def gdas_fix(input_fix_dir, working_dir, config):
@@ -20,11 +20,8 @@ def gdas_fix(input_fix_dir, working_dir, config):
     # create output directories
     ufsda.disk_utils.mkdir(config['fv3jedi_fieldset_dir'])
     ufsda.disk_utils.mkdir(config['fv3jedi_fix_dir'])
-    # figure out analysis resolution
-    if config['DOHYBVAR']:
-        case_anl = config['CASE_ENKF']
-    else:
-        case_anl = config['CASE']
+    # get analysis resolution
+    case_anl = config['CASE_ANL']
     layers = int(config['LEVS'])-1
     # link static B files
     ufsda.disk_utils.symlink(os.path.join(input_fix_dir, 'bump', case_anl),
@@ -106,26 +103,74 @@ def atm_obs(config):
         r2d2_config['target_file_fmt'] = target_file
         r2d2_config['obs_types'] = [ob['obs space']['name']]
         ufsda.r2d2.fetch(r2d2_config)
+
+def bias_obs(config):
+    # fetch bias files
+    r2d2_config = {
+        'start': config['prev_valid_time'],
+        'end': config['prev_valid_time'],
+        'step': config['atm_window_length'],
+        'dump': 'gdas',
+        'experiment': 'oper_gdas',  # change this here and other places to be oper_{dump}
+        'target_dir': config.get('target_dir', config.get('BKG_DIR', './')),
+    }
+    r2d2_config = NiceDict(r2d2_config)
+    # get list of obs to process and their output files
+    obs_list_yaml = config['OBS_LIST']
+    obs_list_config = Configuration(obs_list_yaml)
+    obs_list_config = ufsda.yamltools.iter_config(config, obs_list_config)
+    for ob in obs_list_config['observations']:
+        r2d2_config.pop('file_type', None)
+        r2d2_config['obs_types'] = [ob['obs space']['name']]
         # get bias files if needed
         if 'obs bias' in ob.keys():
             r2d2_config['type'] = 'bc'
             r2d2_config['provider'] = 'gsi'
             r2d2_config['start'] = config['prev_valid_time']
             r2d2_config['end'] = r2d2_config['start']
+
+            # fetch satbias
             r2d2_config['file_type'] = 'satbias'
             target_file = ob['obs bias']['input file']
             r2d2_config['target_file_fmt'] = target_file
-            ufsda.r2d2.fetch(r2d2_config)
+            print(f"config is {config}")
+            try:
+                r2d2_config['experiment'] = config['experiment']
+                ufsda.r2d2.fetch(r2d2_config)
+            except:
+                r2d2_config['experiment'] = 'oper_gdas'
+                ufsda.r2d2.fetch(r2d2_config)
+
+            # fetch satbias_cov
+            r2d2_config['file_type'] = 'satbias_cov'
+            target_file = target_file.replace('satbias', 'satbias_cov')
+            r2d2_config['target_file_fmt'] = target_file
+            try:
+                r2d2_config['experiment'] = config['experiment']
+                ufsda.r2d2.fetch(r2d2_config)
+            except:
+                r2d2_config['experiment'] = 'oper_gdas'
+                ufsda.r2d2.fetch(r2d2_config)
+
+            # fetch tlapse
             r2d2_config['file_type'] = 'tlapse'
-            target_file = target_file.replace('satbias', 'tlapse')
+            target_file = target_file.replace('satbias_cov', 'tlapse')
             target_file = target_file.replace('nc4', 'txt')
             r2d2_config['target_file_fmt'] = target_file
-            ufsda.r2d2.fetch(r2d2_config)
+            try:
+                r2d2_config['experiment'] = config['experiment']
+                ufsda.r2d2.fetch(r2d2_config)
+            except:
+                r2d2_config['experiment'] = 'oper_gdas'
+                ufsda.r2d2.fetch(r2d2_config)
 
 
 def gdas_single_cycle(config):
     # grab backgrounds first
     atm_background(config)
 
-    # grab observations and bias correction files
+    # grab observations
     atm_obs(config)
+
+    # grab bias files
+    bias_obs(config)

--- a/ush/ufsda/yamltools.py
+++ b/ush/ufsda/yamltools.py
@@ -69,6 +69,7 @@ def parse_config(input_config_dict, template=None, clean=True):
 def atmanl_case(config):
     # compute atm analysis case/res variables based on environment and/or config
     case = int(config.get('CASE', os.environ.get('CASE', 'C768'))[1:])
+    case_anl = int(config.get('CASE_ANL', os.environ.get('CASE_ANL', 'C384'))[1:])
     case_enkf = int(config.get('CASE_ENKF', os.environ.get('CASE_ENKF', 'C384'))[1:])
     levs = int(config.get('LEVS', os.environ.get('LEVS', '128')))
     if 'DOHYBVAR' in config:
@@ -76,6 +77,10 @@ def atmanl_case(config):
         del config['DOHYBVAR']
     else:
         dohybvar = isTrue(os.environ.get('DOHYBVAR', 'NO'))
+    # if dohybar is true, we currently need to ensure case_enkf = case_anl
+    if dohybvar and not case_enkf == case_anl:
+        raise KeyError(f"dohybvar is '{dohybvar}' but case_enkf= '{case_enkf}' does not equal case_anl= '{case_anl}'")
+
     # get background geometry
     ntiles = 6  # global, fix later to be more generic
     layout = [
@@ -84,11 +89,7 @@ def atmanl_case(config):
     ]
     io_layout = ['1', '1']  # force to be one file for forseeable future
     config['GEOM_BKG'] = fv3_geom_dict(case, levs, ntiles, layout, io_layout)
-    # get analysis geometry depending on dohybvar
-    if dohybvar:
-        config['GEOM_ANL'] = fv3_geom_dict(case_enkf, levs, ntiles, layout, io_layout)
-    else:
-        config['GEOM_ANL'] = fv3_geom_dict(case, levs, ntiles, layout, io_layout)
+    config['GEOM_ANL'] = fv3_geom_dict(case_anl, levs, ntiles, layout, io_layout)
     return config
 
 

--- a/ush/ufsda/yamltools.py
+++ b/ush/ufsda/yamltools.py
@@ -79,7 +79,7 @@ def atmanl_case(config):
         dohybvar = isTrue(os.environ.get('DOHYBVAR', 'NO'))
     # if dohybar is true, we currently need to ensure case_enkf = case_anl
     if dohybvar and not case_enkf == case_anl:
-        raise KeyError(f"dohybvar is '{dohybvar}' but case_enkf= '{case_enkf}' does not equal case_anl= '{case_anl}'")
+        raise ValueError(f"dohybvar is '{dohybvar}' but case_enkf= '{case_enkf}' does not equal case_anl= '{case_anl}'")
 
     # get background geometry
     ntiles = 6  # global, fix later to be more generic


### PR DESCRIPTION
This PR is opened to request merger of the following changes from branch `feature/cycling` in fork [Russ-Treadon-NOAA/GDASApp](https://github.com/RussTreadon-NOAA/GDASApp) into the authoritative `feature/cycling`.
 * `parm/atm/obs/config/amsua_n19.yaml` - set radiance bias correction error covariance file to satbias_cov
 * `scripts/exgdas_global_atmos_analysis_prep.py` - add function to stage bias correction files
 * `scripts/exgdas_global_atmos_analysis_run.sh` - replace DOHYBVAR with CASE_ANL, trap INCPY return code, fix output cp
 * `ush/get_obs_list.py` - add satbias_cov to list of files to process
 * `ush/jediinc2fv3.py` - add lowercase t (air_temperature) as a variable to check
 * `ush/run_jedi_exe.py` - replace BIAS_DIR with BIAS_IN_DIR and BIAS_OUT_DIR, add CASE_ANL, create bc directory
 * `ush/ufsda/archive.py` - store satbias_cov
 * `ush/ufsda/misc_utils.py` - add CASE_ANL
 * `ush/ufsda/stage.py` - replace DOHYBVAR logic with direct use of CASE_ANL, add function bias_obs
 * `ush/ufsda/yamltools.py` - add case_anl, set GEOM_ANL based on case_anl

These changes have been tested via a C96L127 parallel running on Orion using g-w branch [feature/ufsda-gdasapp](https://github.com/NOAA-EMC/global-workflow/tree/feature/ufsda-gdasapp).  Expected behavior was observed.   `run_jedi_exe.py` was tested using a sample yaml file.  Expected behavior was observed.