### PR TITLE
Add script to run UFO test executable and produce plots

### DIFF
--- a/parm/atm/hofx/hofx_ufotest.yaml
+++ b/parm/atm/hofx/hofx_ufotest.yaml
@@ -1,3 +1,3 @@
 window begin: '$(ATM_WINDOW_BEGIN)'
-window length: $(ATM_WINDOW_LENGTH)
+window end: $(ATM_WINDOW_END)
 observations: $<< $(OBS_LIST)

--- a/parm/atm/hofx/hofx_ufotest.yaml
+++ b/parm/atm/hofx/hofx_ufotest.yaml
@@ -1,0 +1,3 @@
+window begin: '$(ATM_WINDOW_BEGIN)'
+window length: $(ATM_WINDOW_LENGTH)
+observations: $<< $(OBS_LIST)

--- a/parm/atm/obs/testing/sfc_ps.yaml
+++ b/parm/atm/obs/testing/sfc_ps.yaml
@@ -1,0 +1,18 @@
+obs space:
+  name: sfc_ps
+  obsdatain:
+    obsfile: sfc_ps_obs_$(OBS_DATE).nc4
+  obsdataout:
+    obsfile: sfc_ps_diag_$(OBS_DATE).nc4
+  simulated variables: [surface_pressure]
+geovals:
+  filename: sfc_ps_geoval_$(OBS_DATE).nc4
+vector ref: GsiHofXBc
+tolerance: 0.01
+obs operator:
+  name: SfcPCorrected
+  da_psfc_scheme: GSI
+  geovar_sfc_geomz: surface_geopotential_height
+  geovar_geomz: geopotential_height
+linear obs operator:
+  name: Identity

--- a/parm/atm/obs/testing/sondes_ps.yaml
+++ b/parm/atm/obs/testing/sondes_ps.yaml
@@ -1,0 +1,18 @@
+obs space:
+  name: sondes_ps
+  obsdatain:
+    obsfile: sondes_ps_obs_$(OBS_DATE).nc4
+  obsdataout:
+    obsfile: sondes_ps_diag_$(OBS_DATE).nc4
+  simulated variables: [surface_pressure]
+geovals:
+  filename: sondes_ps_geoval_$(OBS_DATE).nc4
+vector ref: GsiHofXBc
+tolerance: 0.01
+obs operator:
+  name: SfcPCorrected
+  da_psfc_scheme: GSI
+  geovar_sfc_geomz: surface_geopotential_height
+  geovar_geomz: geopotential_height
+linear obs operator:
+  name: Identity

--- a/ush/eva/gen_eva_obs_yaml.py
+++ b/ush/eva/gen_eva_obs_yaml.py
@@ -17,7 +17,11 @@ def gen_eva_obs_yaml(inputyaml, templateyaml, outputdir):
     except Exception as e:
         logging.error(f'Error occurred when attempting to load: {inputyaml}, error: {e}')
     # get just the observations part of the YAML
-    jediobs = jedi_yaml_dict['observations']['observers']
+    if 'observers' in jedi_yaml_dict['observations']:
+        jediobs = jedi_yaml_dict['observations']['observers']
+    else:
+        # the unit tests have a different YAML setup
+        jediobs = jedi_yaml_dict['observations']
     # construct a simplified list of obsspaces for EVA
     evaobs = []
     for obsspace in jediobs:

--- a/ush/eva/jedi_gsi_compare.yaml
+++ b/ush/eva/jedi_gsi_compare.yaml
@@ -209,7 +209,7 @@ diagnostics:
         @CHANNELSKEY@
       figure:
         layout: [1,1]
-        title: 'JEDI omb vs. GSI omb| @NAME@ @CYCLE@ | ${variable_title}'
+        title: 'JEDI omb vs. GSI omb | @NAME@ @CYCLE@ | ${variable_title}'
         output name: observation_scatter_plots/@CYCLE@/@NAME@/${variable}/@CHANNELVAR@/gsi_omb_vs_jedi_omb_@CYCLE@_@NAME@_${variable}@CHANNELVAR@.png
       plots:
         - add_xlabel: 'GSI observation minus h(x)'
