### PR TITLE
Update YAML changes and some bug fixes

### DIFF
--- a/modulefiles/GDAS/orion.lua
+++ b/modulefiles/GDAS/orion.lua
@@ -37,8 +37,8 @@ load("nccmp/1.8.7.0")
 load("pio/2.5.1-debug")
 
 load("ecbuild/ecmwf-3.6.1")
-load("fckit/ecmwf-0.9.2")
-load("eckit/ecmwf-1.16.0")
+load("fckit/ecmwf-0.9.5")
+load("eckit/ecmwf-1.18.2")
 load("atlas/ecmwf-0.29.0")
 
 load("hpc/1.2.0")

--- a/modulefiles/GDAS/orion.lua
+++ b/modulefiles/GDAS/orion.lua
@@ -37,8 +37,8 @@ load("nccmp/1.8.7.0")
 load("pio/2.5.1-debug")
 
 load("ecbuild/ecmwf-3.6.1")
-load("fckit/ecmwf-0.9.5")
-load("eckit/ecmwf-1.18.2")
+load("fckit/ecmwf-0.9.2")
+load("eckit/ecmwf-1.16.0")
 load("atlas/ecmwf-0.29.0")
 
 load("hpc/1.2.0")

--- a/parm/atm/obs/lists/gdas_prototype.yaml
+++ b/parm/atm/obs/lists/gdas_prototype.yaml
@@ -1,3 +1,3 @@
-observations:
+observers:
 - $<< $(OBS_YAML_DIR)/amsua_n19.yaml
 - $<< $(OBS_YAML_DIR)/sondes.yaml

--- a/ush/examples/run_jedi_exe/3dhofx.yaml
+++ b/ush/examples/run_jedi_exe/3dhofx.yaml
@@ -1,0 +1,26 @@
+working directory: /work2/noaa/stmp/cmartin/gdas_single_test_hofx
+GDASApp home: /work2/noaa/da/cmartin/GDASApp/work/GDASApp
+GDASApp mode: hofx
+executable options:
+  obs_yaml_dir: /work2/noaa/da/cmartin/GDASApp/work/GDASApp/parm/atm/obs/config
+  yaml_template: /work2/noaa/da/cmartin/GDASApp/work/GDASApp/parm/atm/hofx/hofx_nomodel.yaml
+  executable: /work2/noaa/da/cmartin/GDASApp/work/GDASApp/build/bin/fv3jedi_hofx_nomodel.x
+  obs_list: /work2/noaa/da/cmartin/GDASApp/work/GDASApp/parm/atm/obs/lists/gdas_prototype.yaml
+  gdas_fix_root: /work2/noaa/da/cmartin/GDASApp/fix
+  atm: true
+  layout_x: 4
+  layout_y: 4
+  atm_window_length: PT6H
+  valid_time: 2021-08-01T00:00:00Z
+  dump: gdas
+  case: C768
+  levs: 128
+job options:
+  machine: orion
+  account: da-cpu
+  queue: debug
+  partition: debug
+  walltime: '30:00'
+  ntasks: 96 
+  cpus-per-task: 1
+  modulepath: /work2/noaa/da/cmartin/GDASApp/work/GDASApp/modulefiles

--- a/ush/examples/run_jedi_exe/3dhofx.yaml
+++ b/ush/examples/run_jedi_exe/3dhofx.yaml
@@ -1,4 +1,4 @@
-working directory: /work2/noaa/stmp/cmartin/gdas_single_test_hofx
+working directory: /work2/noaa/stmp/cmartin/gdas_single_test_hofx3d
 GDASApp home: /work2/noaa/da/cmartin/GDASApp/work/GDASApp
 GDASApp mode: hofx
 executable options:
@@ -21,6 +21,6 @@ job options:
   queue: debug
   partition: debug
   walltime: '30:00'
-  ntasks: 96 
+  ntasks: 96
   cpus-per-task: 1
   modulepath: /work2/noaa/da/cmartin/GDASApp/work/GDASApp/modulefiles

--- a/ush/examples/run_jedi_exe/3dhofx.yaml
+++ b/ush/examples/run_jedi_exe/3dhofx.yaml
@@ -6,7 +6,7 @@ executable options:
   yaml_template: /work2/noaa/da/cmartin/GDASApp/work/GDASApp/parm/atm/hofx/hofx_nomodel.yaml
   executable: /work2/noaa/da/cmartin/GDASApp/work/GDASApp/build/bin/fv3jedi_hofx_nomodel.x
   obs_list: /work2/noaa/da/cmartin/GDASApp/work/GDASApp/parm/atm/obs/lists/gdas_prototype.yaml
