### PR TITLE
Additional support for surface pressure observations

### DIFF
--- a/parm/atm/obs/config/sfc.yaml
+++ b/parm/atm/obs/config/sfc.yaml
@@ -1,14 +1,14 @@
 obs space:
-  name: sfc_ps
+  name: sfc
   obsdatain:
-    obsfile: sfc_ps_obs_$(OBS_DATE).nc4
+    obsfile: $(OBS_DIR)/$(OBS_PREFIX)sfc.$(OBS_DATE).nc4
   obsdataout:
-    obsfile: sfc_ps_diag_$(OBS_DATE).nc4
+    obsfile: $(DIAG_DIR)/diag_sfc_$(OBS_DATE).nc4
+  io pool:
+    max pool size: 1
   simulated variables: [surface_pressure]
-geovals:
-  filename: sfc_ps_geoval_$(OBS_DATE).nc4
-vector ref: GsiHofXBc
-tolerance: 0.01
+get values:
+  interpolation method: $(INTERP_METHOD)
 obs operator:
   name: SfcPCorrected
   da_psfc_scheme: GSI

--- a/parm/atm/obs/lists/gdas_prototype.yaml
+++ b/parm/atm/obs/lists/gdas_prototype.yaml
@@ -9,5 +9,5 @@ observers:
 - $<< $(OBS_YAML_DIR)/ompstc8_npp.yaml
 - $<< $(OBS_YAML_DIR)/cris-fsr_n20.yaml
 - $<< $(OBS_YAML_DIR)/cris-fsr_npp.yaml
+- $<< $(OBS_YAML_DIR)/sfc.yaml
 #- $<< $(OBS_YAML_DIR)/sfcship.yaml
-#- $<< $(OBS_YAML_DIR)/sfc.yaml

--- a/parm/atm/obs/testing/sfc.yaml
+++ b/parm/atm/obs/testing/sfc.yaml
@@ -1,0 +1,18 @@
+obs space:
+  name: sfc
+  obsdatain:
+    obsfile: sfc_obs_$(OBS_DATE).nc4
+  obsdataout:
+    obsfile: sfc_diag_$(OBS_DATE).nc4
+  simulated variables: [surface_pressure, air_temperature, virtual_temperature]
+geovals:
+  filename: sfc_geoval_$(OBS_DATE).nc4
+vector ref: GsiHofXBc
+tolerance: 0.01
+obs operator:
+  name: SfcPCorrected
+  da_psfc_scheme: GSI
+  geovar_sfc_geomz: surface_geometric_height
+  geovar_geomz: geopotential_height
+linear obs operator:
+  name: Identity

--- a/ush/eva/jedi_gsi_compare.yaml
+++ b/ush/eva/jedi_gsi_compare.yaml
@@ -16,12 +16,28 @@ diagnostics:
           - name: EffectiveQC
           - name: MetaData
           - name: GsiEffectiveQC
+          - name: GsiFinalObsError
+          - name: EffectiveError
   transforms:
 
     # difference of hofx
     - transform: arithmetic
       new name: experiment::HofXDiff::${variable}
       equals: experiment::hofx::${variable}-experiment::GsiHofXBc::${variable}
+      for:
+        variable: *variables
+
+    # difference of effective error
+    - transform: arithmetic
+      new name: experiment::ErrDiff::${variable}
+      equals: experiment::EffectiveError::${variable}-experiment::GsiFinalObsError::${variable}
+      for:
+        variable: *variables
+
+    # difference of QC
+    - transform: arithmetic
+      new name: experiment::QCDiff::${variable}
+      equals: experiment::EffectiveQC::${variable}-experiment::GsiEffectiveQC::${variable}
       for:
         variable: *variables
 
@@ -95,6 +111,7 @@ diagnostics:
 
   graphics:
 
+    # ---------- Scatter Plots ----------
     # JEDI h(x) vs Observations
     # -------------------------
     - batch figure:
@@ -180,7 +197,7 @@ diagnostics:
           add_ylabel: 'JEDI h(x)'
           add_grid:
           add_legend:
-            loc: 'upper left'
+            loc: 'lower left'
           layers:
           - type: Scatter
             x:
@@ -261,7 +278,151 @@ diagnostics:
             markersize: 5
             color: 'red'
             label: 'hofxdiff vs pressure'
+          statistics:
+            data:
+              variable: experiment::HofXDiff::${variable}
+              @CHANNELKEY@
+            statistic list:
+            - n
+            - min
+            - mean
+            - max
+            - std
+            - name
+            kwargs:
+              fontsize: 6
 
