### PR TITLE
Add in engine section to YAMLs and supporting python code

### DIFF
--- a/parm/aero/obs/config/viirs_n20_aod.yaml
+++ b/parm/aero/obs/config/viirs_n20_aod.yaml
@@ -1,9 +1,13 @@
 obs space:
   name: viirs_n20_aod
   obsdatain:
-    obsfile: $(OBS_DIR)/$(OBS_PREFIX)viirs_n20.$(OBS_DATE).nc4
+    engine:
+      type: H5File
+      obsfile: $(OBS_DIR)/$(OBS_PREFIX)viirs_n20.$(OBS_DATE).nc4
   obsdataout:
-    obsfile: $(DIAG_DIR)/diag_viirs_n20_$(OBS_DATE).nc4
+    engine:
+      type: H5File
+      obsfile: $(DIAG_DIR)/diag_viirs_n20_$(OBS_DATE).nc4
   io pool:
     max pool size: 1
   simulated variables: [aerosol_optical_depth]

--- a/parm/aero/obs/config/viirs_npp_aod.yaml
+++ b/parm/aero/obs/config/viirs_npp_aod.yaml
@@ -1,9 +1,13 @@
 obs space:
   name: viirs_npp_aod
   obsdatain:
-    obsfile: $(OBS_DIR)/$(OBS_PREFIX)viirs_npp.$(OBS_DATE).nc4
+    engine:
+      name: H5File
+      obsfile: $(OBS_DIR)/$(OBS_PREFIX)viirs_npp.$(OBS_DATE).nc4
   obsdataout:
-    obsfile: $(DIAG_DIR)/diag_viirs_npp_$(OBS_DATE).nc4
+    engine:
+      name: H5File
+      obsfile: $(DIAG_DIR)/diag_viirs_npp_$(OBS_DATE).nc4
   io pool:
     max pool size: 1
   simulated variables: [aerosol_optical_depth]

--- a/parm/aero/obs/config/viirs_npp_aod.yaml
+++ b/parm/aero/obs/config/viirs_npp_aod.yaml
@@ -2,11 +2,11 @@ obs space:
   name: viirs_npp_aod
   obsdatain:
     engine:
-      name: H5File
+      type: H5File
       obsfile: $(OBS_DIR)/$(OBS_PREFIX)viirs_npp.$(OBS_DATE).nc4
   obsdataout:
     engine:
-      name: H5File
+      type: H5File
       obsfile: $(DIAG_DIR)/diag_viirs_npp_$(OBS_DATE).nc4
   io pool:
     max pool size: 1

--- a/parm/atm/obs/config/aircraft.yaml
+++ b/parm/atm/obs/config/aircraft.yaml
@@ -1,13 +1,17 @@
 obs space:
   name: Aircraft
   obsdatain:
-    obsfile: $(OBS_DIR)/$(OBS_PREFIX)aircraft.$(OBS_DATE).nc4
+    engine:
+      name: H5File
+      obsfile: $(OBS_DIR)/$(OBS_PREFIX)aircraft.$(OBS_DATE).nc4
     obsgrouping:
       group variables: ["station_id"]
       sort variable: "air_pressure"
       sort order: "descending"
   obsdataout:
-    obsfile: $(DIAG_DIR)/diag_aircraft_$(OBS_DATE).nc4
+    engine:
+      name: H5File
+      obsfile: $(DIAG_DIR)/diag_aircraft_$(OBS_DATE).nc4
   io pool:
     max pool size: 1
   simulated variables: [eastward_wind, northward_wind, air_temperature, specific_humidity]

--- a/parm/atm/obs/config/aircraft.yaml
+++ b/parm/atm/obs/config/aircraft.yaml
@@ -2,7 +2,7 @@ obs space:
   name: Aircraft
   obsdatain:
     engine:
-      name: H5File
+      type: H5File
       obsfile: $(OBS_DIR)/$(OBS_PREFIX)aircraft.$(OBS_DATE).nc4
     obsgrouping:
       group variables: ["station_id"]