-  gdas_fix_root: /work2/noaa/da/cmartin/GDASApp/fix
+  gdas_fix_root: /work2/noaa/da/fhan/GDASApp/fix
   atm: true
   layout_x: 4
   layout_y: 4

--- a/ush/examples/run_jedi_exe/3dvar.yaml
+++ b/ush/examples/run_jedi_exe/3dvar.yaml
@@ -1,4 +1,4 @@
-working directory: /work2/noaa/stmp/cmartin/gdas_single_test
+working directory: /work2/noaa/stmp/cmartin/gdas_single_test_3dvar
 GDASApp home: /work2/noaa/da/cmartin/GDASApp/work/GDASApp
 GDASApp mode: variational
 executable options:
@@ -15,8 +15,8 @@ executable options:
   valid_time: 2021-12-21T06:00:00Z
   dump: gdas
   case: C96
-  case_enkf: C48
-  dohybvar: true
+  case_anl: C48
+  dohybvar: false
   levs: 128
 job options:
   machine: orion

--- a/ush/examples/run_jedi_exe/3dvar.yaml
+++ b/ush/examples/run_jedi_exe/3dvar.yaml
@@ -1,0 +1,29 @@
+working directory: /work2/noaa/stmp/cmartin/gdas_single_test
+GDASApp home: /work2/noaa/da/cmartin/GDASApp/work/GDASApp
+GDASApp mode: variational
+executable options:
+  berror_yaml: /work2/noaa/da/cmartin/GDASApp/work/GDASApp/parm/atm/berror/staticb_bump.yaml
+  obs_yaml_dir: /work2/noaa/da/cmartin/GDASApp/work/GDASApp/parm/atm/obs/config
+  yaml_template: /work2/noaa/da/cmartin/GDASApp/work/GDASApp/parm/atm/variational/3dvar_dripcg.yaml
+  executable: /work2/noaa/da/cmartin/GDASApp/work/GDASApp/build/bin/fv3jedi_var.x
+  obs_list: /work2/noaa/da/cmartin/GDASApp/work/GDASApp/parm/atm/obs/lists/gdas_prototype.yaml
+  gdas_fix_root: /work2/noaa/da/cmartin/GDASApp/fix
+  atm: true
+  layout_x: 1
+  layout_y: 1
+  atm_window_length: PT6H
+  valid_time: 2021-12-21T06:00:00Z
+  dump: gdas
+  case: C96
+  case_enkf: C48
+  dohybvar: true
+  levs: 128
+job options:
+  machine: orion
+  account: da-cpu
+  queue: debug
+  partition: debug
+  walltime: '10:00'
+  ntasks: 6
+  cpus-per-task: 1
+  modulepath: /work2/noaa/da/cmartin/GDASApp/work/GDASApp/modulefiles

--- a/ush/examples/run_jedi_exe/3dvar.yaml
+++ b/ush/examples/run_jedi_exe/3dvar.yaml
@@ -7,7 +7,7 @@ executable options:
   yaml_template: /work2/noaa/da/cmartin/GDASApp/work/GDASApp/parm/atm/variational/3dvar_dripcg.yaml
   executable: /work2/noaa/da/cmartin/GDASApp/work/GDASApp/build/bin/fv3jedi_var.x
   obs_list: /work2/noaa/da/cmartin/GDASApp/work/GDASApp/parm/atm/obs/lists/gdas_prototype.yaml
-  gdas_fix_root: /work2/noaa/da/cmartin/GDASApp/fix
+  gdas_fix_root: /work2/noaa/da/fhan/GDASApp/fix
   atm: true
   layout_x: 1
   layout_y: 1

--- a/ush/examples/run_jedi_exe/4dhofx.yaml
+++ b/ush/examples/run_jedi_exe/4dhofx.yaml
@@ -6,7 +6,7 @@ executable options:
   yaml_template: /work2/noaa/da/cmartin/GDASApp/work/GDASApp/parm/atm/hofx/hofx4d.yaml
   executable: /work2/noaa/da/cmartin/GDASApp/work/GDASApp/build/bin/fv3jedi_hofx.x
   obs_list: /work2/noaa/da/cmartin/GDASApp/work/GDASApp/parm/atm/obs/lists/gdas_prototype.yaml
