### PR TITLE
Make interpolation method configurable

### DIFF
--- a/parm/atm/obs/config/amsua_n19.yaml
+++ b/parm/atm/obs/config/amsua_n19.yaml
@@ -8,6 +8,8 @@ obs space:
     max pool size: 1
   simulated variables: [brightness_temperature]
   channels: &amsua_n19_channels 1-15
+get values:
+  interpolation method: $(INTERP_METHOD)
 obs operator:
   name: CRTM
   Absorbers: [H2O,O3]

--- a/parm/atm/obs/config/sondes.yaml
+++ b/parm/atm/obs/config/sondes.yaml
@@ -11,6 +11,8 @@ obs space:
   io pool:
     max pool size: 1
   simulated variables: [eastward_wind, northward_wind, air_temperature, specific_humidity, surface_pressure]
+get values:
+  interpolation method: $(INTERP_METHOD)
 obs operator:
   name: Composite
   components:

--- a/ush/examples/run_jedi_exe/3dhofx.yaml
+++ b/ush/examples/run_jedi_exe/3dhofx.yaml
@@ -15,6 +15,7 @@ executable options:
   dump: gdas
   case: C768
   levs: 128
+  interp_method: barycentric
 job options:
   machine: orion
   account: da-cpu

--- a/ush/examples/run_jedi_exe/3dvar.yaml
+++ b/ush/examples/run_jedi_exe/3dvar.yaml
@@ -18,6 +18,7 @@ executable options:
   case_anl: C48
   dohybvar: false
   levs: 128
+  interp_method: barycentric
 job options:
   machine: orion
   account: da-cpu

--- a/ush/examples/run_jedi_exe/4dhofx.yaml
+++ b/ush/examples/run_jedi_exe/4dhofx.yaml
@@ -16,6 +16,7 @@ executable options:
   dump: gdas
   case: C768
   levs: 128
+  interp_method: barycentric
 job options:
   machine: orion
   account: da-cpu

--- a/ush/run_jedi_exe.py
+++ b/ush/run_jedi_exe.py
@@ -80,6 +80,7 @@ def run_jedi_exe(yamlconfig):
         'forecast_steps': calc_fcst_steps(executable_subconfig.get('forecast_step', 'PT6H'),
                                           executable_subconfig['atm_window_length']),
         'BKG_TSTEP': executable_subconfig.get('forecast_step', 'PT6H'),
+        'INTERP_METHOD': executable_subconfig.get('interp_method','barycentric'),
     }
     template = executable_subconfig['yaml_template']
     output_file = os.path.join(workdir, f"gdas_{app_mode}.yaml")

--- a/ush/run_jedi_exe.py
+++ b/ush/run_jedi_exe.py
@@ -80,7 +80,7 @@ def run_jedi_exe(yamlconfig):
         'forecast_steps': calc_fcst_steps(executable_subconfig.get('forecast_step', 'PT6H'),
                                           executable_subconfig['atm_window_length']),
         'BKG_TSTEP': executable_subconfig.get('forecast_step', 'PT6H'),
-        'INTERP_METHOD': executable_subconfig.get('interp_method','barycentric'),
+        'INTERP_METHOD': executable_subconfig.get('interp_method', 'barycentric'),
     }
     template = executable_subconfig['yaml_template']
     output_file = os.path.join(workdir, f"gdas_{app_mode}.yaml")


### PR DESCRIPTION
This PR adds changes to make interpolation method configurable. Interpolation method refers to the method that transforms model fields to GeoVaLs (after model side variable change). 

Currently JEDI supports two methods for interpolating model fields to GeoVaLs: `barycentric` (default) and `inverse distance`. Interpolation method is configurable via `get values` within the `observers` block and each `obs space` has its own associated `get values`. This should not be confused with the `get values` within the `observations` block (see [hofx_nomodel.yaml](https://github.com/JCSDA-internal/fv3-jedi/blob/develop/test/testinput/hofx_nomodel.yaml#L26)). I'm not sure if the JEDI code will be refactored to consolidate the two `get values` in the future, but currently interpolation to GeoVaLs are controlled specifically by `get values` within `observers`.

This change should not impact any existing functionalities of GDASApp. But if one wants to investigate interpolation-induced uncertainty and how such uncertainty propagates from GeoVaLs to H(x) to analysis, experiments with different interpolation methods can be run by specifying an additional `interp_method` parameter in the sample yamls (in `ush/examples/run_jedi_exe/`). This is related to an ongoing work on interpolation-induced uncertainty and you can read more [here](https://docs.google.com/presentation/d/11UZ63r3ZzXB_a7qHIynuibZ-R4b3MZFsyBPPfw2HyQo/edit#slide=id.g88c2cd9c02_0_0) if interested. 