### PR TITLE
Converter script to change/add to EWOK YAMLs for use in GDASApp

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -42,6 +42,7 @@ list(APPEND test_input
   ${PROJECT_SOURCE_DIR}/test/testinput/check_yaml_keys_ref.yaml
   ${PROJECT_SOURCE_DIR}/test/testinput/check_yaml_keys_test.yaml
   ${PROJECT_SOURCE_DIR}/test/testinput/bufr_adpsfc.yaml
+  ${PROJECT_SOURCE_DIR}/test/testinput/amsua_n19_ewok.yaml
 )
 
 # create testinput dir
@@ -59,6 +60,24 @@ install(FILES ${test_input}
 
 # create testout dir
 file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/test/testoutput)
+
+# create testreference dir
+file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/test/testreference)
+
+# list of test reference files to install
+list(APPEND test_reference
+  ${PROJECT_SOURCE_DIR}/test/testreference/amsua_n19_gdas.yaml
+)
+
+# symlink
+foreach(FILENAME ${test_reference})
+  file(RELATIVE_PATH FILENAME_REL ${PROJECT_SOURCE_DIR}/test/testreference/ ${FILENAME})
+  file(CREATE_LINK ${FILENAME} ${PROJECT_BINARY_DIR}/test/testreference/${FILENAME_REL} SYMBOLIC)
+endforeach(FILENAME)
+
+# install
+install(FILES ${test_reference}
+        DESTINATION "test/testreference/")
 
 ##### unit tests
 # test for python coding norms
@@ -97,6 +116,10 @@ set_tests_properties(
 PROPERTIES
          ENVIRONMENT "PYTHONPATH=${PROJECT_BINARY_DIR}/ush:$ENV{PYTHONPATH};PARMgfs=${PROJECT_SOURCE_DIR}/parm"
 )
+# test for converting ewok yaml to gdas
+add_test(NAME test_gdasapp_convert_ewok_yaml
+         COMMAND ${PROJECT_SOURCE_DIR}/test/convert_ewok_yaml.sh ${PROJECT_BINARY_DIR} ${PROJECT_SOURCE_DIR}
+         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/)
 
 # soca tests
 add_subdirectory(soca)

--- a/test/convert_ewok_yaml.sh
+++ b/test/convert_ewok_yaml.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -ex
+bindir=$1
+srcdir=$2
+
+# run converter python script
+$srcdir/ush/convert_yaml_ewok2gdas.py $bindir/test/testinput/amsua_n19_ewok.yaml $bindir/test/testoutput/amsua_n19_gdas.yaml
+
+# run a diff on the output and reference file
+diff $bindir/test/testoutput/amsua_n19_gdas.yaml $bindir/test/testreference/amsua_n19_gdas.yaml