-  gdas_fix_root: /work2/noaa/da/cmartin/GDASApp/fix
+  gdas_fix_root: /work2/noaa/da/fhan/GDASApp/fix
   atm: true
   layout_x: 4
   layout_y: 4

--- a/ush/examples/run_jedi_exe/4dhofx.yaml
+++ b/ush/examples/run_jedi_exe/4dhofx.yaml
@@ -1,0 +1,27 @@
+working directory: /work2/noaa/stmp/cmartin/gdas_single_test_hofx
+GDASApp home: /work2/noaa/da/cmartin/GDASApp/work/GDASApp
+GDASApp mode: hofx
+executable options:
+  obs_yaml_dir: /work2/noaa/da/cmartin/GDASApp/work/GDASApp/parm/atm/obs/config
+  yaml_template: /work2/noaa/da/cmartin/GDASApp/work/GDASApp/parm/atm/hofx/hofx4d.yaml
+  executable: /work2/noaa/da/cmartin/GDASApp/work/GDASApp/build/bin/fv3jedi_hofx.x
+  obs_list: /work2/noaa/da/cmartin/GDASApp/work/GDASApp/parm/atm/obs/lists/gdas_prototype.yaml
+  gdas_fix_root: /work2/noaa/da/cmartin/GDASApp/fix
+  atm: true
+  layout_x: 4
+  layout_y: 4
+  atm_window_length: PT6H
+  forecast_step: PT1H
+  valid_time: 2021-08-01T00:00:00Z
+  dump: gdas
+  case: C768
+  levs: 128
+job options:
+  machine: orion
+  account: da-cpu
+  queue: debug
+  partition: debug
+  walltime: '30:00'
+  ntasks: 96
+  cpus-per-task: 1
+  modulepath: /work2/noaa/da/cmartin/GDASApp/work/GDASApp/modulefiles

--- a/ush/examples/run_jedi_exe/4dhofx.yaml
+++ b/ush/examples/run_jedi_exe/4dhofx.yaml
@@ -1,4 +1,4 @@
-working directory: /work2/noaa/stmp/cmartin/gdas_single_test_hofx
+working directory: /work2/noaa/stmp/cmartin/gdas_single_test_hofx4d
 GDASApp home: /work2/noaa/da/cmartin/GDASApp/work/GDASApp
 GDASApp mode: hofx
 executable options:

--- a/ush/run_jedi_exe.py
+++ b/ush/run_jedi_exe.py
@@ -56,7 +56,7 @@ def run_jedi_exe(yamlconfig):
         'layout_y': str(executable_subconfig['layout_y']),
         'BKG_DIR': os.path.join(workdir, 'bkg'),
         'fv3jedi_fix_dir': os.path.join(workdir, 'Data', 'fv3files'),
-        'fv3jedi_fieldset_dir': os.path.join(workdir, 'Data', 'fieldsets'),
+        'fv3jedi_fieldmetadata_dir': os.path.join(workdir, 'Data', 'fieldmetadata'),
         'ANL_DIR': os.path.join(workdir, 'anl'),
         'fv3jedi_staticb_dir': os.path.join(workdir, 'berror'),
         'BIAS_IN_DIR': os.path.join(workdir, 'obs'),
@@ -91,7 +91,7 @@ def run_jedi_exe(yamlconfig):
     logging.info(f'Wrote YAML file to {output_file}')
     # use R2D2 to stage backgrounds, obs, bias correction files, etc.
     ufsda.stage.gdas_single_cycle(var_config)
-    # link additional fix files needed (CRTM, fieldsets, etc.)
+    # link additional fix files needed (CRTM, fieldmetadata, etc.)
     gdasfix = executable_subconfig['gdas_fix_root']
     ufsda.stage.gdas_fix(gdasfix, workdir, var_config)
     # link executable

--- a/ush/ufsda/misc_utils.py
+++ b/ush/ufsda/misc_utils.py
@@ -24,7 +24,7 @@ def calc_fcst_steps(fcst_step, win_length):
     h = int(re.findall('PT(\\d+)H', win_length)[0])
     h2 = int(re.findall('PT(\\d+)H', fcst_step)[0])
     assert h % h2 == 0, "win_length must be divisible by fcst_step"
