### PR TITLE
Force fewer tasks per node for hyperspectral IR instruments

### DIFF
--- a/ush/examples/run_jedi_exe/3dhofx_hera.yaml
+++ b/ush/examples/run_jedi_exe/3dhofx_hera.yaml
@@ -23,5 +23,4 @@ job options:
   partition: hera
   walltime: '30:00'
   ntasks: 96
-  cpus-per-task: 1
   modulepath: /scratch1/NCEPDEV/da/Cory.R.Martin/GDASApp/work/GDASApp/modulefiles

--- a/ush/examples/run_jedi_exe/3dhofx_orion.yaml
+++ b/ush/examples/run_jedi_exe/3dhofx_orion.yaml
@@ -23,5 +23,4 @@ job options:
   partition: debug
   walltime: '30:00'
   ntasks: 96
-  cpus-per-task: 1
   modulepath: /work2/noaa/da/cmartin/GDASApp/work/GDASApp/modulefiles

--- a/ush/examples/run_jedi_exe/3dvar_hera.yaml
+++ b/ush/examples/run_jedi_exe/3dvar_hera.yaml
@@ -26,5 +26,4 @@ job options:
   partition: hera
   walltime: '10:00'
   ntasks: 6
-  cpus-per-task: 1
   modulepath: /scratch1/NCEPDEV/da/Cory.R.Martin/GDASApp/work/GDASApp/modulefiles

--- a/ush/examples/run_jedi_exe/3dvar_orion.yaml
+++ b/ush/examples/run_jedi_exe/3dvar_orion.yaml
@@ -26,5 +26,4 @@ job options:
   partition: debug
   walltime: '10:00'
   ntasks: 6
-  cpus-per-task: 1
   modulepath: /work2/noaa/da/cmartin/GDASApp/work/GDASApp/modulefiles

--- a/ush/examples/run_jedi_exe/4dhofx_hera.yaml
+++ b/ush/examples/run_jedi_exe/4dhofx_hera.yaml
@@ -24,5 +24,4 @@ job options:
   partition: hera
   walltime: '30:00'
   ntasks: 96
-  cpus-per-task: 1
   modulepath: /scratch1/NCEPDEV/da/Cory.R.Martin/GDASApp/work/GDASApp/modulefiles

--- a/ush/examples/run_jedi_exe/4dhofx_orion.yaml
+++ b/ush/examples/run_jedi_exe/4dhofx_orion.yaml
@@ -24,5 +24,4 @@ job options:
   partition: debug
   walltime: '30:00'
   ntasks: 96
-  cpus-per-task: 1
   modulepath: /work2/noaa/da/cmartin/GDASApp/work/GDASApp/modulefiles

--- a/ush/ufsda/misc_utils.py
+++ b/ush/ufsda/misc_utils.py
@@ -60,7 +60,7 @@ def create_batch_job(job_config, working_dir, executable, yaml_path):
                 taskspernode = job_config.get("ntasks-per-node", 18)
             elif job_config['machine'] == 'orion':
                 taskspernode = job_config.get("ntasks-per-node", 24)
-            else
+            else:
                 taskspernode = job_config.get("ntasks-per-node", 12)
             sbatch = f"""#SBATCH -J GDASApp
 #SBATCH -o GDASApp.o%J

--- a/ush/ufsda/misc_utils.py
+++ b/ush/ufsda/misc_utils.py
@@ -69,7 +69,7 @@ def create_batch_job(job_config, working_dir, executable, yaml_path):
 #SBATCH -p {job_config['partition']}
 #SBATCH --ntasks={job_config['ntasks']}
 #SBATCH --ntasks-per-node={taskspernode}
-#SBATCH --cpus-per-task={job_config['cpus-per-task']}
+#SBATCH --cpus-per-task=1
 #SBATCH --exclusive
 #SBATCH -t {job_config['walltime']}"""
             f.write(sbatch)

--- a/ush/ufsda/misc_utils.py
+++ b/ush/ufsda/misc_utils.py
@@ -56,20 +56,23 @@ def create_batch_job(job_config, working_dir, executable, yaml_path):
     with open(batch_script, 'w') as f:
         f.write('#!/bin/bash\n')
         if scheduler[job_config['machine']] == 'slurm':
+            if job_config['machine'] == 'hera':
+                taskspernode = job_config.get("ntasks-per-node", 18)
+            elif job_config['machine'] == 'orion':
+                taskspernode = job_config.get("ntasks-per-node", 24)
+            else
+                taskspernode = job_config.get("ntasks-per-node", 12)
             sbatch = f"""#SBATCH -J GDASApp
 #SBATCH -o GDASApp.o%J
 #SBATCH -A {job_config['account']}
 #SBATCH -q {job_config['queue']}
 #SBATCH -p {job_config['partition']}
 #SBATCH --ntasks={job_config['ntasks']}
+#SBATCH --ntasks-per-node={taskspernode}
 #SBATCH --cpus-per-task={job_config['cpus-per-task']}
 #SBATCH --exclusive
 #SBATCH -t {job_config['walltime']}"""
             f.write(sbatch)
-        if job_config['machine'] == 'hera':  # orion might need this eventually too when full suite of obs?
-            cpus_per_node = f"""
-#SBATCH --ntasks-per-node={job_config.get("ntasks-per-node", 18)}"""
-            f.write(cpus_per_node)
         commands = f"""
 module purge
 module use {job_config['modulepath']}


### PR DESCRIPTION
GDASApp crashed on Orion with CrIS, this is to reduce the number of tasks per node so that we don't use too much memory per node.