@@ -236,6 +236,31 @@ diagnostics:
             markersize: 5
             color: 'red'
             label: 'GSI omb vs JEDI omb (passed QC in JEDI)'
+
+    # H(x) difference as a function of pressure
+    - batch figure:
+        variables: *variables
+        @CHANNELSKEY@
+      figure:
+        layout: [1,1]
+        title: 'H(x) JEDI-GSI vs Ob P. | @NAME@ @CYCLE@ | ${variable_title}'
+        output name: observation_scatter_plots/@CYCLE@/@NAME@/${variable}/@CHANNELVAR@/hofxdiff_vs_pressure_@CYCLE@_@NAME@_${variable}@CHANNELVAR@.png
+      plots:
+        - add_xlabel: 'h(x) JEDI - h(x) GSI'
+          add_ylabel: 'Observation Pressure'
+          add_grid:
+          add_legend:
+            loc: 'lower left'
+          layers:
+          - type: Scatter
+            x:
+              variable: experiment::HofXDiff::${variable}
+            y:
+              variable: experiment::MetaData::air_pressure
+            @CHANNELKEY@
+            markersize: 5
+            color: 'red'
+            label: 'hofxdiff vs pressure'
 
     # Map plot of h(x) difference
     # --------
@@ -270,5 +295,5 @@ diagnostics:
             colorbar: true
             # below may need to be edited/removed
             cmap: 'bwr'
-            vmin: -0.1
-            vmax: 0.1
+            vmin: -10
+            vmax: 10

--- a/ush/ufoeval/run_ufo_hofx_test.sh
+++ b/ush/ufoeval/run_ufo_hofx_test.sh
@@ -14,7 +14,7 @@ cycle=2021080100
 obtype=sondes_ps
 workdir=/work2/noaa/da/$LOGNAME/ufoeval/$cycle/$obtype
 yamlpath=/work2/noaa/da/cmartin/UFO_eval/geovals/yamls/sondes_ps.yaml
-GDASApp=/work2/noaa/da/cmartin/GDASApp/work/GDASApp
+GDASApp=/work2/noaa/da/cmartin/GDASApp/dev/GDASApp
 exename=test_ObsOperator.x
 machine=orion
 
@@ -42,6 +42,7 @@ cp -rf $ObsDir/${obtype}_obs_${cycle}.nc4 $workdir/.
 ln -sf $GDASApp/build/bin/$exename $workdir/.
 
 # Copy/generate YAML for test executable
+# First, create the input YAML for the genYAML script
 
 # Run executable
 cd $workdir

--- a/ush/ufoeval/run_ufo_hofx_test.sh
+++ b/ush/ufoeval/run_ufo_hofx_test.sh
@@ -11,11 +11,11 @@
 #-------------------------------------------------------------
 #--------------- User modified options below -----------------
 cycle=2021080100
-obtype=sondes_ps
+obtype=sfc_ps
 workdir=/work2/noaa/da/$LOGNAME/ufoeval/$cycle/$obtype
-yamlpath=/work2/noaa/da/cmartin/UFO_eval/geovals/yamls/sondes_ps.yaml
+yamlpath=/work2/noaa/da/cmartin/GDASApp/dev/GDASApp/parm/atm/obs/testing/sfc_ps.yaml
 GDASApp=/work2/noaa/da/cmartin/GDASApp/dev/GDASApp
-exename=test_ObsOperator.x
+exename=test_ObsFilters.x
 machine=orion
 
 #-------------- Do not modify below this line ----------------
@@ -24,9 +24,17 @@ GeoDir=/work2/noaa/da/cmartin/UFO_eval/data/gsi_geovals_l127/nofgat_aug2021/2022
 ObsDir=/work2/noaa/da/cmartin/UFO_eval/data/gsi_geovals_l127/nofgat_aug2021/20220806/obs/
 FixDir=/work2/noaa/da/cmartin/GDASApp/fix/
 
