### PR TITLE
Create sfcship yaml files with QC filters

### DIFF
--- a/parm/atm/obs/config/sfcship.yaml
+++ b/parm/atm/obs/config/sfcship.yaml
@@ -1,0 +1,77 @@
+obs space:
+  name: sfcship
+  obsdatain:
+    engine:
+      type: H5File
+      obsfile: $(OBS_DIR)/$(OBS_PREFIX)sfcship.$(OBS_DATE).nc4
+  obsdataout:
+    engine:
+      type: H5File
+      obsfile: $(DIAG_DIR)/diag_sfcship_$(OBS_DATE).nc4
+      overwrite: true
+  io pool:
+    max pool size: 1
+  simulated variables: [surface_pressure, air_temperature, specific_humidity]
+get values:
+  interpolation method: $(INTERP_METHOD)
+obs operator:
+  name: Composite
+  components:
+    - name: VertInterp
+      variables:
+      - name: air_temperature
+      - name: specific_humidity
+    - name: SfcPCorrected
+      variables:
+      - name: surface_pressure
+      da_psfc_scheme: GSI
+      geovar_sfc_geomz: surface_geometric_height
+      geovar_geomz: geopotential_height
+linear obs operator:
+  name: Identity
+
+obs filters:
+  # Observation range sanity check
+  - filter: Bounds Check
+    filter variables:
+    - name: surface_pressure
+    minvalue: 37499
+    maxvalue: 106999
+    action:
+      name: reject
+    filter variables:
+    - name: air_temperature
+    minvalue: 195
+    maxvalue: 327
+    action:
+      name: reject
+    filter variables:
+    - name: specific_humidity
+    minvalue: 0
+    maxvalue: 0.03499
+    action:
+      name: reject
+
+  # Gross error check with (O - B) / ObsError greater than threshold.
+  - filter: Background Check
+    filter variables:
+    - name: surface_pressure
+    threshold: 3.6
+    absolute threshold: 990.0
+    action:
+      name: reject
+    defer to post: true
+    filter variables:
+    - name: air_temperature
+    threshold: 7.0
+    absolute threshold: 9.0
+    action:
+      name: reject
+    defer to post: true
+
+  # Reject all ObsType 183
+  - filter: BlackList
+    where:
+    - variable:
+        name: surface_pressure@ObsType
+      is_in: 183

--- a/parm/atm/obs/config/sfcship.yaml
+++ b/parm/atm/obs/config/sfcship.yaml
@@ -35,19 +35,19 @@ obs filters:
   - filter: Bounds Check
     filter variables:
     - name: surface_pressure
-    minvalue: 37499
-    maxvalue: 106999
+    minvalue: 37499.0
+    maxvalue: 106999.0
     action:
       name: reject
     filter variables:
     - name: air_temperature
-    minvalue: 195
-    maxvalue: 327
+    minvalue: 195.0
+    maxvalue: 327.0
     action:
       name: reject
     filter variables:
     - name: specific_humidity
-    minvalue: 0
+    minvalue: 0.0
     maxvalue: 0.03499
     action:
       name: reject
@@ -74,4 +74,4 @@ obs filters:
     where:
     - variable:
         name: surface_pressure@ObsType
-      is_in: 183
+      is_in: 183.0

--- a/parm/atm/obs/config/sfcship.yaml
+++ b/parm/atm/obs/config/sfcship.yaml
@@ -74,4 +74,4 @@ obs filters:
     where:
     - variable:
         name: surface_pressure@ObsType
-      is_in: 183.0
+      is_in: 183

--- a/parm/atm/obs/testing/sfcship.yaml
+++ b/parm/atm/obs/testing/sfcship.yaml
@@ -32,19 +32,19 @@ obs filters:
   - filter: Bounds Check
     filter variables:
     - name: surface_pressure
-    minvalue: 37499
-    maxvalue: 106999
+    minvalue: 37499.0
+    maxvalue: 106999.0
     action:
       name: reject
     filter variables:
     - name: air_temperature
-    minvalue: 195
-    maxvalue: 327
+    minvalue: 195.0
+    maxvalue: 327.0
     action:
       name: reject
     filter variables:
     - name: specific_humidity
-    minvalue: 0
+    minvalue: 0.0
     maxvalue: 0.03499
     action:
       name: reject
@@ -71,4 +71,4 @@ obs filters:
     where:
     - variable:
         name: surface_pressure@ObsType
-      is_in: 183
+      is_in: 183.0

--- a/parm/atm/obs/testing/sfcship.yaml
+++ b/parm/atm/obs/testing/sfcship.yaml
@@ -71,4 +71,4 @@ obs filters:
     where:
     - variable:
         name: surface_pressure@ObsType
-      is_in: 183.0
+      is_in: 183

--- a/parm/atm/obs/testing/sfcship.yaml
+++ b/parm/atm/obs/testing/sfcship.yaml
@@ -1,0 +1,74 @@
+obs space:
+  name: sfcship
+  obsdatain:
+    engine:
+      type: H5File
+      obsfile: sfcship_obs_$(OBS_DATE).nc4
+  obsdataout:
+    engine:
+      type: H5File
+      obsfile: sfcship_diag_$(OBS_DATE).nc4
+      overwrite: true
+  _source: ldm
+  simulated variables: [surface_pressure, air_temperature, specific_humidity]
+geovals:
+  filename: sfcship_geoval_$(OBS_DATE).nc4
+obs operator:
+  name: Composite
+  components:
+    - name: VertInterp
+      variables:
+      - name: air_temperature
+      - name: specific_humidity
+    - name: SfcPCorrected
+      variables:
+      - name: surface_pressure
+      da_psfc_scheme: GSI
+      geovar_sfc_geomz: surface_geometric_height
+      geovar_geomz: geopotential_height
+      
+obs filters:
+  # Observation range sanity check
+  - filter: Bounds Check
+    filter variables:
+    - name: surface_pressure
+    minvalue: 37499
+    maxvalue: 106999
+    action:
+      name: reject
+    filter variables:
+    - name: air_temperature
+    minvalue: 195
+    maxvalue: 327
+    action:
+      name: reject
+    filter variables:
+    - name: specific_humidity
+    minvalue: 0
+    maxvalue: 0.03499
+    action:
+      name: reject
+
+  # Gross error check with (O - B) / ObsError greater than threshold.
+  - filter: Background Check
+    filter variables:
+    - name: surface_pressure
+    threshold: 3.6
+    absolute threshold: 990.0
+    action:
+      name: reject
+    defer to post: true
+    filter variables:
+    - name: air_temperature
+    threshold: 7.0
+    absolute threshold: 9.0
+    action:
+      name: reject
+    defer to post: true
+
+  # Reject all ObsType 183
+  - filter: BlackList
+    where:
+    - variable:
+        name: surface_pressure@ObsType
+      is_in: 183


### PR DESCRIPTION
Added are yaml files for testing and config with QC filters applied and tested. Discussion of these filters can be found here [JEDI-T20#36](https://github.com/NOAA-EMC/JEDI-T2O/issues/36) about the filters being used, the data that is not accepted by GSI, but being accepted in JEDI, and some unanswered questions (mainly specific humidity).

The filters mainly come from the existing UFO yaml files [here](https://github.com/JCSDA-internal/ufo/blob/develop/ewok/skylab/ship.yaml), with the addition of blacklisting all observations from type 183. None of these observations were being assimilated in GSI.