--- a/test/testinput/amsua_n19_ewok.yaml
+++ b/test/testinput/amsua_n19_ewok.yaml
@@ -1,0 +1,323 @@
+obs space:
+  name: amsua_n19
+  obsdatain:
+    obsfile: $(experiment_dir)/{{current_cycle}}/amsua_n19.{{window_begin}}.nc4
+  obsdataout:
+    obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).amsua_n19.{{window_begin}}.nc4
+  simulated variables: [brightness_temperature]
+  channels: &amsua_n19_channels 1-15
+obs operator:
+  name: CRTM
+  Absorbers: [H2O,O3,CO2]
+  Clouds: [Water, Ice]
+  Cloud_Fraction: 1.0
+  obs options:
+    Sensor_ID: amsua_n19
+    EndianType: little_endian
+    CoefficientPath: $(jedi_build)/ufo/test/Data/
+obs bias:
+  input file: $(experiment_dir)/{{current_cycle}}/amsua_n19.{{background_time}}.satbias.nc4
+  variational bc:
+    predictors:
+    - name: constant
+    - name: lapse_rate
+      order: 2
+      tlapse: &amsua_n19_tlapse $(experiment_dir)/{{current_cycle}}/amsua_n19.{{background_time}}.tlapse.txt
+    - name: lapse_rate
+      tlapse: *amsua_n19_tlapse
+    - name: emissivity
+    - name: scan_angle
+      order: 4
+    - name: scan_angle
+      order: 3
+    - name: scan_angle
+      order: 2
+    - name: scan_angle
+obs filters:
+- filter: BlackList
+  filter variables:
+  - name: brightness_temperature
+    channels: *amsua_n19_channels
+  action:
+    name: assign error
+    error function:
+      name: ObsErrorModelRamp@ObsFunction
+      channels: *amsua_n19_channels
+      options:
+        channels: *amsua_n19_channels
+        xvar:
+          name: CLWRetSymmetricMW@ObsFunction
+          options:
+            clwret_ch238: 1
+            clwret_ch314: 2
+            clwret_types: [ObsValue, HofX]
+        x0:    [ 0.050,  0.030,  0.030,  0.020,  0.000,
+                 0.100,  0.000,  0.000,  0.000,  0.000,
+                 0.000,  0.000,  0.000,  0.000,  0.030]
+        x1:    [ 0.600,  0.450,  0.400,  0.450,  1.000,
+                 1.500,  0.000,  0.000,  0.000,  0.000,
+                 0.000,  0.000,  0.000,  0.000,  0.200]
+        err0:  [ 2.500,  2.200,  2.000,  0.550,  0.300,
+                 0.230,  0.230,  0.250,  0.250,  0.350,
+                 0.400,  0.550,  0.800,  3.000,  3.500]
+        err1:  [20.000, 18.000, 12.000,  3.000,  0.500,
+                 0.300,  0.230,  0.250,  0.250,  0.350,
+                 0.400,  0.550,  0.800,  3.000, 18.000]
+#  CLW Retrieval Check
+- filter: Bounds Check
+  filter variables:
+  - name: brightness_temperature
+    channels: 1-6, 15
+  test variables:
+  - name: CLWRetMW@ObsFunction
+    options:
+      clwret_ch238: 1
+      clwret_ch314: 2
+      clwret_types: [ObsValue]
+  maxvalue: 999.0
+  action:
+    name: reject
+#  CLW Retrieval Check
+- filter: Bounds Check
+  filter variables:
+  - name: brightness_temperature
+    channels: 1-6, 15
+  test variables:
+  - name: CLWRetMW@ObsFunction
+    options:
+      clwret_ch238: 1
+      clwret_ch314: 2
+      clwret_types: [HofX]
+  maxvalue: 999.0
+  action:
+    name: reject
+#  Hydrometeor Check (cloud/precipitation affected chanels)
+- filter: Bounds Check
+  filter variables:
+  - name: brightness_temperature
+    channels: *amsua_n19_channels
+  test variables:
+  - name: HydrometeorCheckAMSUA@ObsFunction
+    channels: *amsua_n19_channels
+    options:
+      channels: *amsua_n19_channels
+      obserr_clearsky: [ 2.500, 2.200, 2.000, 0.550, 0.300,
+                         0.230, 0.230, 0.250, 0.250, 0.350,
+                         0.400, 0.550, 0.800, 3.000, 3.500]
+      clwret_function:
+        name: CLWRetMW@ObsFunction
+        options:
+          clwret_ch238: 1
+          clwret_ch314: 2
+          clwret_types: [ObsValue]
+      obserr_function:
+        name: ObsErrorModelRamp@ObsFunction
+        channels: *amsua_n19_channels
+        options:
+          channels: *amsua_n19_channels
+          xvar:
+            name: CLWRetSymmetricMW@ObsFunction
+            options:
+              clwret_ch238: 1
+              clwret_ch314: 2
+              clwret_types: [ObsValue, HofX]
+          x0:    [ 0.050,  0.030,  0.030,  0.020,  0.000,
+                   0.100,  0.000,  0.000,  0.000,  0.000,
+                   0.000,  0.000,  0.000,  0.000,  0.030]
+          x1:    [ 0.600,  0.450,  0.400,  0.450,  1.000,
+                   1.500,  0.000,  0.000,  0.000,  0.000,
+                   0.000,  0.000,  0.000,  0.000,  0.200]
+          err0:  [ 2.500,  2.200,  2.000,  0.550,  0.300,
+                   0.230,  0.230,  0.250,  0.250,  0.350,
+                   0.400,  0.550,  0.800,  3.000,  3.500]
+          err1:  [20.000, 18.000, 12.000,  3.000,  0.500,
+                   0.300,  0.230,  0.250,  0.250,  0.350,
+                   0.400,  0.550,  0.800,  3.000, 18.000]
+  maxvalue: 0.0
+  action:
+    name: reject
+#  Topography check
+- filter: BlackList
+  filter variables:
+  - name: brightness_temperature
+    channels: *amsua_n19_channels
+  action:
+    name: inflate error
+    inflation variable:
+      name: ObsErrorFactorTopoRad@ObsFunction
+      channels: *amsua_n19_channels
+      options:
+        sensor: amsua_n19
+        channels: *amsua_n19_channels
+#  Transmittnace Top Check
+- filter: BlackList
+  filter variables:
+  - name: brightness_temperature
+    channels: *amsua_n19_channels
+  action:
+    name: inflate error
+    inflation variable:
+      name: ObsErrorFactorTransmitTopRad@ObsFunction
+      channels: *amsua_n19_channels
+      options:
+        channels: *amsua_n19_channels
+#  Surface Jacobian check
+- filter: BlackList
+  filter variables:
+  - name: brightness_temperature
+    channels: *amsua_n19_channels
+  action:
+    name: inflate error
+    inflation variable:
+      name: ObsErrorFactorSurfJacobianRad@ObsFunction
+      channels: *amsua_n19_channels
+      options:
+        channels: *amsua_n19_channels
+        obserr_demisf: [0.010, 0.020, 0.015, 0.020, 0.200]
+        obserr_dtempf: [0.500, 2.000, 1.000, 2.000, 4.500]
+#  Situation dependent Check
+- filter: BlackList
+  filter variables:
+  - name: brightness_temperature
+    channels: *amsua_n19_channels
+  action:
+    name: inflate error
+    inflation variable:
+      name: ObsErrorFactorSituDependMW@ObsFunction
+      channels: *amsua_n19_channels
+      options:
+        sensor: amsua_n19
+        channels: *amsua_n19_channels
+        clwobs_function:
+          name: CLWRetMW@ObsFunction
+          options:
+            clwret_ch238: 1
+            clwret_ch314: 2
+            clwret_types: [ObsValue]
+        clwbkg_function:
+          name: CLWRetMW@ObsFunction
+          options:
+            clwret_ch238: 1
+            clwret_ch314: 2
+            clwret_types: [HofX]
+            bias_application: HofX
+        scatobs_function:
+          name: SCATRetMW@ObsFunction
+          options:
+            scatret_ch238: 1
+            scatret_ch314: 2
+            scatret_ch890: 15
+            scatret_types: [ObsValue]
+            bias_application: HofX
+        clwmatchidx_function:
+          name: CLWMatchIndexMW@ObsFunction
+          channels: *amsua_n19_channels
+          options:
+            channels: *amsua_n19_channels
+            clwobs_function:
+              name: CLWRetMW@ObsFunction
+              options:
+                clwret_ch238: 1
+                clwret_ch314: 2
+                clwret_types: [ObsValue]
+            clwbkg_function:
+              name: CLWRetMW@ObsFunction
+              options:
+                clwret_ch238: 1
+                clwret_ch314: 2
+                clwret_types: [HofX]
+                bias_application: HofX
+            clwret_clearsky: [0.050, 0.030, 0.030, 0.020, 0.000,
+                              0.100, 0.000, 0.000, 0.000, 0.000,
+                              0.000, 0.000, 0.000, 0.000, 0.030]
+        obserr_clearsky: [2.500, 2.200, 2.000, 0.550, 0.300,
+                          0.230, 0.230, 0.250, 0.250, 0.350,
+                          0.400, 0.550, 0.800, 3.000, 3.500]
+#  Gross check
+- filter: Background Check
+  filter variables:
+  - name: brightness_temperature
+    channels: *amsua_n19_channels
+  function absolute threshold:
+  - name: ObsErrorBoundMW@ObsFunction
+    channels: *amsua_n19_channels
+    options:
+      sensor: amsua_n19
+      channels: *amsua_n19_channels
+      obserr_bound_latitude:
+        name: ObsErrorFactorLatRad@ObsFunction
+        options:
+          latitude_parameters: [25.0, 0.25, 0.04, 3.0]
+      obserr_bound_transmittop:
+        name: ObsErrorFactorTransmitTopRad@ObsFunction
+        channels: *amsua_n19_channels
+        options:
+          channels: *amsua_n19_channels
+      obserr_bound_topo:
+        name: ObsErrorFactorTopoRad@ObsFunction
+        channels: *amsua_n19_channels
+        options:
+          channels: *amsua_n19_channels
+          sensor: amsua_n19
+      obserr_function:
+        name: ObsErrorModelRamp@ObsFunction
+        channels: *amsua_n19_channels
+        options:
+          channels: *amsua_n19_channels
+          xvar:
+            name: CLWRetSymmetricMW@ObsFunction
+            options:
+              clwret_ch238: 1
+              clwret_ch314: 2
+              clwret_types: [ObsValue, HofX]
+              bias_application: HofX
+          x0:    [ 0.050,  0.030,  0.030,  0.020,  0.000,
+                   0.100,  0.000,  0.000,  0.000,  0.000,
+                   0.000,  0.000,  0.000,  0.000,  0.030]
+          x1:    [ 0.600,  0.450,  0.400,  0.450,  1.000,
+                   1.500,  0.000,  0.000,  0.000,  0.000,
+                   0.000,  0.000,  0.000,  0.000,  0.200]
+          err0:  [ 2.500,  2.200,  2.000,  0.550,  0.300,
+                   0.230,  0.230,  0.250,  0.250,  0.350,
+                   0.400,  0.550,  0.800,  3.000,  3.500]
+          err1:  [20.000, 18.000, 12.000,  3.000,  0.500,
+                   0.300,  0.230,  0.250,  0.250,  0.350,
+                   0.400,  0.550,  0.800,  3.000, 18.000]
+      obserr_bound_max: [4.5, 4.5, 4.5, 2.5, 2.0,
+                         2.0, 2.0, 2.0, 2.0, 2.0,
+                         2.5, 3.5, 4.5, 4.5, 4.5]
+  action:
+    name: reject
+#  Inter-channel check
+- filter: Bounds Check
+  filter variables:
+  - name: brightness_temperature
+    channels: *amsua_n19_channels
+  test variables:
+  - name: InterChannelConsistencyCheck@ObsFunction
+    channels: *amsua_n19_channels
+    options:
+      channels: *amsua_n19_channels
+      sensor: amsua_n19
+      use_flag: [ 1,  1,  1,  1,  1,
+                  1, -1, -1,  1,  1,
+                  1,  1,  1, -1,  1 ]
+  maxvalue: 1.0e-12
+  action:
+    name: reject
+#  Useflag check
+- filter: Bounds Check
+  filter variables:
+  - name: brightness_temperature
+    channels: *amsua_n19_channels
+  test variables:
+  - name: ChannelUseflagCheckRad@ObsFunction
+    channels: *amsua_n19_channels
+    options:
+      channels: *amsua_n19_channels
+      use_flag: [ 1,  1,  1,  1,  1,
+                  1, -1, -1,  1,  1,
+                  1,  1,  1, -1,  1 ]
+  minvalue: 1.0e-12
+  action:
+    name: reject

