### PR TITLE
Update filetype to auxgrid and add gridtype latlon (#111)

### DIFF
--- a/parm/atm/lgetkf/lgetkf.yaml
+++ b/parm/atm/lgetkf/lgetkf.yaml
@@ -44,11 +44,13 @@ local ensemble DA:
     mult: 1.0
 
 #output:
-#  filetype: latlon
+#  filetype: auxgrid
+#  gridtype: latlon
 #  filename: $(ANL_DIR)/mem%{member}%/atmanl.
 
 output ensemble increments:
-  filetype: latlon
+  filetype: auxgrid
+  gridtype: latlon
   filename: $(ANL_DIR)/mem%{member}%/atminc.
 
 geometry: $(GEOM_ANL)

--- a/parm/atm/variational/3dvar_dripcg.yaml
+++ b/parm/atm/variational/3dvar_dripcg.yaml
@@ -39,6 +39,7 @@ final:
     departures: anlmob
   increment:
     output:
-      filetype: latlon
+      filetype: auxgrid
+      gridtype: latlon
       filename: $(ANL_DIR)/atminc.
     geometry: $(GEOM_ANL)


### PR DESCRIPTION
Completion of fv3-jedi PR [#560](https://github.com/JCSDA-internal/fv3-jedi/pull/560) requires updating output grid keywords in GDASApp `parm/atm/lgetkf/lgetkf.yaml` and `parm/atm/variational/3dvar_dripcg.yaml`.   See issue #111 for details.

Without merger of this PR into GDASApp develop, execution of `fv3jedi_letkf.x` using the existing `parm/atm/lgetkf/lgetkf.yaml` or execution of `fv3jedi_var.x` with `parm/atm/variational/3dvar_dripcg.yaml`  results in an exception when processing the output section of the input yaml.
```
Exception: latlon does not exist in fv3jedi::IOFactory
Exception: oops::Variational<FV3JEDI, UFO and IODA observations> terminating...
```

`latlon` has been replaced by the more generic `auxgrid` for _auxiliary grid_.    An new keyword, `gridtype` specifies the type of auxiliary grid.   Currently there are two valid options for `gridtype`:  `latlon` and `gaussian`.

The required changes to `parm/atm/lgetkf/lgetkf.yaml` and `parm/atm/variational/3dvar_dripcg.yaml` have been committed to `feature/auxgrid`.   This PR merges these updated yaml files in `develop`.