### PR TITLE
Add VADER and Update Modulefiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,4 @@ soca/
 test-data-release/
 ufo/
 ufo-data/
+vader/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,7 @@ if(BUILD_GDASBUNDLE)
 
 # Core JEDI repositories
   ecbuild_bundle( PROJECT oops  GIT "https://github.com/jcsda/oops.git"  BRANCH develop UPDATE )
+  ecbuild_bundle( PROJECT vader GIT "https://github.com/jcsda/vader.git" BRANCH develop UPDATE )
   ecbuild_bundle( PROJECT saber GIT "https://github.com/jcsda/saber.git" BRANCH develop UPDATE )
   ecbuild_bundle( PROJECT ioda  GIT "https://github.com/jcsda/ioda.git"  BRANCH develop UPDATE )
   ecbuild_bundle( PROJECT ufo   GIT "https://github.com/jcsda/ufo.git" BRANCH develop UPDATE )

--- a/modulefiles/GDAS/hera.lua
+++ b/modulefiles/GDAS/hera.lua
@@ -37,8 +37,8 @@ load("nccmp/1.8.7.0")
 load("pio/2.5.1-debug")
 
 load("ecbuild/ecmwf-3.6.1")
-load("eckit/ecmwf-1.16.0")
-load("fckit/ecmwf-0.9.2")
+load("eckit/ecmwf-1.18.2")
+load("fckit/ecmwf-0.9.5")
 load("atlas/ecmwf-0.29.0")
 load("nco/4.9.1")
 

--- a/modulefiles/GDAS/orion.lua
+++ b/modulefiles/GDAS/orion.lua
@@ -57,6 +57,9 @@ setenv('R2D2_CONFIG', '/work2/noaa/da/cmartin/GDASApp/R2D2_SHARED/config_orion.y
 
 execute{cmd="ulimit -s unlimited",modeA={"load"}}
 
+-- below is hack because of hardcoded python exe in fckit
+prepend_path("LD_LIBRARY_PATH","/apps/python-3.9.2/lib")
+
 whatis("Name: ".. pkgName)
 whatis("Version: " .. pkgVersion)
 whatis("Category: GDASApp")

--- a/modulefiles/GDAS/orion.lua
+++ b/modulefiles/GDAS/orion.lua
@@ -37,8 +37,8 @@ load("nccmp/1.8.7.0")
 load("pio/2.5.1-debug")
 
 load("ecbuild/ecmwf-3.6.1")
-load("eckit/ecmwf-1.18.2")
 load("fckit/ecmwf-0.9.5")
+load("eckit/ecmwf-1.18.2")
 load("atlas/ecmwf-0.29.0")
 
 load("hpc/1.2.0")

--- a/modulefiles/GDAS/orion.lua
+++ b/modulefiles/GDAS/orion.lua
@@ -37,8 +37,8 @@ load("nccmp/1.8.7.0")
 load("pio/2.5.1-debug")
 
 load("ecbuild/ecmwf-3.6.1")
-load("eckit/ecmwf-1.16.0")
-load("fckit/ecmwf-0.9.2")
+load("eckit/ecmwf-1.18.2")
+load("fckit/ecmwf-0.9.5")
 load("atlas/ecmwf-0.29.0")
 
 load("hpc/1.2.0")


### PR DESCRIPTION
Closes #56 

This PR adds VADER to the CMakeLists.txt for the pseudo bundle, adds vader/ to the .gitignore, and updates eckit and fckit module versions for Hera and Orion.