--- a/test/testreference/amsua_n19_gdas.yaml
+++ b/test/testreference/amsua_n19_gdas.yaml
@@ -1,19 +1,34 @@
+obs space:
+  name: amsua_n19
+  obsdatain:
+    obsfile: $(OBS_DIR)/$(OBS_PREFIX)amsua_n19.$(OBS_DATE).nc4
+  obsdataout:
+    obsfile: $(DIAG_DIR)/diag_amsua_n19_$(OBS_DATE).nc4
+  simulated variables:
+  - brightness_temperature
+  channels: 1-15
+  io pool:
+    max pool size: 1
+obs operator:
+  name: CRTM
+  Absorbers:
+  - H2O
+  - O3
+  - CO2
+  Clouds:
+  - Water
+  - Ice
+  Cloud_Fraction: 1.0
+  obs options:
+    Sensor_ID: amsua_n19
+    EndianType: little_endian
+    CoefficientPath: $(CRTM_COEFF_DIR)/
+  linear obs operator:
+    Absorbers:
+    - H2O
+    - O3
 obs bias:
-  covariance:
-    largest analysis variance: 10000.0
-    minimal required obs number: 20
-    output file: $(BIAS_OUT_DIR)/$(OBS_PREFIX)amsua_n19.satbias_cov.$(OBS_DATE).nc4
-    prior:
-      inflation:
-        ratio: 1.1
-        ratio for small dataset: 2.0
-      input file: $(BIAS_IN_DIR)/$(BIAS_PREFIX)amsua_n19.satbias_cov.$(BIAS_DATE).nc4
-    step size: 0.0001
-    variance range:
-    - 1.0e-06
-    - 10.0
   input file: $(BIAS_IN_DIR)/$(BIAS_PREFIX)amsua_n19.satbias.$(BIAS_DATE).nc4
-  output file: $(BIAS_OUT_DIR)/$(OBS_PREFIX)amsua_n19.satbias.$(OBS_DATE).nc4
   variational bc:
     predictors:
     - name: constant
@@ -30,45 +45,40 @@ obs bias:
     - name: scan_angle
       order: 2
     - name: scan_angle
+  output file: $(BIAS_OUT_DIR)/$(OBS_PREFIX)amsua_n19.satbias.$(OBS_DATE).nc4
+  covariance:
+    minimal required obs number: 20
+    variance range:
+    - 1.0e-06
+    - 10.0
+    step size: 0.0001
+    largest analysis variance: 10000.0
+    prior:
+      input file: $(BIAS_IN_DIR)/$(BIAS_PREFIX)amsua_n19.satbias_cov.$(BIAS_DATE).nc4
+      inflation:
+        ratio: 1.1
+        ratio for small dataset: 2.0
+    output file: $(BIAS_OUT_DIR)/$(OBS_PREFIX)amsua_n19.satbias_cov.$(OBS_DATE).nc4
 obs filters:
-- action:
+- filter: BlackList
+  filter variables:
+  - name: brightness_temperature
+    channels: 1-15
+  action:
+    name: assign error
     error function:
-      channels: 1-15
       name: ObsErrorModelRamp@ObsFunction
+      channels: 1-15
       options:
         channels: 1-15
-        err0:
-        - 2.5
-        - 2.2
-        - 2.0
-        - 0.55
-        - 0.3
-        - 0.23
-        - 0.23
-        - 0.25
-        - 0.25
-        - 0.35
-        - 0.4
-        - 0.55
-        - 0.8
-        - 3.0
-        - 3.5
-        err1:
-        - 20.0
-        - 18.0
-        - 12.0
-        - 3.0
-        - 0.5
-        - 0.3
-        - 0.23
-        - 0.25
-        - 0.25
-        - 0.35
-        - 0.4
-        - 0.55
-        - 0.8
-        - 3.0
-        - 18.0
+        xvar:
+          name: CLWRetSymmetricMW@ObsFunction
+          options:
+            clwret_ch238: 1
+            clwret_ch314: 2
+            clwret_types:
+            - ObsValue
+            - HofX
         x0:
         - 0.05
         - 0.03
@@ -101,26 +111,42 @@ obs filters:
         - 0.0
         - 0.0
         - 0.2
-        xvar:
-          name: CLWRetSymmetricMW@ObsFunction
-          options:
-            clwret_ch238: 1
-            clwret_ch314: 2
-            clwret_types:
-            - ObsValue
-            - HofX
-    name: assign error
-  filter: BlackList
+        err0:
+        - 2.5
+        - 2.2
+        - 2.0
+        - 0.55
+        - 0.3
+        - 0.23
+        - 0.23
+        - 0.25
+        - 0.25
+        - 0.35
+        - 0.4
+        - 0.55
+        - 0.8
+        - 3.0
+        - 3.5
+        err1:
+        - 20.0
+        - 18.0
+        - 12.0
+        - 3.0
+        - 0.5
+        - 0.3
+        - 0.23
+        - 0.25
+        - 0.25
+        - 0.35
+        - 0.4
+        - 0.55
+        - 0.8
+        - 3.0
+        - 18.0
+- filter: Bounds Check
   filter variables:
-  - channels: 1-15
-    name: brightness_temperature
-- action:
-    name: reject
-  filter: Bounds Check
-  filter variables:
-  - channels: 1-6, 15
-    name: brightness_temperature
-  maxvalue: 999.0
+  - name: brightness_temperature
+    channels: 1-6, 15
   test variables:
   - name: CLWRetMW@ObsFunction
     options:
@@ -128,13 +154,13 @@ obs filters:
       clwret_ch314: 2
       clwret_types:
       - ObsValue
-- action:
-    name: reject
-  filter: Bounds Check
-  filter variables:
-  - channels: 1-6, 15
-    name: brightness_temperature
   maxvalue: 999.0