+# other variables that should not change often
+export CDATE=$cycle
+export assim_freq=6
+export GDATE=$(date +%Y%m%d%H -d "${CDATE:0:8} ${CDATE:8:2} - ${assim_freq} hours")
+export PDY=${CDATE:0:8}
+export cyc=${CDATE:8:2}
+
 # Load Modules for GDASApp
 module use $GDASApp/modulefiles
 module load GDAS/$machine
+export PYTHONPATH=$GDASApp/ush:$PYTHONPATH
 
 # Create and set up the working directory
 mkdir -p $workdir
@@ -42,7 +50,27 @@ cp -rf $ObsDir/${obtype}_obs_${cycle}.nc4 $workdir/.
 ln -sf $GDASApp/build/bin/$exename $workdir/.
 
 # Copy/generate YAML for test executable
-# First, create the input YAML for the genYAML script
+# First, create the input YAMLs for the genYAML script
+cat > $workdir/obslist.yaml << EOF
+observations:
+- $<< $yamlpath
+EOF
+cat > $workdir/temp.yaml << EOF
+template: $GDASApp/parm/atm/hofx/hofx_ufotest.yaml
+output: $workdir/${obtype}_${cycle}.yaml
+config:
+  atm: true
+  OBS_DIR: ./
+  DIAG_DIR: ./
+  CRTM_COEFF_DIR: crtm
+  BIAS_IN_DIR: ./
+  OBS_LIST: $workdir/obslist.yaml
+  BKG_DIR: ./
+  OBS_DATE: '$CDATE'
+  BIAS_DATE: '$GDATE'
+  INTERP_METHOD: '$INTERP_METHOD'
+EOF
+$GDASApp/ush/genYAML --config $workdir/temp.yaml
 
 # Run executable
 cd $workdir
@@ -52,5 +80,9 @@ cd $workdir
 module load EVA/$machine
 
 # Generate EVA YAML
+$GDASApp/ush/eva/gen_eva_obs_yaml.py -i ./${obtype}_${cycle}.yaml -t $GDASApp/ush/eva/jedi_gsi_compare.yaml -o $workdir
 
 # Run EVA
+for yaml in $(ls eva_*.yaml); do
+  eva $yaml
+done

--- a/ush/ufoeval/run_ufo_hofx_test.sh
+++ b/ush/ufoeval/run_ufo_hofx_test.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# run_hfo_hofx_test.sh
+# This script is intended to simplify/automate large portions
+# of the UFO acceptance for GDAS.
+# This script will:
+# - Create a working directory
+# - Stage fix files, obs, geovals, etc.
+# - Run the UFO test executable(s) necessary
+# - Produce an EVA YAML
+# - Run EVA
+#-------------------------------------------------------------
+#--------------- User modified options below -----------------
+cycle=2021080100
+obtype=sondes_ps
+workdir=/work2/noaa/da/$LOGNAME/ufoeval/$cycle/$obtype
+yamlpath=/work2/noaa/da/cmartin/UFO_eval/geovals/yamls/sondes_ps.yaml
+GDASApp=/work2/noaa/da/cmartin/GDASApp/work/GDASApp
+exename=test_ObsOperator.x
+machine=orion
+
+#-------------- Do not modify below this line ----------------
+# paths that should only be changed by an expert user
+GeoDir=/work2/noaa/da/cmartin/UFO_eval/data/gsi_geovals_l127/nofgat_aug2021/20220806/geovals/
+ObsDir=/work2/noaa/da/cmartin/UFO_eval/data/gsi_geovals_l127/nofgat_aug2021/20220806/obs/
+FixDir=/work2/noaa/da/cmartin/GDASApp/fix/
+
+# Load Modules for GDASApp
+module use $GDASApp/modulefiles
+module load GDAS/$machine
+
+# Create and set up the working directory
+mkdir -p $workdir
+
+# Link CRTM coefficients
+ln -sf $FixDir/crtm/2.3.0 $workdir/crtm
+
+# Copy obs and geovals
+cp -rf $GeoDir/${obtype}_geoval_${cycle}.nc4 $workdir/.
+cp -rf $ObsDir/${obtype}_obs_${cycle}.nc4 $workdir/.
+
+# Link executable
+ln -sf $GDASApp/build/bin/$exename $workdir/.
+
+# Copy/generate YAML for test executable
+
+# Run executable
+cd $workdir
+./$exename ${obtype}_${cycle}.yaml
+
+# Load EVA modules
+module load EVA/$machine
+
+# Generate EVA YAML
+
+# Run EVA

