### PR TITLE
Update sondes.yaml

### DIFF
--- a/parm/atm/obs/config/sondes.yaml
+++ b/parm/atm/obs/config/sondes.yaml
@@ -242,6 +242,7 @@ obs filters:
 #       name: ObsErrorFactorConventional@ObsFunction
 #       options:
 #         test QCflag: PreQC
+#         pressure: MetaData/air_pressure
 #         inflate variables: [virtual_temperature]
 #   defer to post: true
   #

--- a/parm/atm/obs/config/sondes.yaml
+++ b/parm/atm/obs/config/sondes.yaml
@@ -189,8 +189,8 @@ obs filters:
         options:
           xvar:
             name: MetaData/air_pressure
-          xvals: [25000, 20000, 10]
-          errors: [0.2, 0.4, 0.8]        # 20% RH up to 250 mb, then increased rapidly above
+          xvals: [25000]
+          errors: [0.2]        # 20% RH fixed error
   #
   - filter: Perform Action
     filter variables:

--- a/parm/atm/obs/config/sondes.yaml
+++ b/parm/atm/obs/config/sondes.yaml
@@ -24,7 +24,7 @@ obs operator:
    - name: SfcPCorrected
      variables:
      - name: surface_pressure
-     da_psfc_scheme: UKMO
+     da_psfc_scheme: GSI
 linear obs operator:
   name: Composite
   components:

--- a/parm/atm/obs/config/sondes.yaml
+++ b/parm/atm/obs/config/sondes.yaml
@@ -185,13 +185,12 @@ obs filters:
     action:
       name: assign error
       error function:
-        name: ObsErrorModelStepwiseLinear@ObsFunction
+        name: ObsErrorModelHumidity@ObsFunction
         options:
           xvar:
             name: MetaData/air_pressure
           xvals: [25000, 20000, 10]
           errors: [0.2, 0.4, 0.8]        # 20% RH up to 250 mb, then increased rapidly above
-          scale_factor_var: ObsValue/specific_humidity
   #
   - filter: Perform Action
     filter variables:


### PR DESCRIPTION
This PR updates sondes.yaml to use `ObsErrorModelHumidity@ObsFunction` for specific humidity error assignment. Compared to the original version, the new obs function **more accurately** mimics GSI error assignment for specific humidity, i.e., the RH error from `prepobs_errtable.txt` is scaled by **forecast saturation specific humidity** rather than **observed specific humidity**. 

For details about the obs function, check out https://github.com/JCSDA-internal/ufo/pull/1927 (UFO PR for the new obs function) and https://github.com/JCSDA-internal/jedi-docs/pull/426 (documentation for the new obs function)

The recently added GSI scheme of `SfcPCorrected` obs operator (https://github.com/JCSDA-internal/ufo/pull/1984) is also updated here.