+  action:
+    name: reject
+- filter: Bounds Check
+  filter variables:
+  - name: brightness_temperature
+    channels: 1-6, 15
   test variables:
   - name: CLWRetMW@ObsFunction
     options:
@@ -142,25 +168,18 @@ obs filters:
       clwret_ch314: 2
       clwret_types:
       - HofX
-- action:
+  maxvalue: 999.0
+  action:
     name: reject
-  filter: Bounds Check
+- filter: Bounds Check
   filter variables:
-  - channels: 1-15
-    name: brightness_temperature
-  maxvalue: 0.0
+  - name: brightness_temperature
+    channels: 1-15
   test variables:
-  - channels: 1-15
-    name: HydrometeorCheckAMSUA@ObsFunction
+  - name: HydrometeorCheckAMSUA@ObsFunction
+    channels: 1-15
     options:
       channels: 1-15
-      clwret_function:
-        name: CLWRetMW@ObsFunction
-        options:
-          clwret_ch238: 1
-          clwret_ch314: 2
-          clwret_types:
-          - ObsValue
       obserr_clearsky:
       - 2.5
       - 2.2
@@ -177,43 +196,26 @@ obs filters:
       - 0.8
       - 3.0
       - 3.5
+      clwret_function:
+        name: CLWRetMW@ObsFunction
+        options:
+          clwret_ch238: 1
+          clwret_ch314: 2
+          clwret_types:
+          - ObsValue
       obserr_function:
-        channels: 1-15
         name: ObsErrorModelRamp@ObsFunction
+        channels: 1-15
         options:
           channels: 1-15
-          err0:
-          - 2.5
-          - 2.2
-          - 2.0
-          - 0.55
-          - 0.3
-          - 0.23
-          - 0.23
-          - 0.25
-          - 0.25
-          - 0.35
-          - 0.4
-          - 0.55
-          - 0.8
-          - 3.0
-          - 3.5
-          err1:
-          - 20.0
-          - 18.0
-          - 12.0
-          - 3.0
-          - 0.5
-          - 0.3
-          - 0.23
-          - 0.25
-          - 0.25
-          - 0.35
-          - 0.4
-          - 0.55
-          - 0.8
-          - 3.0
-          - 18.0
+          xvar:
+            name: CLWRetSymmetricMW@ObsFunction
+            options:
+              clwret_ch238: 1
+              clwret_ch314: 2
+              clwret_types:
+              - ObsValue
+              - HofX
           x0:
           - 0.05
           - 0.03
@@ -246,41 +248,73 @@ obs filters:
           - 0.0
           - 0.0
           - 0.2
-          xvar:
-            name: CLWRetSymmetricMW@ObsFunction
-            options:
-              clwret_ch238: 1
-              clwret_ch314: 2
-              clwret_types:
-              - ObsValue
-              - HofX
-- action:
+          err0:
+          - 2.5
+          - 2.2
+          - 2.0
+          - 0.55
+          - 0.3
+          - 0.23
+          - 0.23
+          - 0.25
+          - 0.25
+          - 0.35
+          - 0.4
+          - 0.55
+          - 0.8
+          - 3.0
+          - 3.5
+          err1:
+          - 20.0
+          - 18.0
+          - 12.0
+          - 3.0
+          - 0.5
+          - 0.3
+          - 0.23
+          - 0.25
+          - 0.25
+          - 0.35
+          - 0.4
+          - 0.55
+          - 0.8
+          - 3.0
+          - 18.0
+  maxvalue: 0.0
+  action:
+    name: reject
+- filter: BlackList
+  filter variables:
+  - name: brightness_temperature
+    channels: 1-15
+  action:
+    name: inflate error
     inflation variable:
-      channels: 1-15
       name: ObsErrorFactorTopoRad@ObsFunction
+      channels: 1-15
       options:
-        channels: 1-15
         sensor: amsua_n19
-    name: inflate error
-  filter: BlackList
+        channels: 1-15
+- filter: BlackList
   filter variables:
-  - channels: 1-15
-    name: brightness_temperature
-- action:
+  - name: brightness_temperature
+    channels: 1-15
+  action:
+    name: inflate error
     inflation variable:
-      channels: 1-15
       name: ObsErrorFactorTransmitTopRad@ObsFunction
+      channels: 1-15
       options:
         channels: 1-15
-    name: inflate error
-  filter: BlackList
+- filter: BlackList
   filter variables:
-  - channels: 1-15
-    name: brightness_temperature
-- action:
+  - name: brightness_temperature
+    channels: 1-15
+  action:
+    name: inflate error
     inflation variable:
-      channels: 1-15
       name: ObsErrorFactorSurfJacobianRad@ObsFunction
+      channels: 1-15
       options:
         channels: 1-15
         obserr_demisf:
@@ -295,38 +329,47 @@ obs filters:
         - 1.0
         - 2.0
         - 4.5
-    name: inflate error
-  filter: BlackList
+- filter: BlackList
   filter variables:
-  - channels: 1-15
-    name: brightness_temperature
-- action:
+  - name: brightness_temperature
+    channels: 1-15
+  action:
+    name: inflate error
     inflation variable:
-      channels: 1-15
       name: ObsErrorFactorSituDependMW@ObsFunction
+      channels: 1-15
       options:
+        sensor: amsua_n19
         channels: 1-15
+        clwobs_function:
+          name: CLWRetMW@ObsFunction
+          options:
+            clwret_ch238: 1
+            clwret_ch314: 2
+            clwret_types:
+            - ObsValue
         clwbkg_function:
           name: CLWRetMW@ObsFunction
           options:
-            bias_application: HofX
             clwret_ch238: 1
             clwret_ch314: 2
             clwret_types:
             - HofX
+            bias_application: HofX
+        scatobs_function:
+          name: SCATRetMW@ObsFunction
+          options:
+            scatret_ch238: 1
+            scatret_ch314: 2
+            scatret_ch890: 15
+            scatret_types:
+            - ObsValue
+            bias_application: HofX
         clwmatchidx_function:
-          channels: 1-15
           name: CLWMatchIndexMW@ObsFunction
+          channels: 1-15
           options:
             channels: 1-15
-            clwbkg_function:
-              name: CLWRetMW@ObsFunction
-              options:
-                bias_application: HofX
-                clwret_ch238: 1
-                clwret_ch314: 2
-                clwret_types:
-                - HofX
             clwobs_function:
               name: CLWRetMW@ObsFunction
               options:
@@ -334,6 +377,14 @@ obs filters:
                 clwret_ch314: 2
                 clwret_types:
                 - ObsValue
+            clwbkg_function:
+              name: CLWRetMW@ObsFunction
+              options:
+                clwret_ch238: 1
+                clwret_ch314: 2
+                clwret_types:
+                - HofX
+                bias_application: HofX
             clwret_clearsky:
             - 0.05
             - 0.03
@@ -350,13 +401,6 @@ obs filters:
             - 0.0
             - 0.0
             - 0.03
-        clwobs_function:
-          name: CLWRetMW@ObsFunction
-          options:
-            clwret_ch238: 1
-            clwret_ch314: 2
-            clwret_types:
-            - ObsValue
         obserr_clearsky:
         - 2.5
         - 2.2