+    # QC difference as a function of H(x) difference
+    - batch figure:
+        variables: *variables
+        @CHANNELSKEY@
+      figure:
+        layout: [1,1]
+        title: 'H(x) JEDI-GSI vs QC JEDI-GSI. | @NAME@ @CYCLE@ | ${variable_title}'
+        output name: observation_scatter_plots/@CYCLE@/@NAME@/${variable}/@CHANNELVAR@/hofxdiff_vs_qcdiff_@CYCLE@_@NAME@_${variable}@CHANNELVAR@.png
+      plots:
+        - add_xlabel: 'h(x) JEDI - h(x) GSI'
+          add_ylabel: 'h(x) JEDI - h(x) GSI'
+          add_grid:
+          add_legend:
+            loc: 'lower left'
+          layers:
+          - type: Scatter
+            x:
+              variable: experiment::QCDiff::${variable}
+            y:
+              variable: experiment::HofXDiff::${variable}
+            @CHANNELKEY@
+            markersize: 5
+            color: 'red'
+            label: 'hofxdiff vs qcdiff'
+          statistics:
+            data:
+              variable: experiment::QCDiff::${variable}
+              @CHANNELKEY@
+            statistic list:
+            - n
+            - min
+            - mean
+            - max
+            - std
+            - name
+            kwargs:
+              fontsize: 6
+
+    # Error difference as a function of pressure
+    - batch figure:
+        variables: *variables
+        @CHANNELSKEY@
+      figure:
+        layout: [1,1]
+        title: 'Error JEDI-GSI vs Ob P. | @NAME@ @CYCLE@ | ${variable_title}'
+        output name: observation_scatter_plots/@CYCLE@/@NAME@/${variable}/@CHANNELVAR@/errordiff_vs_pressure_@CYCLE@_@NAME@_${variable}@CHANNELVAR@.png
+      plots:
+        - add_xlabel: 'Error JEDI - Error GSI'
+          add_ylabel: 'Observation Pressure'
+          add_grid:
+          add_legend:
+            loc: 'lower left'
+          layers:
+          - type: Scatter
+            x:
+              variable: experiment::ErrDiff::${variable}
+            y:
+              variable: experiment::MetaData::air_pressure
+            @CHANNELKEY@
+            markersize: 5
+            color: 'red'
+            label: 'errordiff vs pressure'
+
+    # ---------- Histograms ----------
+    # Histogram of h(x) difference
+    - batch figure:
+        variables: *variables
+        @CHANNELSKEY@
+      figure:
+        layout: [1,1]
+        title: 'Difference of h(x) JEDI-GSI | @NAME@ @CYCLE@ | ${variable_title}'
+        output name: histograms/@CYCLE@/@NAME@/${variable}/@CHANNELVAR@/hofxdiff_histogram_@CYCLE@_@NAME@_${variable}@CHANNELVAR@.png
+      plots:
+        - add_xlabel: 'h(x) JEDI - h(x) GSI'
+          add_ylabel: 'Count'
+          statistics:
+            data:
+              variable: experiment::HofXDiff::${variable}
+              @CHANNELKEY@
+            statistic list:
+            - n
+            - min
+            - mean
+            - max
+            - std
+            - name
+            kwargs:
+              fontsize: 6
+          layers:
+          - type: Histogram
+            data:
+              variable: experiment::HofXDiff::${variable}
+              @CHANNELKEY@
+            color: 'blue'
+            label: 'h(x) JEDI - h(x) GSI'
+            bins: 100
+
+    # Histogram of obs error difference
+    - batch figure:
+        variables: *variables
+        @CHANNELSKEY@
+      figure:
+        layout: [1,1]
+        title: 'Difference of final obs error JEDI-GSI | @NAME@ @CYCLE@ | ${variable_title}'
+        output name: histograms/@CYCLE@/@NAME@/${variable}/@CHANNELVAR@/errordiff_histogram_@CYCLE@_@NAME@_${variable}@CHANNELVAR@.png
+      plots:
+        - add_xlabel: 'error JEDI - error GSI'
+          add_ylabel: 'Count'
+          statistics:
+            data:
+              variable: experiment::ErrDiff::${variable}
+              @CHANNELKEY@
+            statistic list:
+            - n
+            - min
+            - mean
+            - max
+            - std
+            - name
+            kwargs:
+              fontsize: 6
+          layers:
+          - type: Histogram
+            data:
+              variable: experiment::ErrDiff::${variable}
+              @CHANNELKEY@
+            color: 'blue'
+            label: 'error JEDI - error GSI'
+            bins: 100
+
+    # ---------- Map Plots ----------
     # Map plot of h(x) difference
     # --------
 