-    if h2 > h//2: 
+    if h2 > h//2:
         return [fcst_step]
     start = f'PT{h-h//2}H'
     end = f'PT{h+h//2}H'

--- a/ush/ufsda/misc_utils.py
+++ b/ush/ufsda/misc_utils.py
@@ -22,6 +22,9 @@ def calc_fcst_steps(fcst_step, win_length):
     # assumes only hours for now, probably bad...
     # also assumes the window is symmetric, probably also bad
     h = int(re.findall('PT(\\d+)H', win_length)[0])
+    h2 = int(re.findall('PT(\\d+)H', fcst_step)[0])
+    assert h%h2 == 0, "win_length must be divisible by fcst_step"
+    if h2 > h//2: return [fcst_step]
     start = f'PT{h-h//2}H'
     end = f'PT{h+h//2}H'
     # solo has a nice utility for this

--- a/ush/ufsda/misc_utils.py
+++ b/ush/ufsda/misc_utils.py
@@ -24,7 +24,8 @@ def calc_fcst_steps(fcst_step, win_length):
     h = int(re.findall('PT(\\d+)H', win_length)[0])
     h2 = int(re.findall('PT(\\d+)H', fcst_step)[0])
     assert h % h2 == 0, "win_length must be divisible by fcst_step"
-    if h2 > h//2: return [fcst_step]
+    if h2 > h//2: 
+        return [fcst_step]
     start = f'PT{h-h//2}H'
     end = f'PT{h+h//2}H'
     # solo has a nice utility for this

--- a/ush/ufsda/misc_utils.py
+++ b/ush/ufsda/misc_utils.py
@@ -23,7 +23,7 @@ def calc_fcst_steps(fcst_step, win_length):
     # also assumes the window is symmetric, probably also bad
     h = int(re.findall('PT(\\d+)H', win_length)[0])
     h2 = int(re.findall('PT(\\d+)H', fcst_step)[0])
-    assert h%h2 == 0, "win_length must be divisible by fcst_step"
+    assert h % h2 == 0, "win_length must be divisible by fcst_step"
     if h2 > h//2: return [fcst_step]
     start = f'PT{h-h//2}H'
     end = f'PT{h+h//2}H'

--- a/ush/ufsda/stage.py
+++ b/ush/ufsda/stage.py
@@ -45,6 +45,7 @@ def gdas_fix(input_fix_dir, working_dir, config):
                                           'fv3files', 'field_table_gfdl'),
                              os.path.join(config['fv3jedi_fix_dir'], 'field_table'))
     # link fieldmetadata
+    # Note that the required data will be dependent on input file type (restart vs history, etc.)
     ufsda.disk_utils.symlink(os.path.join(input_fix_dir, 'fv3jedi',
                                           'fieldmetadata', 'gfs-restart.yaml'),
                              os.path.join(config['fv3jedi_fieldmetadata_dir'], 'gfs-restart.yaml'))
@@ -216,9 +217,17 @@ def gdas_single_cycle(config):
             target_file = ob['obs bias']['input file']
             r2d2_config['target_file_fmt'] = target_file
             ufsda.r2d2.fetch(r2d2_config)
-            # temp hack to copy satbias as satbias_cov
-            if os.path.isfile(target_file):
-                shutil.copy(target_file, target_file.replace('satbias', 'satbias_cov'))
+            r2d2_config['file_type'] = 'satbias_cov'
+            target_file2 = target_file.replace('satbias', 'satbias_cov')
+            r2d2_config['target_file_fmt'] = target_file2
+            try:
+                ufsda.r2d2.fetch(r2d2_config)
+            except:
+                print('Warning: satbias_cov file cannot be fetched from R2D2!')
+                # temp hack to copy satbias as satbias_cov
+                # if satbias_cov does not exists in R2D2
+                if os.path.isfile(target_file) and not os.path.isfile(target_file2):
+                    shutil.copy(target_file, target_file2)
             r2d2_config['file_type'] = 'tlapse'
             target_file = target_file.replace('satbias', 'tlapse')
             target_file = target_file.replace('nc4', 'txt')

--- a/ush/ufsda/stage.py
+++ b/ush/ufsda/stage.py
@@ -218,7 +218,7 @@ def gdas_single_cycle(config):
             ufsda.r2d2.fetch(r2d2_config)
             # temp hack to copy satbias as satbias_cov
             if os.path.isfile(target_file):