@@ -373,31 +417,15 @@ obs filters:
         - 0.8
         - 3.0
         - 3.5
-        scatobs_function:
-          name: SCATRetMW@ObsFunction
-          options:
-            bias_application: HofX
-            scatret_ch238: 1
-            scatret_ch314: 2
-            scatret_ch890: 15
-            scatret_types:
-            - ObsValue
-        sensor: amsua_n19
-    name: inflate error
-  filter: BlackList
+- filter: Background Check
   filter variables:
-  - channels: 1-15
-    name: brightness_temperature
-- action:
-    name: reject
-  filter: Background Check
-  filter variables:
-  - channels: 1-15
-    name: brightness_temperature
+  - name: brightness_temperature
+    channels: 1-15
   function absolute threshold:
-  - channels: 1-15
-    name: ObsErrorBoundMW@ObsFunction
+  - name: ObsErrorBoundMW@ObsFunction
+    channels: 1-15
     options:
+      sensor: amsua_n19
       channels: 1-15
       obserr_bound_latitude:
         name: ObsErrorFactorLatRad@ObsFunction
@@ -407,70 +435,31 @@ obs filters:
           - 0.25
           - 0.04
           - 3.0
-      obserr_bound_max:
-      - 4.5
-      - 4.5
-      - 4.5
-      - 2.5
-      - 2.0
-      - 2.0
-      - 2.0
-      - 2.0
-      - 2.0
-      - 2.0
-      - 2.5
-      - 3.5
-      - 4.5
-      - 4.5
-      - 4.5
-      obserr_bound_topo:
+      obserr_bound_transmittop:
+        name: ObsErrorFactorTransmitTopRad@ObsFunction
         channels: 1-15
+        options:
+          channels: 1-15
+      obserr_bound_topo:
         name: ObsErrorFactorTopoRad@ObsFunction
+        channels: 1-15
         options:
           channels: 1-15
           sensor: amsua_n19
-      obserr_bound_transmittop:
-        channels: 1-15
-        name: ObsErrorFactorTransmitTopRad@ObsFunction
-        options:
-          channels: 1-15
       obserr_function:
-        channels: 1-15
         name: ObsErrorModelRamp@ObsFunction
+        channels: 1-15
         options:
           channels: 1-15
-          err0:
-          - 2.5
-          - 2.2
-          - 2.0
-          - 0.55
-          - 0.3
-          - 0.23
-          - 0.23
-          - 0.25
-          - 0.25
-          - 0.35
-          - 0.4
-          - 0.55
-          - 0.8
-          - 3.0
-          - 3.5
-          err1:
-          - 20.0
-          - 18.0
-          - 12.0
-          - 3.0
-          - 0.5
-          - 0.3
-          - 0.23
-          - 0.25
-          - 0.25
-          - 0.35
-          - 0.4
-          - 0.55
-          - 0.8
-          - 3.0
-          - 18.0
+          xvar:
+            name: CLWRetSymmetricMW@ObsFunction
+            options:
+              clwret_ch238: 1
+              clwret_ch314: 2
+              clwret_types:
+              - ObsValue
+              - HofX
+              bias_application: HofX
           x0:
           - 0.05
           - 0.03
@@ -503,55 +492,92 @@ obs filters:
           - 0.0
           - 0.0
           - 0.2
-          xvar:
-            name: CLWRetSymmetricMW@ObsFunction
-            options:
-              bias_application: HofX
-              clwret_ch238: 1
-              clwret_ch314: 2
-              clwret_types:
-              - ObsValue
-              - HofX
-      sensor: amsua_n19
-- action:
+          err0:
+          - 2.5
+          - 2.2
+          - 2.0
+          - 0.55
+          - 0.3
+          - 0.23
+          - 0.23
+          - 0.25
+          - 0.25
+          - 0.35
+          - 0.4
+          - 0.55
+          - 0.8
+          - 3.0
+          - 3.5
+          err1:
+          - 20.0
+          - 18.0
+          - 12.0
+          - 3.0
+          - 0.5
+          - 0.3
+          - 0.23
+          - 0.25
+          - 0.25
+          - 0.35
+          - 0.4
+          - 0.55
+          - 0.8
+          - 3.0
+          - 18.0
+      obserr_bound_max:
+      - 4.5
+      - 4.5
+      - 4.5
+      - 2.5
+      - 2.0
+      - 2.0
+      - 2.0
+      - 2.0
+      - 2.0
+      - 2.0
+      - 2.5
+      - 3.5
+      - 4.5
+      - 4.5
+      - 4.5
+  action:
     name: reject
-  filter: Bounds Check
+- filter: Bounds Check
   filter variables:
-  - channels: 1-15
-    name: brightness_temperature
+  - name: brightness_temperature
+    channels: 1-15
+  test variables:
+  - name: InterChannelConsistencyCheck@ObsFunction
+    channels: 1-15
+    options:
+      channels: 1-15
+      sensor: amsua_n19
+      use_flag:
+      - 1
+      - 1
+      - 1
+      - 1
+      - 1
+      - 1
+      - -1
+      - -1
+      - 1
+      - 1
+      - 1
+      - 1
+      - 1
+      - -1
+      - 1
   maxvalue: 1.0e-12
-  test variables:
-  - channels: 1-15
-    name: InterChannelConsistencyCheck@ObsFunction
-    options:
-      channels: 1-15
-      sensor: amsua_n19
-      use_flag:
-      - 1
-      - 1
-      - 1
-      - 1
-      - 1
-      - 1
-      - -1
-      - -1
-      - 1
-      - 1
-      - 1
-      - 1
-      - 1
-      - -1
-      - 1
-- action:
+  action:
     name: reject
-  filter: Bounds Check
+- filter: Bounds Check
   filter variables:
-  - channels: 1-15
-    name: brightness_temperature
-  minvalue: 1.0e-12
+  - name: brightness_temperature
+    channels: 1-15
   test variables:
-  - channels: 1-15
-    name: ChannelUseflagCheckRad@ObsFunction
+  - name: ChannelUseflagCheckRad@ObsFunction
+    channels: 1-15
     options:
       channels: 1-15
       use_flag:
@@ -570,32 +596,6 @@ obs filters:
       - 1
       - -1
       - 1
-obs operator:
-  Absorbers:
-  - H2O
-  - O3
-  - CO2
-  Cloud_Fraction: 1.0
-  Clouds:
-  - Water
-  - Ice
-  linear obs operator:
-    Absorbers:
-    - H2O
-    - O3
-  name: CRTM
-  obs options:
-    CoefficientPath: $(CRTM_COEFF_DIR)/
-    EndianType: little_endian
-    Sensor_ID: amsua_n19
-obs space:
-  channels: 1-15
-  io pool:
-    max pool size: 1
-  name: amsua_n19
-  obsdatain:
-    obsfile: $(OBS_DIR)/$(OBS_PREFIX)amsua_n19.$(OBS_DATE).nc4
-  obsdataout:
-    obsfile: $(DIAG_DIR)/diag_amsua_n19_$(OBS_DATE).nc4
-  simulated variables:
-  - brightness_temperature
+  minvalue: 1.0e-12
+  action:
+    name: reject