@@ -295,5 +456,5 @@ diagnostics:
             colorbar: true
             # below may need to be edited/removed
             cmap: 'bwr'
-            vmin: -10
-            vmax: 10
+            vmin: -3000
+            vmax: 3000

--- a/ush/ufoeval/run_ufo_hofx_test.sh
+++ b/ush/ufoeval/run_ufo_hofx_test.sh
@@ -20,8 +20,8 @@ machine=orion
 
 #-------------- Do not modify below this line ----------------
 # paths that should only be changed by an expert user
-GeoDir=/work2/noaa/da/cmartin/UFO_eval/data/gsi_geovals_l127/nofgat_aug2021/20220809/geovals/
-ObsDir=/work2/noaa/da/cmartin/UFO_eval/data/gsi_geovals_l127/nofgat_aug2021/20220809/obs/
+GeoDir=/work2/noaa/da/cmartin/UFO_eval/data/gsi_geovals_l127/nofgat_aug2021/20220816/geovals/
+ObsDir=/work2/noaa/da/cmartin/UFO_eval/data/gsi_geovals_l127/nofgat_aug2021/20220816/obs/
 FixDir=/work2/noaa/da/cmartin/GDASApp/fix/
 
 # other variables that should not change often

--- a/ush/ufoeval/run_ufo_hofx_test.sh
+++ b/ush/ufoeval/run_ufo_hofx_test.sh
@@ -74,8 +74,6 @@ $GDASApp/ush/genYAML --config $workdir/temp.yaml
 
 # Run executable
 cd $workdir
-export OOPS_DEBUG=1
-export OOPS_TRACE=1
 ./$exename ${obtype}_${cycle}.yaml
 
 # Load EVA modules

--- a/ush/ufoeval/run_ufo_hofx_test.sh
+++ b/ush/ufoeval/run_ufo_hofx_test.sh
@@ -11,17 +11,17 @@
 #-------------------------------------------------------------
 #--------------- User modified options below -----------------
 cycle=2021080100
-obtype=sfc_ps
+obtype=sfc
 workdir=/work2/noaa/da/$LOGNAME/ufoeval/$cycle/$obtype
-yamlpath=/work2/noaa/da/cmartin/GDASApp/dev/GDASApp/parm/atm/obs/testing/sfc_ps.yaml
+yamlpath=/work2/noaa/da/cmartin/GDASApp/dev/GDASApp/parm/atm/obs/testing/sfc.yaml
 GDASApp=/work2/noaa/da/cmartin/GDASApp/dev/GDASApp
 exename=test_ObsFilters.x
 machine=orion
 
 #-------------- Do not modify below this line ----------------
 # paths that should only be changed by an expert user
-GeoDir=/work2/noaa/da/cmartin/UFO_eval/data/gsi_geovals_l127/nofgat_aug2021/20220806/geovals/
-ObsDir=/work2/noaa/da/cmartin/UFO_eval/data/gsi_geovals_l127/nofgat_aug2021/20220806/obs/
+GeoDir=/work2/noaa/da/cmartin/UFO_eval/data/gsi_geovals_l127/nofgat_aug2021/20220809/geovals/
+ObsDir=/work2/noaa/da/cmartin/UFO_eval/data/gsi_geovals_l127/nofgat_aug2021/20220809/obs/
 FixDir=/work2/noaa/da/cmartin/GDASApp/fix/
 
 # other variables that should not change often
@@ -74,6 +74,8 @@ $GDASApp/ush/genYAML --config $workdir/temp.yaml
 
 # Run executable
 cd $workdir
+export OOPS_DEBUG=1
+export OOPS_TRACE=1
 ./$exename ${obtype}_${cycle}.yaml
 
 # Load EVA modules


### PR DESCRIPTION
This PR does 3 main things:

- Adds official support for surface pressure observations in hofx/var applications (note: results may not yet be right using obs in R2D2 at this time due to a bug in combining t/ps obs, see previously merged https://github.com/JCSDA-internal/ioda-converters/pull/953)
- Adds a test file for geovals for other surface ob types
- Adds additional plot types to the example EVA generation template
- Update the paths to the input files for running UFO with GSI geovals