@@ -10,7 +10,7 @@ obs space:
       sort order: "descending"
   obsdataout:
     engine:
-      name: H5File
+      type: H5File
       obsfile: $(DIAG_DIR)/diag_aircraft_$(OBS_DATE).nc4
   io pool:
     max pool size: 1

--- a/parm/atm/obs/config/amsua_n19.yaml
+++ b/parm/atm/obs/config/amsua_n19.yaml
@@ -1,9 +1,13 @@
 obs space:
   name: amsua_n19
   obsdatain:
-    obsfile: $(OBS_DIR)/$(OBS_PREFIX)amsua_n19.$(OBS_DATE).nc4
+    engine:
+      name: H5File
+      obsfile: $(OBS_DIR)/$(OBS_PREFIX)amsua_n19.$(OBS_DATE).nc4
   obsdataout:
-    obsfile: $(DIAG_DIR)/diag_amsua_n19_$(OBS_DATE).nc4
+    engine:
+      name: H5File
+      obsfile: $(DIAG_DIR)/diag_amsua_n19_$(OBS_DATE).nc4
   io pool:
     max pool size: 1
   simulated variables: [brightness_temperature]

--- a/parm/atm/obs/config/amsua_n19.yaml
+++ b/parm/atm/obs/config/amsua_n19.yaml
@@ -2,11 +2,11 @@ obs space:
   name: amsua_n19
   obsdatain:
     engine:
-      name: H5File
+      type: H5File
       obsfile: $(OBS_DIR)/$(OBS_PREFIX)amsua_n19.$(OBS_DATE).nc4
   obsdataout:
     engine:
-      name: H5File
+      type: H5File
       obsfile: $(DIAG_DIR)/diag_amsua_n19_$(OBS_DATE).nc4
   io pool:
     max pool size: 1

--- a/parm/atm/obs/config/atms_n20.yaml
+++ b/parm/atm/obs/config/atms_n20.yaml
@@ -1,9 +1,13 @@
 obs space:
   name: atms_n20
   obsdatain:
-    obsfile: $(OBS_DIR)/$(OBS_PREFIX)atms_n20.$(OBS_DATE).nc4
+    engine:
+      name: H5File
+      obsfile: $(OBS_DIR)/$(OBS_PREFIX)atms_n20.$(OBS_DATE).nc4
   obsdataout:
-    obsfile: $(DIAG_DIR)/diag_atms_n20_$(OBS_DATE).nc4
+    engine:
+      name: H5File
+      obsfile: $(DIAG_DIR)/diag_atms_n20_$(OBS_DATE).nc4
   io pool:
     max pool size: 1
   simulated variables: [brightness_temperature]

--- a/parm/atm/obs/config/atms_n20.yaml
+++ b/parm/atm/obs/config/atms_n20.yaml
@@ -2,11 +2,11 @@ obs space:
   name: atms_n20
   obsdatain:
     engine:
-      name: H5File
+      type: H5File
       obsfile: $(OBS_DIR)/$(OBS_PREFIX)atms_n20.$(OBS_DATE).nc4
   obsdataout:
     engine:
-      name: H5File
+      type: H5File
       obsfile: $(DIAG_DIR)/diag_atms_n20_$(OBS_DATE).nc4
   io pool:
     max pool size: 1

--- a/parm/atm/obs/config/cris-fsr_n20.yaml
+++ b/parm/atm/obs/config/cris-fsr_n20.yaml
@@ -2,11 +2,11 @@ obs space:
   name: cris-fsr_n20
   obsdatain:
     engine:
-      name: H5File
+      type: H5File
       obsfile: $(OBS_DIR)/$(OBS_PREFIX)cris-fsr_n20.$(OBS_DATE).nc4
   obsdataout:
     engine:
-      name: H5File
+      type: H5File
       obsfile: $(DIAG_DIR)/diag_cris-fsr_n20_$(OBS_DATE).nc4
   io pool:
     max pool size: 1