--- a/test/testreference/amsua_n19_gdas.yaml
+++ b/test/testreference/amsua_n19_gdas.yaml
@@ -1,0 +1,601 @@
+obs bias:
+  covariance:
+    largest analysis variance: 10000.0
+    minimal required obs number: 20
+    output file: $(BIAS_OUT_DIR)/$(OBS_PREFIX)amsua_n19.satbias_cov.$(OBS_DATE).nc4
+    prior:
+      inflation:
+        ratio: 1.1
+        ratio for small dataset: 2.0
+      input file: $(BIAS_IN_DIR)/$(BIAS_PREFIX)amsua_n19.satbias_cov.$(BIAS_DATE).nc4
+    step size: 0.0001
+    variance range:
+    - 1.0e-06
+    - 10.0
+  input file: $(BIAS_IN_DIR)/$(BIAS_PREFIX)amsua_n19.satbias.$(BIAS_DATE).nc4
+  output file: $(BIAS_OUT_DIR)/$(OBS_PREFIX)amsua_n19.satbias.$(OBS_DATE).nc4
+  variational bc:
+    predictors:
+    - name: constant
+    - name: lapse_rate
+      order: 2
+      tlapse: $(BIAS_IN_DIR)/$(BIAS_PREFIX)amsua_n19.tlapse.$(BIAS_DATE).txt
+    - name: lapse_rate
+      tlapse: $(BIAS_IN_DIR)/$(BIAS_PREFIX)amsua_n19.tlapse.$(BIAS_DATE).txt
+    - name: emissivity
+    - name: scan_angle
+      order: 4
+    - name: scan_angle
+      order: 3
+    - name: scan_angle
+      order: 2
+    - name: scan_angle
+obs filters:
+- action:
+    error function:
+      channels: 1-15
+      name: ObsErrorModelRamp@ObsFunction
+      options:
+        channels: 1-15
+        err0:
+        - 2.5
+        - 2.2
+        - 2.0
+        - 0.55
+        - 0.3
+        - 0.23
+        - 0.23
+        - 0.25
+        - 0.25
+        - 0.35
+        - 0.4
+        - 0.55
+        - 0.8
+        - 3.0
+        - 3.5
+        err1:
+        - 20.0
+        - 18.0
+        - 12.0
+        - 3.0
+        - 0.5
+        - 0.3
+        - 0.23
+        - 0.25
+        - 0.25
+        - 0.35
+        - 0.4
+        - 0.55
+        - 0.8
+        - 3.0
+        - 18.0
+        x0:
+        - 0.05
+        - 0.03
+        - 0.03
+        - 0.02
+        - 0.0
+        - 0.1
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.03
+        x1:
+        - 0.6
+        - 0.45
+        - 0.4
+        - 0.45
+        - 1.0
+        - 1.5
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.0
+        - 0.2
+        xvar:
+          name: CLWRetSymmetricMW@ObsFunction
+          options:
+            clwret_ch238: 1
+            clwret_ch314: 2
+            clwret_types:
+            - ObsValue
+            - HofX
+    name: assign error
+  filter: BlackList
+  filter variables:
+  - channels: 1-15
+    name: brightness_temperature
+- action:
+    name: reject
+  filter: Bounds Check
+  filter variables:
+  - channels: 1-6, 15
+    name: brightness_temperature
+  maxvalue: 999.0
+  test variables:
+  - name: CLWRetMW@ObsFunction
+    options:
+      clwret_ch238: 1
+      clwret_ch314: 2
+      clwret_types:
+      - ObsValue
+- action:
+    name: reject
+  filter: Bounds Check
+  filter variables:
+  - channels: 1-6, 15
+    name: brightness_temperature
+  maxvalue: 999.0
+  test variables:
+  - name: CLWRetMW@ObsFunction
+    options:
+      clwret_ch238: 1
+      clwret_ch314: 2
+      clwret_types:
+      - HofX
+- action:
+    name: reject
+  filter: Bounds Check
+  filter variables:
+  - channels: 1-15
+    name: brightness_temperature
+  maxvalue: 0.0
+  test variables:
+  - channels: 1-15
+    name: HydrometeorCheckAMSUA@ObsFunction
+    options:
+      channels: 1-15
+      clwret_function:
+        name: CLWRetMW@ObsFunction
+        options:
+          clwret_ch238: 1
+          clwret_ch314: 2
+          clwret_types:
+          - ObsValue
+      obserr_clearsky:
+      - 2.5
+      - 2.2
+      - 2.0
+      - 0.55
+      - 0.3
+      - 0.23
+      - 0.23
+      - 0.25
+      - 0.25
+      - 0.35
+      - 0.4
+      - 0.55
+      - 0.8
+      - 3.0
+      - 3.5
+      obserr_function:
+        channels: 1-15
+        name: ObsErrorModelRamp@ObsFunction
+        options:
+          channels: 1-15
+          err0:
+          - 2.5
+          - 2.2
+          - 2.0
+          - 0.55
+          - 0.3
+          - 0.23
+          - 0.23
+          - 0.25
+          - 0.25
+          - 0.35
+          - 0.4
+          - 0.55
+          - 0.8
+          - 3.0
+          - 3.5
+          err1:
+          - 20.0
+          - 18.0
+          - 12.0
+          - 3.0
+          - 0.5
+          - 0.3
+          - 0.23
+          - 0.25
+          - 0.25
+          - 0.35
+          - 0.4
+          - 0.55
+          - 0.8
+          - 3.0
+          - 18.0
+          x0:
+          - 0.05
+          - 0.03
+          - 0.03
+          - 0.02
+          - 0.0
+          - 0.1
+          - 0.0
+          - 0.0
+          - 0.0
+          - 0.0
+          - 0.0
+          - 0.0
+          - 0.0
+          - 0.0
+          - 0.03
+          x1:
+          - 0.6
+          - 0.45
+          - 0.4
+          - 0.45
+          - 1.0
+          - 1.5
+          - 0.0
+          - 0.0
+          - 0.0
+          - 0.0
+          - 0.0
+          - 0.0
+          - 0.0
+          - 0.0
+          - 0.2
+          xvar:
+            name: CLWRetSymmetricMW@ObsFunction
+            options:
+              clwret_ch238: 1
+              clwret_ch314: 2
+              clwret_types:
+              - ObsValue
+              - HofX
+- action:
+    inflation variable:
+      channels: 1-15
+      name: ObsErrorFactorTopoRad@ObsFunction
+      options:
+        channels: 1-15
+        sensor: amsua_n19
+    name: inflate error
+  filter: BlackList
+  filter variables:
+  - channels: 1-15
+    name: brightness_temperature
+- action:
+    inflation variable:
+      channels: 1-15
+      name: ObsErrorFactorTransmitTopRad@ObsFunction
+      options:
+        channels: 1-15
+    name: inflate error
+  filter: BlackList
+  filter variables:
+  - channels: 1-15
+    name: brightness_temperature
+- action:
+    inflation variable:
+      channels: 1-15
+      name: ObsErrorFactorSurfJacobianRad@ObsFunction
+      options:
+        channels: 1-15
+        obserr_demisf:
+        - 0.01
+        - 0.02
+        - 0.015
+        - 0.02
+        - 0.2
+        obserr_dtempf:
+        - 0.5
+        - 2.0
+        - 1.0
+        - 2.0
+        - 4.5
+    name: inflate error
+  filter: BlackList
+  filter variables:
+  - channels: 1-15
+    name: brightness_temperature
+- action:
+    inflation variable:
+      channels: 1-15
+      name: ObsErrorFactorSituDependMW@ObsFunction
+      options:
+        channels: 1-15
+        clwbkg_function:
+          name: CLWRetMW@ObsFunction
+          options:
+            bias_application: HofX
+            clwret_ch238: 1
+            clwret_ch314: 2
+            clwret_types:
+            - HofX
+        clwmatchidx_function:
+          channels: 1-15
+          name: CLWMatchIndexMW@ObsFunction
+          options:
+            channels: 1-15
+            clwbkg_function:
+              name: CLWRetMW@ObsFunction
+              options:
+                bias_application: HofX
+                clwret_ch238: 1
+                clwret_ch314: 2
+                clwret_types:
+                - HofX
+            clwobs_function:
+              name: CLWRetMW@ObsFunction
+              options:
+                clwret_ch238: 1
+                clwret_ch314: 2
+                clwret_types:
+                - ObsValue
+            clwret_clearsky:
+            - 0.05
+            - 0.03
+            - 0.03
+            - 0.02
+            - 0.0
+            - 0.1
+            - 0.0
+            - 0.0
+            - 0.0
+            - 0.0
+            - 0.0
+            - 0.0
+            - 0.0
+            - 0.0
+            - 0.03
+        clwobs_function:
+          name: CLWRetMW@ObsFunction
+          options:
+            clwret_ch238: 1
+            clwret_ch314: 2
+            clwret_types:
+            - ObsValue
+        obserr_clearsky:
+        - 2.5
+        - 2.2
+        - 2.0
+        - 0.55
+        - 0.3
+        - 0.23
+        - 0.23
+        - 0.25
+        - 0.25
+        - 0.35
+        - 0.4
+        - 0.55
+        - 0.8
+        - 3.0
+        - 3.5
+        scatobs_function:
+          name: SCATRetMW@ObsFunction
+          options:
+            bias_application: HofX
+            scatret_ch238: 1
+            scatret_ch314: 2
+            scatret_ch890: 15
+            scatret_types:
+            - ObsValue
+        sensor: amsua_n19
+    name: inflate error
+  filter: BlackList
+  filter variables:
+  - channels: 1-15
+    name: brightness_temperature
+- action:
+    name: reject
+  filter: Background Check
+  filter variables:
+  - channels: 1-15
+    name: brightness_temperature
+  function absolute threshold:
+  - channels: 1-15
+    name: ObsErrorBoundMW@ObsFunction
+    options:
+      channels: 1-15
+      obserr_bound_latitude:
+        name: ObsErrorFactorLatRad@ObsFunction
+        options:
+          latitude_parameters:
+          - 25.0
+          - 0.25
+          - 0.04
+          - 3.0
+      obserr_bound_max:
+      - 4.5
+      - 4.5
+      - 4.5
+      - 2.5
+      - 2.0
+      - 2.0
+      - 2.0
+      - 2.0
+      - 2.0
+      - 2.0
+      - 2.5
+      - 3.5
+      - 4.5
+      - 4.5
+      - 4.5
+      obserr_bound_topo:
+        channels: 1-15
+        name: ObsErrorFactorTopoRad@ObsFunction
+        options:
+          channels: 1-15
+          sensor: amsua_n19
+      obserr_bound_transmittop:
+        channels: 1-15
+        name: ObsErrorFactorTransmitTopRad@ObsFunction
+        options:
+          channels: 1-15
+      obserr_function:
+        channels: 1-15
+        name: ObsErrorModelRamp@ObsFunction
+        options:
+          channels: 1-15
+          err0:
+          - 2.5
+          - 2.2
+          - 2.0
+          - 0.55
+          - 0.3
+          - 0.23
+          - 0.23
+          - 0.25
+          - 0.25
+          - 0.35
+          - 0.4
+          - 0.55
+          - 0.8
+          - 3.0
+          - 3.5
+          err1:
+          - 20.0
+          - 18.0
+          - 12.0
+          - 3.0
+          - 0.5
+          - 0.3
+          - 0.23
+          - 0.25
+          - 0.25
+          - 0.35
+          - 0.4
+          - 0.55
+          - 0.8
+          - 3.0
+          - 18.0
+          x0:
+          - 0.05
+          - 0.03
+          - 0.03
+          - 0.02
+          - 0.0
+          - 0.1
+          - 0.0
+          - 0.0
+          - 0.0
+          - 0.0
+          - 0.0
+          - 0.0
+          - 0.0
+          - 0.0
+          - 0.03
+          x1:
+          - 0.6
+          - 0.45
+          - 0.4
+          - 0.45
+          - 1.0
+          - 1.5
+          - 0.0
+          - 0.0
+          - 0.0
+          - 0.0
+          - 0.0
+          - 0.0
+          - 0.0
+          - 0.0
+          - 0.2
+          xvar:
+            name: CLWRetSymmetricMW@ObsFunction
+            options:
+              bias_application: HofX
+              clwret_ch238: 1
+              clwret_ch314: 2
+              clwret_types:
+              - ObsValue
+              - HofX
+      sensor: amsua_n19
+- action:
+    name: reject
+  filter: Bounds Check
+  filter variables:
+  - channels: 1-15
+    name: brightness_temperature
+  maxvalue: 1.0e-12
+  test variables:
+  - channels: 1-15
+    name: InterChannelConsistencyCheck@ObsFunction
+    options:
+      channels: 1-15
+      sensor: amsua_n19
+      use_flag:
+      - 1
+      - 1
+      - 1
+      - 1
+      - 1
+      - 1
+      - -1
+      - -1
+      - 1
+      - 1
+      - 1
+      - 1
+      - 1
+      - -1
+      - 1
+- action:
+    name: reject
+  filter: Bounds Check
+  filter variables:
+  - channels: 1-15
+    name: brightness_temperature
+  minvalue: 1.0e-12
+  test variables:
+  - channels: 1-15
+    name: ChannelUseflagCheckRad@ObsFunction
+    options:
+      channels: 1-15
+      use_flag:
+      - 1
+      - 1
+      - 1
+      - 1
+      - 1
+      - 1
+      - -1
+      - -1
+      - 1
+      - 1
+      - 1
+      - 1
+      - 1
+      - -1
+      - 1
+obs operator:
+  Absorbers:
+  - H2O
+  - O3
+  - CO2
+  Cloud_Fraction: 1.0
+  Clouds:
+  - Water
+  - Ice
+  linear obs operator:
+    Absorbers:
+    - H2O
+    - O3
+  name: CRTM
+  obs options:
+    CoefficientPath: $(CRTM_COEFF_DIR)/
+    EndianType: little_endian
+    Sensor_ID: amsua_n19
+obs space:
+  channels: 1-15
+  io pool:
+    max pool size: 1
+  name: amsua_n19
+  obsdatain:
+    obsfile: $(OBS_DIR)/$(OBS_PREFIX)amsua_n19.$(OBS_DATE).nc4
+  obsdataout:
+    obsfile: $(DIAG_DIR)/diag_amsua_n19_$(OBS_DATE).nc4
+  simulated variables:
+  - brightness_temperature