-                shutil.copy(target_file,target_file.replace('satbias','satbias_cov'))
+                shutil.copy(target_file, target_file.replace('satbias', 'satbias_cov'))
             r2d2_config['file_type'] = 'tlapse'
             target_file = target_file.replace('satbias', 'tlapse')
             target_file = target_file.replace('nc4', 'txt')

--- a/ush/ufsda/stage.py
+++ b/ush/ufsda/stage.py
@@ -9,6 +9,7 @@ import os
 import shutil
 from dateutil import parser
 import ufsda
+import logging
 
 __all__ = ['atm_background', 'atm_obs', 'bias_obs', 'background', 'fv3jedi', 'obs', 'berror', 'gdas_fix', 'gdas_single_cycle']
 
@@ -180,7 +181,7 @@ def gdas_single_cycle(config):
         'fc_date_rendering': 'analysis',
     }
     r2d2_config = NiceDict(r2d2_config)
-    ufsda.r2d2.fetch(r2d2_config)
+    #ufsda.r2d2.fetch(r2d2_config)
     # get gfs metadata
     r2d2_config['model'] = 'gfs_metadata'
     r2d2_config['target_file_fmt'] = '{target_dir}/$(valid_date).$(file_type)'
@@ -222,8 +223,8 @@ def gdas_single_cycle(config):
             r2d2_config['target_file_fmt'] = target_file2
             try:
                 ufsda.r2d2.fetch(r2d2_config)
-            except:
-                print('Warning: satbias_cov file cannot be fetched from R2D2!')
+            except FileNotFoundError:
+                logging.error("Warning: satbias_cov file cannot be fetched from R2D2!")
                 # temp hack to copy satbias as satbias_cov
                 # if satbias_cov does not exists in R2D2
                 if os.path.isfile(target_file) and not os.path.isfile(target_file2):

--- a/ush/ufsda/stage.py
+++ b/ush/ufsda/stage.py
@@ -181,7 +181,7 @@ def gdas_single_cycle(config):
         'fc_date_rendering': 'analysis',
     }
     r2d2_config = NiceDict(r2d2_config)
-    #ufsda.r2d2.fetch(r2d2_config)
+    ufsda.r2d2.fetch(r2d2_config)
     # get gfs metadata
     r2d2_config['model'] = 'gfs_metadata'
     r2d2_config['target_file_fmt'] = '{target_dir}/$(valid_date).$(file_type)'

--- a/ush/ufsda/yamltools.py
+++ b/ush/ufsda/yamltools.py
@@ -107,10 +107,7 @@ def fv3_geom_dict(case, levs, ntiles, layout, io_layout):
         'npy': str(case+1),
         'npz': str(levs-1),
         'ntiles': str(ntiles),
-        'fieldsets': [
-            {'fieldset': '$(fv3jedi_fieldset_dir)/dynamics.yaml'},
-            {'fieldset': '$(fv3jedi_fieldset_dir)/ufo.yaml'},
-        ]
+        'field metadata override': '$(fv3jedi_fieldmetadata_dir)/gfs-restart.yaml'
     }
     return outdict
 


### PR DESCRIPTION
This PR has several purposes:
1. Update yaml changes in `geometry` block (following JEDI repo changes)
- To test, use `gdas_fix_root: /work2/noaa/da/fhan/GDASApp/fix` in the example yamls **for now** (I've already updated the example yamls). This new `fix/` directory has all symlinks from Cory’s `fix/` with the additional `fieldmetadata` folder. Once @CoryMartin-NOAA updates his `fix/` with the new `fieldmetadata` directory, we can go back to the original one maintained by Cory.
2. Update yaml changes in `observations` block (following JEDI repo changes)

3. temp hack to use `satbias` file as `satbias_cov` file so 3DVar won't fail

4. bug fix in `stage.py`: `case_anl` should be `config['CASE_ANL']`, not `config['CASE']`, otherwise the wrong `berror` directory will be linked.

5. bug fix in `calc_fcst_steps()`

6. Testing efforts by @RussTreadon-NOAA revealed additional issues with module versions, we resolved the issue with help from @climbfuji, so I also updated modulefile (`orion.lua`).

I tested this branch using `run_jedi_exe.py` with Cory's example yamls (`3dvar`, `3dhofx` and `4dhofx`), all of them ran to completion with normal logs and output files. 