--- a/parm/atm/obs/config/cris-fsr_n20.yaml
+++ b/parm/atm/obs/config/cris-fsr_n20.yaml
@@ -1,9 +1,13 @@
 obs space:
   name: cris-fsr_n20
   obsdatain:
-    obsfile: $(OBS_DIR)/$(OBS_PREFIX)cris-fsr_n20.$(OBS_DATE).nc4
+    engine:
+      name: H5File
+      obsfile: $(OBS_DIR)/$(OBS_PREFIX)cris-fsr_n20.$(OBS_DATE).nc4
   obsdataout:
-    obsfile: $(DIAG_DIR)/diag_cris-fsr_n20_$(OBS_DATE).nc4
+    engine:
+      name: H5File
+      obsfile: $(DIAG_DIR)/diag_cris-fsr_n20_$(OBS_DATE).nc4
   io pool:
     max pool size: 1
   simulated variables: [brightness_temperature]

--- a/parm/atm/obs/config/cris-fsr_npp.yaml
+++ b/parm/atm/obs/config/cris-fsr_npp.yaml
@@ -2,11 +2,11 @@ obs space:
   name: cris-fsr_npp
   obsdatain:
     engine:
-      name: H5File
+      type: H5File
       obsfile: $(OBS_DIR)/$(OBS_PREFIX)cris-fsr_npp.$(OBS_DATE).nc4 
   obsdataout:
     engine:
-      name: H5File
+      type: H5File
       obsfile: $(DIAG_DIR)/diag_cris-fsr_npp_$(OBS_DATE).nc4
   io pool:
     max pool size: 1

--- a/parm/atm/obs/config/cris-fsr_npp.yaml
+++ b/parm/atm/obs/config/cris-fsr_npp.yaml
@@ -1,9 +1,13 @@
 obs space:
   name: cris-fsr_npp
   obsdatain:
-    obsfile: $(OBS_DIR)/$(OBS_PREFIX)cris-fsr_npp.$(OBS_DATE).nc4 
+    engine:
+      name: H5File
+      obsfile: $(OBS_DIR)/$(OBS_PREFIX)cris-fsr_npp.$(OBS_DATE).nc4 
   obsdataout:
-    obsfile: $(DIAG_DIR)/diag_cris-fsr_npp_$(OBS_DATE).nc4
+    engine:
+      name: H5File
+      obsfile: $(DIAG_DIR)/diag_cris-fsr_npp_$(OBS_DATE).nc4
   io pool:
     max pool size: 1
   simulated variables: [brightness_temperature]

--- a/parm/atm/obs/config/lgetkf_amsua_n19.yaml
+++ b/parm/atm/obs/config/lgetkf_amsua_n19.yaml
@@ -4,9 +4,13 @@ obs space:
     name: Halo
     halo size: 1250e3
   obsdatain:
-    obsfile: $(OBS_DIR)/$(OBS_PREFIX)amsua_n19.$(OBS_DATE).nc4
+    engine:
+      name: H5File
+      obsfile: $(OBS_DIR)/$(OBS_PREFIX)amsua_n19.$(OBS_DATE).nc4
   obsdataout:
-    obsfile: $(DIAG_DIR)/diag_amsua_n19_lgetkf.$(OBS_DATE).nc4
+    engine:
+      name: H5File
+      obsfile: $(DIAG_DIR)/diag_amsua_n19_lgetkf.$(OBS_DATE).nc4
   io pool:
     max pool size: 1
   simulated variables: [brightness_temperature]

--- a/parm/atm/obs/config/lgetkf_amsua_n19.yaml
+++ b/parm/atm/obs/config/lgetkf_amsua_n19.yaml
@@ -5,11 +5,11 @@ obs space:
     halo size: 1250e3
   obsdatain:
     engine:
-      name: H5File
+      type: H5File
       obsfile: $(OBS_DIR)/$(OBS_PREFIX)amsua_n19.$(OBS_DATE).nc4
   obsdataout:
     engine:
-      name: H5File
+      type: H5File
       obsfile: $(DIAG_DIR)/diag_amsua_n19_lgetkf.$(OBS_DATE).nc4
   io pool:
     max pool size: 1

--- a/parm/atm/obs/config/lgetkf_sondes.yaml
+++ b/parm/atm/obs/config/lgetkf_sondes.yaml
@@ -4,9 +4,13 @@ obs space:
     name: Halo
     halo size: 1250e3
   obsdatain:
-    obsfile: $(OBS_DIR)/$(OBS_PREFIX)sondes.$(OBS_DATE).nc4
+    engine:
+      name: H5File
+      obsfile: $(OBS_DIR)/$(OBS_PREFIX)sondes.$(OBS_DATE).nc4
   obsdataout:
-    obsfile: $(DIAG_DIR)/diag_sondes_lgetkf.$(OBS_DATE).nc4
+    engine:
+      name: H5File
+      obsfile: $(DIAG_DIR)/diag_sondes_lgetkf.$(OBS_DATE).nc4
   io pool:
     max pool size: 1
   simulated variables: [eastward_wind, northward_wind, air_temperature]

--- a/parm/atm/obs/config/lgetkf_sondes.yaml
+++ b/parm/atm/obs/config/lgetkf_sondes.yaml
@@ -5,11 +5,11 @@ obs space:
     halo size: 1250e3
   obsdatain:
     engine:
-      name: H5File
+      type: H5File
       obsfile: $(OBS_DIR)/$(OBS_PREFIX)sondes.$(OBS_DATE).nc4
   obsdataout:
     engine:
-      name: H5File
+      type: H5File
       obsfile: $(DIAG_DIR)/diag_sondes_lgetkf.$(OBS_DATE).nc4
   io pool:
     max pool size: 1

--- a/parm/atm/obs/config/omi_aura.yaml
+++ b/parm/atm/obs/config/omi_aura.yaml
@@ -2,11 +2,11 @@ obs space:
   name: omi_aura
   obsdatain:
     engine:
-      name: H5File
+      type: H5File
       obsfile: $(OBS_DIR)/$(OBS_PREFIX)omi_aura.$(OBS_DATE).nc4
   obsdataout:
     engine:
-      name: H5File
+      type: H5File
       obsfile: $(DIAG_DIR)/diag_omi_aura_$(OBS_DATE).nc4
   io pool:
     max pool size: 1

--- a/parm/atm/obs/config/omi_aura.yaml
+++ b/parm/atm/obs/config/omi_aura.yaml
@@ -1,9 +1,13 @@
 obs space:
   name: omi_aura
   obsdatain:
-    obsfile: $(OBS_DIR)/$(OBS_PREFIX)omi_aura.$(OBS_DATE).nc4
+    engine:
+      name: H5File
+      obsfile: $(OBS_DIR)/$(OBS_PREFIX)omi_aura.$(OBS_DATE).nc4
   obsdataout:
-    obsfile: $(DIAG_DIR)/diag_omi_aura_$(OBS_DATE).nc4
+    engine:
+      name: H5File
+      obsfile: $(DIAG_DIR)/diag_omi_aura_$(OBS_DATE).nc4
   io pool:
     max pool size: 1
   simulated variables: [integrated_layer_ozone_in_air]

--- a/parm/atm/obs/config/ompsnp_npp.yaml
+++ b/parm/atm/obs/config/ompsnp_npp.yaml
@@ -2,11 +2,11 @@ obs space:
   name: ompsnp_npp
   obsdatain:
     engine:
-      name: H5File
+      type: H5File
       obsfile: $(OBS_DIR)/$(OBS_PREFIX)ompsnp_npp.$(OBS_DATE).nc4
   obsdataout:
     engine:
-      name: H5File
+      type: H5File
       obsfile: $(DIAG_DIR)/diag_ompsnp_npp_$(OBS_DATE).nc4
   io pool:
     max pool size: 1