--- a/ush/convert_yaml_ewok2gdas.py
+++ b/ush/convert_yaml_ewok2gdas.py
@@ -69,7 +69,7 @@ def convert_yaml_ewok_to_gdas(ewokyaml, gdasyaml):
     # write out new YAML file
     try:
         with open(gdasyaml, 'w') as yamlout:
-            yaml.dump(ob_dict, yamlout, default_flow_style=False)
+            yaml.dump(ob_dict, yamlout, default_flow_style=False, sort_keys=False)
         logging.info(f'Wrote YAML to {gdasyaml}')
     except Exception as e:
         logging.error(f'Error occurred when attempting to write: {gdasyaml}, error: {e}')

--- a/ush/convert_yaml_ewok2gdas.py
+++ b/ush/convert_yaml_ewok2gdas.py
@@ -4,6 +4,7 @@ import copy
 import logging
 import yaml
 
+
 def convert_yaml_ewok_to_gdas(ewokyaml, gdasyaml):
     logging.basicConfig(format='%(asctime)s:%(levelname)s:%(message)s', level=logging.INFO, datefmt='%Y-%m-%d %H:%M:%S')
     # first, read input YAML into memory
@@ -60,9 +61,9 @@ def convert_yaml_ewok_to_gdas(ewokyaml, gdasyaml):
             'prior': {
                 'input file': f"$(BIAS_IN_DIR)/$(BIAS_PREFIX){obtype}.satbias_cov.$(BIAS_DATE).nc4",
                 'inflation': {'ratio': 1.1, 'ratio for small dataset': 2.0},
-                },
+            },
             'output file': f"$(BIAS_OUT_DIR)/$(OBS_PREFIX){obtype}.satbias_cov.$(OBS_DATE).nc4",