--- a/ush/ufsda/ufs_yaml.py
+++ b/ush/ufsda/ufs_yaml.py
@@ -41,8 +41,6 @@ def parse_config(templateyaml=None, clean=True):
     # grab cycle specific time variables and add them to config
     cycle_dict = get_cycle_vars()
     config_out.update(cycle_dict)
-    # define bundle based on env var
-    config_out['bundle'] = os.path.join(os.environ['HOMEgfs'], 'sorc', 'ufs_da.fd', 'UFS-DA', 'src')
     # going to now nest multiple times to do includes and replace
     config_out = update_config(config_out)
     if clean:
@@ -100,10 +98,10 @@ def get_cycle_vars():
     cycle_dict['fv3_bkg_time'] = cdate.strftime('%Y%m%d.%H%M%S')
     cycle_dict['fv3_bkg_datetime'] = cdate.strftime('%Y-%m-%dT%H:%M:%SZ')
     cycle_dict['current_cycle'] = cdate.strftime('%Y%m%d%H')
-    cycle_dict['background_dir'] = os.environ['COMIN_GES']
-    cycle_dict['staticb_dir'] = os.environ['STATICB_DIR']
-    cycle_dict['soca_input_fix_dir'] = os.environ['SOCA_INPUT_FIX_DIR']
-    cycle_dict['COMOUT'] = os.environ['COMOUT']
+    cycle_dict['background_dir'] = os.getenv('COMIN_GES', './')
+    cycle_dict['staticb_dir'] = os.getenv('STATICB_DIR', './')
+    cycle_dict['soca_input_fix_dir'] = os.getenv('SOCA_INPUT_FIX_DIR', './')
+    cycle_dict['COMOUT'] = os.getenv('COMOUT', './')
     return cycle_dict
 
 
@@ -118,7 +116,6 @@ def get_exp_vars():
     exp_dict['npy_ges'] = npx
     exp_dict['npz'] = str(int(os.environ['LEVS'])-1)
     exp_dict['experiment'] = os.getenv('PSLOT', 'oper') + '_' + os.getenv('CDUMP', 'gdas')
-    exp_dict['jedi_build'] = os.path.join(os.environ['HOMEgfs'], 'sorc', 'ufs_da.fd', 'UFS-DA', 'build')
     exp_dict['experiment_dir'] = 'Data/obs'
     return exp_dict
 

--- a/ush/ufsda/yamltools.py
+++ b/ush/ufsda/yamltools.py
@@ -137,7 +137,9 @@ def calc_time_vars(config):
     # get atm window begin
     h = re.findall('PT(\\d+)H', config['ATM_WINDOW_LENGTH'])[0]
     win_begin = valid_time_obj - datetime.timedelta(hours=int(h)/2)
+    win_end = valid_time_obj + datetime.timedelta(hours=int(h)/2)
     config['ATM_WINDOW_BEGIN'] = win_begin.strftime('%Y-%m-%dT%H:%M:%SZ')
+    config['ATM_WINDOW_END'] = win_end.strftime('%Y-%m-%dT%H:%M:%SZ')
     config['BEGIN_YYYYmmddHHMMSS'] = win_begin.strftime('%Y%m%d.%H%M%S')
     return config
 


### PR DESCRIPTION
Closes #106

This PR does a few things but mainly in support of adding a shell script that will facilitate the process of checking QC and H(X) when using GSI-produced GeoVaLs.

Added:
- a new YAML template for the UFO test executables
- a new directory for obs YAMLs for debugging/testing
- the aforementioned shell script to ush/ufoeval

Modified:
- YAML generation tool supporting functions (mainly to remove old things that are no longer needed)
- the EVA YAML generation tool to handle input YAML from both UFO tests and FV3-JEDI executables
- Added an hofx difference vs ob pressure plot to the EVA template 