--- a/parm/atm/obs/config/ompsnp_npp.yaml
+++ b/parm/atm/obs/config/ompsnp_npp.yaml
@@ -1,9 +1,13 @@
 obs space:
   name: ompsnp_npp
   obsdatain:
-    obsfile: $(OBS_DIR)/$(OBS_PREFIX)ompsnp_npp.$(OBS_DATE).nc4
+    engine:
+      name: H5File
+      obsfile: $(OBS_DIR)/$(OBS_PREFIX)ompsnp_npp.$(OBS_DATE).nc4
   obsdataout:
-    obsfile: $(DIAG_DIR)/diag_ompsnp_npp_$(OBS_DATE).nc4
+    engine:
+      name: H5File
+      obsfile: $(DIAG_DIR)/diag_ompsnp_npp_$(OBS_DATE).nc4
   io pool:
     max pool size: 1
   simulated variables: [integrated_layer_ozone_in_air]

--- a/parm/atm/obs/config/ompstc8_npp.yaml
+++ b/parm/atm/obs/config/ompstc8_npp.yaml
@@ -2,11 +2,11 @@ obs space:
   name: ompstc8_npp
   obsdatain:
     engine:
-      name: H5File
+      type: H5File
       obsfile: $(OBS_DIR)/$(OBS_PREFIX)ompstc8_npp.$(OBS_DATE).nc4
   obsdataout:
     engine:
-      name: H5File
+      type: H5File
       obsfile: $(DIAG_DIR)/diag_ompstc8_npp_$(OBS_DATE).nc4
   io pool:
     max pool size: 1

--- a/parm/atm/obs/config/ompstc8_npp.yaml
+++ b/parm/atm/obs/config/ompstc8_npp.yaml
@@ -1,9 +1,13 @@
 obs space:
   name: ompstc8_npp
   obsdatain:
-    obsfile: $(OBS_DIR)/$(OBS_PREFIX)ompstc8_npp.$(OBS_DATE).nc4
+    engine:
+      name: H5File
+      obsfile: $(OBS_DIR)/$(OBS_PREFIX)ompstc8_npp.$(OBS_DATE).nc4
   obsdataout:
-    obsfile: $(DIAG_DIR)/diag_ompstc8_npp_$(OBS_DATE).nc4
+    engine:
+      name: H5File
+      obsfile: $(DIAG_DIR)/diag_ompstc8_npp_$(OBS_DATE).nc4
   io pool:
     max pool size: 1
   simulated variables: [integrated_layer_ozone_in_air]

--- a/parm/atm/obs/config/satwind.yaml
+++ b/parm/atm/obs/config/satwind.yaml
@@ -2,11 +2,11 @@ obs space:
   name: satwind
   obsdatain:
     engine:
-      name: H5File
+      type: H5File
       obsfile: $(OBS_DIR)/$(OBS_PREFIX)satwind.$(OBS_DATE).nc4
   obsdataout:
     engine:
-      name: H5File
+      type: H5File
       obsfile: $(DIAG_DIR)/diag_satwind_$(OBS_DATE).nc4
   io pool:
     max pool size: 1

--- a/parm/atm/obs/config/satwind.yaml
+++ b/parm/atm/obs/config/satwind.yaml
@@ -1,9 +1,13 @@
 obs space:
   name: satwind
   obsdatain:
-    obsfile: $(OBS_DIR)/$(OBS_PREFIX)satwind.$(OBS_DATE).nc4
+    engine:
+      name: H5File
+      obsfile: $(OBS_DIR)/$(OBS_PREFIX)satwind.$(OBS_DATE).nc4
   obsdataout:
-    obsfile: $(DIAG_DIR)/diag_satwind_$(OBS_DATE).nc4
+    engine:
+      name: H5File
+      obsfile: $(DIAG_DIR)/diag_satwind_$(OBS_DATE).nc4
   io pool:
     max pool size: 1
   simulated variables: [eastward_wind, northward_wind]

--- a/parm/atm/obs/config/sfc.yaml
+++ b/parm/atm/obs/config/sfc.yaml
@@ -2,11 +2,11 @@ obs space:
   name: sfc
   obsdatain:
     engine:
-      name: H5File
+      type: H5File
       obsfile: $(OBS_DIR)/$(OBS_PREFIX)sfc.$(OBS_DATE).nc4
   obsdataout:
     engine:
-      name: H5File
+      type: H5File
       obsfile: $(DIAG_DIR)/diag_sfc_$(OBS_DATE).nc4
   io pool:
     max pool size: 1

--- a/parm/atm/obs/config/sfc.yaml
+++ b/parm/atm/obs/config/sfc.yaml
@@ -1,9 +1,13 @@
 obs space:
   name: sfc
   obsdatain:
-    obsfile: $(OBS_DIR)/$(OBS_PREFIX)sfc.$(OBS_DATE).nc4
+    engine:
+      name: H5File
+      obsfile: $(OBS_DIR)/$(OBS_PREFIX)sfc.$(OBS_DATE).nc4
   obsdataout:
-    obsfile: $(DIAG_DIR)/diag_sfc_$(OBS_DATE).nc4
+    engine:
+      name: H5File
+      obsfile: $(DIAG_DIR)/diag_sfc_$(OBS_DATE).nc4
   io pool:
     max pool size: 1
   simulated variables: [surface_pressure]

--- a/parm/atm/obs/config/sondes.yaml
+++ b/parm/atm/obs/config/sondes.yaml
@@ -1,13 +1,17 @@
 obs space:
   name: sondes
   obsdatain:
-    obsfile: $(OBS_DIR)/$(OBS_PREFIX)sondes.$(OBS_DATE).nc4
+    engine:
+      name: H5File
+      obsfile: $(OBS_DIR)/$(OBS_PREFIX)sondes.$(OBS_DATE).nc4
     obsgrouping:
       group variables: ["station_id"]
       sort variable: "air_pressure"
       sort order: "descending"
   obsdataout:
-    obsfile: $(DIAG_DIR)/diag_sondes_$(OBS_DATE).nc4
+    engine:
+      name: H5File
+      obsfile: $(DIAG_DIR)/diag_sondes_$(OBS_DATE).nc4
   io pool:
     max pool size: 1
   simulated variables: [eastward_wind, northward_wind, air_temperature, specific_humidity, surface_pressure]

--- a/parm/atm/obs/config/sondes.yaml
+++ b/parm/atm/obs/config/sondes.yaml
@@ -2,7 +2,7 @@ obs space:
   name: sondes
   obsdatain:
     engine:
-      name: H5File
+      type: H5File
       obsfile: $(OBS_DIR)/$(OBS_PREFIX)sondes.$(OBS_DATE).nc4
     obsgrouping:
       group variables: ["station_id"]
@@ -10,7 +10,7 @@ obs space:
       sort order: "descending"
   obsdataout:
     engine:
-      name: H5File
+      type: H5File
       obsfile: $(DIAG_DIR)/diag_sondes_$(OBS_DATE).nc4
   io pool:
     max pool size: 1

--- a/parm/atm/obs/testing/sfc.yaml
+++ b/parm/atm/obs/testing/sfc.yaml
@@ -2,11 +2,11 @@ obs space:
   name: sfc
   obsdatain:
     engine:
-      name: H5File
+      type: H5File
       obsfile: sfc_obs_$(OBS_DATE).nc4
   obsdataout:
     engine:
-      name: H5File
+      type: H5File
       obsfile: sfc_diag_$(OBS_DATE).nc4
   simulated variables: [surface_pressure, air_temperature, virtual_temperature]
 geovals:

--- a/parm/atm/obs/testing/sfc.yaml
+++ b/parm/atm/obs/testing/sfc.yaml
@@ -1,9 +1,13 @@
 obs space:
   name: sfc
   obsdatain:
-    obsfile: sfc_obs_$(OBS_DATE).nc4
+    engine:
+      name: H5File
+      obsfile: sfc_obs_$(OBS_DATE).nc4
   obsdataout:
-    obsfile: sfc_diag_$(OBS_DATE).nc4
+    engine:
+      name: H5File
+      obsfile: sfc_diag_$(OBS_DATE).nc4
   simulated variables: [surface_pressure, air_temperature, virtual_temperature]
 geovals:
   filename: sfc_geoval_$(OBS_DATE).nc4

--- a/parm/atm/obs/testing/sondes_ps.yaml
+++ b/parm/atm/obs/testing/sondes_ps.yaml
@@ -2,11 +2,11 @@ obs space:
   name: sondes_ps
   obsdatain:
     engine:
-      name: H5File
+      type: H5File
       obsfile: sondes_ps_obs_$(OBS_DATE).nc4
   obsdataout:
     engine:
-      name: H5File
+      type: H5File
       obsfile: sondes_ps_diag_$(OBS_DATE).nc4
   simulated variables: [surface_pressure]
 geovals:

--- a/parm/atm/obs/testing/sondes_ps.yaml
+++ b/parm/atm/obs/testing/sondes_ps.yaml
@@ -1,9 +1,13 @@
 obs space:
   name: sondes_ps
   obsdatain:
-    obsfile: sondes_ps_obs_$(OBS_DATE).nc4
+    engine:
+      name: H5File
+      obsfile: sondes_ps_obs_$(OBS_DATE).nc4
   obsdataout:
-    obsfile: sondes_ps_diag_$(OBS_DATE).nc4
+    engine:
+      name: H5File
+      obsfile: sondes_ps_diag_$(OBS_DATE).nc4
   simulated variables: [surface_pressure]
 geovals:
   filename: sondes_ps_geoval_$(OBS_DATE).nc4

--- a/test/testinput/amsua_n19_ewok.yaml
+++ b/test/testinput/amsua_n19_ewok.yaml
@@ -2,11 +2,11 @@ obs space:
   name: amsua_n19
   obsdatain:
     engine:
-      name: H5File
+      type: H5File
       obsfile: $(experiment_dir)/{{current_cycle}}/amsua_n19.{{window_begin}}.nc4
   obsdataout:
     engine:
-      name: H5File
+      type: H5File
       obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).amsua_n19.{{window_begin}}.nc4
   simulated variables: [brightness_temperature]
   channels: &amsua_n19_channels 1-15

--- a/test/testinput/amsua_n19_ewok.yaml
+++ b/test/testinput/amsua_n19_ewok.yaml
@@ -1,9 +1,13 @@
 obs space:
   name: amsua_n19
   obsdatain:
-    obsfile: $(experiment_dir)/{{current_cycle}}/amsua_n19.{{window_begin}}.nc4
+    engine:
+      name: H5File
+      obsfile: $(experiment_dir)/{{current_cycle}}/amsua_n19.{{window_begin}}.nc4
   obsdataout:
-    obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).amsua_n19.{{window_begin}}.nc4
+    engine:
+      name: H5File
+      obsfile: $(experiment_dir)/{{current_cycle}}/$(experiment).amsua_n19.{{window_begin}}.nc4
   simulated variables: [brightness_temperature]
   channels: &amsua_n19_channels 1-15
 obs operator:

--- a/test/testreference/amsua_n19_gdas.yaml
+++ b/test/testreference/amsua_n19_gdas.yaml
@@ -2,11 +2,11 @@ obs space:
   name: amsua_n19
   obsdatain:
     engine:
-      name: H5File
+      type: H5File
       obsfile: $(OBS_DIR)/$(OBS_PREFIX)amsua_n19.$(OBS_DATE).nc4
   obsdataout:
     engine:
-      name: H5File
+      type: H5File
       obsfile: $(DIAG_DIR)/diag_amsua_n19_$(OBS_DATE).nc4
   simulated variables:
   - brightness_temperature

--- a/test/testreference/amsua_n19_gdas.yaml
+++ b/test/testreference/amsua_n19_gdas.yaml
@@ -1,9 +1,13 @@
 obs space:
   name: amsua_n19
   obsdatain:
-    obsfile: $(OBS_DIR)/$(OBS_PREFIX)amsua_n19.$(OBS_DATE).nc4
+    engine:
+      name: H5File
+      obsfile: $(OBS_DIR)/$(OBS_PREFIX)amsua_n19.$(OBS_DATE).nc4
   obsdataout:
-    obsfile: $(DIAG_DIR)/diag_amsua_n19_$(OBS_DATE).nc4
+    engine:
+      name: H5File
+      obsfile: $(DIAG_DIR)/diag_amsua_n19_$(OBS_DATE).nc4
   simulated variables:
   - brightness_temperature
   channels: 1-15

--- a/ush/convert_yaml_ewok2gdas.py
+++ b/ush/convert_yaml_ewok2gdas.py
@@ -19,14 +19,14 @@ def convert_yaml_ewok_to_gdas(ewokyaml, gdasyaml):
     # replace relevant YAML keys as appropriate
 
     # obs space input file
-    infile = ob_dict['obs space']['obsdatain']['obsfile']
+    infile = ob_dict['obs space']['obsdatain']['engine']['obsfile']
     obtype = infile.split('/')[2].split('.')[0]
     infile = f"$(OBS_DIR)/$(OBS_PREFIX){obtype}.$(OBS_DATE).nc4"
-    ob_dict['obs space']['obsdatain']['obsfile'] = infile
+    ob_dict['obs space']['obsdatain']['engine']['obsfile'] = infile
 
     # obs space output diag
     outfile = f"$(DIAG_DIR)/diag_{obtype}_$(OBS_DATE).nc4"
-    ob_dict['obs space']['obsdataout']['obsfile'] = outfile
+    ob_dict['obs space']['obsdataout']['engine']['obsfile'] = outfile
 
     # io pool to one
     ob_dict['obs space']['io pool'] = {'max pool size': 1}

--- a/ush/get_obs_list.py
+++ b/ush/get_obs_list.py
@@ -26,7 +26,7 @@ def get_obs_list(yamlconfig, outputfile):
     with open(outputfile, 'w') as outf:
         for ob in obs_list:
             # get obsdatain
-            obsdatain = ob['obs space']['obsdatain']['obsfile']
+            obsdatain = ob['obs space']['obsdatain']['engine']['obsfile']
             outf.write(f"{obsdatain}\n")
             if 'obs bias' in ob.keys():
                 biasin = ob['obs bias']['input file']

--- a/ush/ufsda/stage.py
+++ b/ush/ufsda/stage.py
@@ -149,7 +149,7 @@ def atm_obs(config):
         r2d2_config['provider'] = 'ncdiag'
         r2d2_config['start'] = config['window_begin']
         r2d2_config['end'] = r2d2_config['start']
-        target_file = ob['obs space']['obsdatain']['obsfile']
+        target_file = ob['obs space']['obsdatain']['engine']['obsfile']
         r2d2_config['target_file_fmt'] = target_file
         r2d2_config['obs_types'] = [ob['obs space']['name']]
         ufsda.r2d2.fetch(r2d2_config)
@@ -247,7 +247,7 @@ def gdas_single_cycle(config):
         r2d2_config['provider'] = 'ncdiag'
         r2d2_config['start'] = config['window_begin']
         r2d2_config['end'] = r2d2_config['start']
-        target_file = ob['obs space']['obsdatain']['obsfile']
+        target_file = ob['obs space']['obsdatain']['engine']['obsfile']
         r2d2_config['target_file_fmt'] = target_file
         r2d2_config['obs_types'] = [ob['obs space']['name']]
         ufsda.r2d2.fetch(r2d2_config)


### PR DESCRIPTION
Closes #152 

Thanks to a recent change in IODA, all `obsdatain` and `obsdataout` sections need to explicitly specify what 'engine' to use (in our case `H5File`) to read/write IODA files.

This PR updates the YAMLs and also (should) properly modify the python scripts that use these entries for file manipulation.