-            }
+        }
         ob_dict['obs bias']['covariance'] = cov_dict
 
     # write out new YAML file

--- a/ush/convert_yaml_ewok2gdas.py
+++ b/ush/convert_yaml_ewok2gdas.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+import argparse
+import copy
+import logging
+import yaml
+
+def convert_yaml_ewok_to_gdas(ewokyaml, gdasyaml):
+    logging.basicConfig(format='%(asctime)s:%(levelname)s:%(message)s', level=logging.INFO, datefmt='%Y-%m-%d %H:%M:%S')
+    # first, read input YAML into memory
+    try:
+        with open(ewokyaml, 'r') as ewokyaml_opened:
+            ob_dict = yaml.safe_load(ewokyaml_opened)
+        logging.info(f'Loading configuration from {ewokyaml}')
+    except Exception as e:
+        logging.error(f'Error occurred when attempting to load: {ewokyaml}, error: {e}')
+
+    # -----------------------------------------
+    # replace relevant YAML keys as appropriate
+
+    # obs space input file
+    infile = ob_dict['obs space']['obsdatain']['obsfile']
+    obtype = infile.split('/')[2].split('.')[0]
+    infile = f"$(OBS_DIR)/$(OBS_PREFIX){obtype}.$(OBS_DATE).nc4"
+    ob_dict['obs space']['obsdatain']['obsfile'] = infile
+
+    # obs space output diag
+    outfile = f"$(DIAG_DIR)/diag_{obtype}_$(OBS_DATE).nc4"
+    ob_dict['obs space']['obsdataout']['obsfile'] = outfile
+
+    # io pool to one
+    ob_dict['obs space']['io pool'] = {'max pool size': 1}
+
+    # CRTM stuff if appropriate
+    if 'obs options' in ob_dict['obs operator'].keys():
+        if 'CoefficientPath' in ob_dict['obs operator']['obs options'].keys():
+            ob_dict['obs operator']['obs options']['CoefficientPath'] = "$(CRTM_COEFF_DIR)/"
+    if 'Absorbers' in ob_dict['obs operator'].keys():
+        absorbers = ob_dict['obs operator']['Absorbers']
+        # fv3-jedi cannot handle CO2 in the linear obs operator
+        if 'CO2' in absorbers:
+            linear_absorbers = copy.deepcopy(absorbers)
+            linear_absorbers.remove('CO2')
+            ob_dict['obs operator']['linear obs operator'] = {'Absorbers': linear_absorbers}
+
+    # obs bias if appropriate
+    if 'obs bias' in ob_dict.keys():
+        bias_in = f"$(BIAS_IN_DIR)/$(BIAS_PREFIX){obtype}.satbias.$(BIAS_DATE).nc4"
+        ob_dict['obs bias']['input file'] = bias_in
+        bias_out = f"$(BIAS_OUT_DIR)/$(OBS_PREFIX){obtype}.satbias.$(OBS_DATE).nc4"
+        ob_dict['obs bias']['output file'] = bias_out
+        for p in ob_dict['obs bias']['variational bc']['predictors']:
+            if 'tlapse' in p.keys():
+                p['tlapse'] = f"$(BIAS_IN_DIR)/$(BIAS_PREFIX){obtype}.tlapse.$(BIAS_DATE).txt"
+        # add a new covariance section with constants by default
+        cov_dict = {
+            'minimal required obs number': 20,
+            'variance range': [1.0e-6, 10.0],
+            'step size': 1.0e-4,
+            'largest analysis variance': 10000.0,
+            'prior': {
+                'input file': f"$(BIAS_IN_DIR)/$(BIAS_PREFIX){obtype}.satbias_cov.$(BIAS_DATE).nc4",
+                'inflation': {'ratio': 1.1, 'ratio for small dataset': 2.0},
+                },
+            'output file': f"$(BIAS_OUT_DIR)/$(OBS_PREFIX){obtype}.satbias_cov.$(OBS_DATE).nc4",
+            }
+        ob_dict['obs bias']['covariance'] = cov_dict
+
+    # write out new YAML file
+    try:
+        with open(gdasyaml, 'w') as yamlout:
+            yaml.dump(ob_dict, yamlout, default_flow_style=False)
+        logging.info(f'Wrote YAML to {gdasyaml}')
+    except Exception as e:
+        logging.error(f'Error occurred when attempting to write: {gdasyaml}, error: {e}')
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument('EWOKYAML', type=str, help='Input EWOK UFO YAML file')
+    parser.add_argument('GDASYAML', type=str, help='Output GDASApp observation YAML file')
+    args = parser.parse_args()
+    convert_yaml_ewok_to_gdas(args.EWOKYAML, args.GDASYAML)


### PR DESCRIPTION
This script will:

- Change paths where appropriate
- Remove CO2 from the obs operator where appropriate
- Add a standard covariance section

so that EWOK YAMLs for each ob type (e.g. in ufo/ewok/jedi-gdas) can be translated for use here in GDASApp with minimal user intervention.