### PR TITLE
Initial checkout of satwind.yaml for parm/atm/obs/testing/ and parm/atm/obs/config/

### DIFF
--- a/parm/atm/obs/config/satwind.yaml
+++ b/parm/atm/obs/config/satwind.yaml
@@ -13,141 +13,20 @@ obs space:
   simulated variables: [eastward_wind, northward_wind]
 get values:
   interpolation method: $(INTERP_METHOD)
-#
 obs operator:
   name: VertInterp
-#
-obs filters:
-  # Observation Range Sanity Check
-  - filter: Bounds Check
+obs pre filters:
+# Assign the initial observation error, based on height/pressure
+# Hard-wiring to prepobs_errtable.global by Type
+# ObsError is currently not updating in diag file, but passes directly to EffectiveError when no inflation is specified in YAML
+  # Type 240 (GOES SWIR): Assigned all dummy values in prepobs_errtable.global
+  - filter: Perform Action
     filter variables:
     - name: eastward_wind
     - name: northward_wind
-    minvalue: -130
-    maxvalue: 130
-    action:
-      name: reject
-  #
-  - filter: Bounds Check
-    filter variables:
-    - name: eastward_wind
-    - name: northward_wind
-    test variables:
-    - name: Velocity@ObsFunction
-    maxvalue: 130.0
-    action:
-      name: reject
-  #
-# - filter: Bounds Check
-#   filter variables:
-#   - name: eastward_wind
-#   - name: northward_wind
-#   test variables:
-#   - name: MetaData/satwind_quality_ind_no_fc
-#   minvalue: 80.0
-#   action:
-#     name: reject
-  # GOES IR (245), EUMET IR (253), JMA IR (252) reject when pressure between 400 and 800 mb.
-  - filter: Bounds Check
-    filter variables:
-    - name: eastward_wind
-    - name: northward_wind
-    test variables:
-    - name: MetaData/air_pressure
-    minvalue: 40000
-    maxvalue: 80000
     where:
-    - variable:
-        name: ObsType/eastward_wind
-      is_in: 245, 252, 253
-    action:
-      name: reject
-  # GOES WV (246, 250, 254), reject when pressure greater than 400 mb.
-  - filter: Bounds Check
-    filter variables:
-    - name: eastward_wind
-    - name: northward_wind
-    test variables:
-    - name: MetaData/air_pressure
-    maxvalue: 40000
-    where:
-    - variable:
-        name: ObsType/eastward_wind
-      is_in: 246, 250, 254
-    action:
-      name: reject
-  # EUMET (242) and JMA (243) vis, reject when pressure less than 700 mb.
-  - filter: Bounds Check
-    filter variables:
-    - name: eastward_wind
-    - name: northward_wind
-    test variables:
-    - name: MetaData/air_pressure
-    minvalue: 70000
-    where:
-    - variable:
-        name: ObsType/eastward_wind
-      is_in: 242, 243
-    action:
-      name: reject
-  # MODIS-Aqua/Terra (257) and (259), reject when pressure less than 250 mb.
-  - filter: Bounds Check
-    filter variables:
-    - name: eastward_wind
-    - name: northward_wind
-    test variables:
-    - name: MetaData/air_pressure
-    minvalue: 25000
-    where:
-    - variable:
-        name: ObsType/eastward_wind
-      is_in: 257-259
-    action:
-      name: reject
-  # MODIS-Aqua/Terra (258) and (259), reject when pressure greater than 600 mb.
-  - filter: Bounds Check
-    filter variables:
-    - name: eastward_wind
-    - name: northward_wind
-    test variables:
-    - name: MetaData/air_pressure
-    maxvalue: 60000
-    where:
-    - variable:
-        name: ObsType/eastward_wind
-      is_in: 258, 259
-    action:
-      name: reject
-  #
-  # Reject all obs with PreQC mark already set above 3
-  # - filter: PreQC
-  #   maxvalue: 3
-  #   action:
-  #     name: reject
-  #
-  # Multiple satellite platforms, reject when pressure is more than 50 mb above tropopause.
-  - filter: Difference Check
-    filter variables:
-    - name: eastward_wind
-    - name: northward_wind
-    reference: TropopauseEstimate@ObsFunction
-    value: MetaData/air_pressure
-    minvalue: -5000                    # 50 hPa above tropopause level, negative p-diff
-    action:
-      name: reject
-  # Difference check surface_pressure and ObsValue/air_pressure, if less than 100 hPa, reject.
-  - filter: Difference Check
-    filter variables:
-    - name: eastward_wind
-    - name: northward_wind
-    reference: GeoVaLs/surface_pressure
-    value: MetaData/air_pressure
-    maxvalue: -10000
-  # Assign the initial observation error, based on height/pressure
-  - filter: Bounds Check
-    filter variables:
-    - name: eastward_wind
-    - name: northward_wind
+    - variable: ObsType/eastward_wind
+      is_in: 240
     minvalue: -135
     maxvalue: 135
     action:
@@ -157,82 +36,849 @@ obs filters:
         options:
           xvar:
             name: MetaData/air_pressure
-          xvals: [100000, 95000, 80000, 65000, 60000, 55000, 50000, 45000, 40000, 35000, 30000, 25000, 20000, 15000, 10000]   #Pressure (Pa)
-          errors: [1.4, 1.5, 1.6, 1.8, 1.9, 2.0, 2.1, 2.3, 2.6, 2.8, 3.0, 3.2, 2.7, 2.4, 2.1]
-
-  # Reject when difference of wind direction is more than 50 degrees.
+          xvals: [110000,0]   #Pressure (Pa)
+          errors: [1000000000.,1000000000.]
+  # Type 241 (Multi Spec. Imager LWIR): Assigned all dummy values
+  - filter: Perform Action
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 241
+    minvalue: -135
+    maxvalue: 135
+    action:
+      name: assign error
+      error function:
+        name: ObsErrorModelStepwiseLinear@ObsFunction
+        options:
+          xvar:
+            name: MetaData/air_pressure
+          xvals: [110000,0]   #Pressure (Pa)
+          errors: [1000000000.,1000000000.]
+  # Type 242 (Himawari VIS)
+  - filter: Perform Action
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 242
+    minvalue: -135
+    maxvalue: 135
+    action:
+      name: assign error
+      error function:
+        name: ObsErrorModelStepwiseLinear@ObsFunction
+        options:
+          xvar:
+            name: MetaData/air_pressure
+          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          errors: [3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.9,3.9,4.,4.,4.1,5.,6.,6.3,6.6,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.]
+  # Type 243  (MVIRI/SEVIRI VIS)
+  - filter: Perform Action
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 243
+    minvalue: -135
+    maxvalue: 135
+    action:
+      name: assign error
+      error function:
+        name: ObsErrorModelStepwiseLinear@ObsFunction
+        options:
+          xvar:
+            name: MetaData/air_pressure
+          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          errors: [3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.9,3.9,4.,4.,4.1,5.,6.,6.3,6.6,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.]
+  # Type 244 (AVHRR LWIR)
+  - filter: Perform Action
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 244
+    minvalue: -135
+    maxvalue: 135
+    action:
+      name: assign error
+      error function:
+        name: ObsErrorModelStepwiseLinear@ObsFunction
+        options:
+          xvar:
+            name: MetaData/air_pressure
+          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          errors: [3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.9,3.9,4.,4.,4.1,5.,6.,6.3,6.6,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.]
+  # Type 245 (GOES LWIR): I am assuming these are halved relative to prepobs_errtable.global, based on read_satwnd.f90: L1410–1416
+  - filter: Perform Action
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 245
+    minvalue: -135
+    maxvalue: 135
+    action:
+      name: assign error
+      error function:
+        name: ObsErrorModelStepwiseLinear@ObsFunction
+        options:
+          xvar:
+            name: MetaData/air_pressure
+          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          errors: [7.6,7.6,7.6,7.6,7.6,7.6,7.6,7.6,7.8,7.8,8.,8.,8.2,10.,12.,12.6,13.2,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.]
+  # Type 246 (GOES cloud-top WV): I am assuming these are halved relative to prepobs_errtable.global, based on read_satwnd.f90: L1410–1416
+  - filter: Perform Action
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 246
+    minvalue: -135
+    maxvalue: 135
+    action:
+      name: assign error
+      error function:
+        name: ObsErrorModelStepwiseLinear@ObsFunction
+        options:
+          xvar:
+            name: MetaData/air_pressure
+          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          errors: [7.6,7.6,7.6,7.6,7.6,7.6,7.6,7.6,7.8,7.8,8.,8.,8.2,10.,12.,12.6,13.2,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.]
+  # Type 247 (GOES clear-sky WV): I am assuming these are halved relative to prepobs_errtable.global, based on read_satwnd.f90: L1410–1416
+  - filter: Perform Action
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 247
+    minvalue: -135
+    maxvalue: 135
+    action:
+      name: assign error
+      error function:
+        name: ObsErrorModelStepwiseLinear@ObsFunction
+        options:
+          xvar:
+            name: MetaData/air_pressure
+          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          errors: [7.6,7.6,7.6,7.6,7.6,7.6,7.6,7.6,7.8,7.8,8.,8.,8.2,10.,12.,12.6,13.2,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.]
+  # Type 248 (GOES Sounder cloud-top WV): Assigned all dummy values
+  - filter: Perform Action
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 248
+    minvalue: -135
+    maxvalue: 135
+    action:
+      name: assign error
+      error function:
+        name: ObsErrorModelStepwiseLinear@ObsFunction
+        options:
+          xvar:
+            name: MetaData/air_pressure
+          xvals: [110000,0]   #Pressure (Pa)
+          errors: [1000000000.,1000000000.]
+  # Type 249 (GOES Sounder clear-sky WV): Assigned all dummy values
+  - filter: Perform Action
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 249
+    minvalue: -135
+    maxvalue: 135
+    action:
+      name: assign error
+      error function:
+        name: ObsErrorModelStepwiseLinear@ObsFunction
+        options:
+          xvar:
+            name: MetaData/air_pressure
+          xvals: [110000,0]   #Pressure (Pa)
+          errors: [1000000000.,1000000000.]
+  # Type 250 (Himawari AHI WV, cloud-top or clear-sky)
+  - filter: Perform Action
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 250
+    minvalue: -135
+    maxvalue: 135
+    action:
+      name: assign error
+      error function:
+        name: ObsErrorModelStepwiseLinear@ObsFunction
+        options:
+          xvar:
+            name: MetaData/air_pressure
+          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          errors: [3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.9,3.9,4.,4.,4.1,5.,7.,7.3,7.6,8.,8.,8.,8.,8.,8.,8.,8.,8.,8.,8.,8.,8.,8.,8.,8.]
+  # Type 251 (GOES VIS): Assigned all dummy values
+  - filter: Perform Action
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 251
+    minvalue: -135
+    maxvalue: 135
+    action:
+      name: assign error
+      error function:
+        name: ObsErrorModelStepwiseLinear@ObsFunction
+        options:
+          xvar:
+            name: MetaData/air_pressure
+          xvals: [110000,0]   #Pressure (Pa)
+          errors: [1000000000.,1000000000.]
+  # Type 252 (Himawari AHI LWIR)
+  - filter: Perform Action
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 252
+    minvalue: -135
+    maxvalue: 135
+    action:
+      name: assign error
+      error function:
+        name: ObsErrorModelStepwiseLinear@ObsFunction
+        options:
+          xvar:
+            name: MetaData/air_pressure
+          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          errors: [3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.9,3.9,4.,4.,4.1,5.,6.,6.3,6.6,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.]
+  # Type 253 (MVIRI/SEVERI LWIR)
+  - filter: Perform Action
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 253
+    minvalue: -135
+    maxvalue: 135
+    action: 
+      name: assign error
+      error function:
+        name: ObsErrorModelStepwiseLinear@ObsFunction
+        options:
+          xvar:
+            name: MetaData/air_pressure
+          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          errors: [3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.9,3.9,4.,4.,4.1,5.,6.,6.3,6.6,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.]
+  # Type 254 (MVIRI/SEVIRI WV, both cloud-top and clear-sky)
+  - filter: Perform Action
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 254
+    minvalue: -135
+    maxvalue: 135
+    action:
+      name: assign error
+      error function:
+        name: ObsErrorModelStepwiseLinear@ObsFunction
+        options:
+          xvar:
+            name: MetaData/air_pressure
+          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          errors: [3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.9,3.9,4.,4.5,6.1,6.,6.5,7.3,7.6,7.,7.5,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.]
+  # Type 255 (GOES low-level picture triplet cloud drift): According to prepbufr table this should no longer exist??
+  - filter: Perform Action
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 255
+    minvalue: -135
+    maxvalue: 135
+    action:
+      name: assign error
+      error function:
+        name: ObsErrorModelStepwiseLinear@ObsFunction
+        options:
+          xvar:
+            name: MetaData/air_pressure
+          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          errors: [3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.9,3.9,4.,4.,4.1,5.,6.,6.3,6.6,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.]
+  # Type 256 (Multi Spec. Imager WV, both clear-sky and cloud-top): Assigned all dummy values
+  - filter: Perform Action
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 256
+    minvalue: -135
+    maxvalue: 135
+    action:
+      name: assign error
+      error function:
+        name: ObsErrorModelStepwiseLinear@ObsFunction
+        options:
+          xvar:
+            name: MetaData/air_pressure
+          xvals: [110000,0]   #Pressure (Pa)
+          errors: [1000000000.,1000000000.]
+  # Type 257 (MODIS LWIR)
+  - filter: Perform Action
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 257
+    minvalue: -135
+    maxvalue: 135
+    action: 
+      name: assign error
+      error function:
+        name: ObsErrorModelStepwiseLinear@ObsFunction
+        options:
+          xvar:
+            name: MetaData/air_pressure
+          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          errors: [3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.9,3.9,4.,4.,4.1,5.,6.,6.3,6.6,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.]
+  # Type 258 (MODIS cloud-top WV): Some levels assigned dummy values
+  - filter: Perform Action
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 258
+    minvalue: -135
+    maxvalue: 135
+    action:
+      name: assign error
+      error function:
+        name: ObsErrorModelStepwiseLinear@ObsFunction
+        options:
+          xvar:
+            name: MetaData/air_pressure
+          xvals: [110000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          errors: [1000000000.,1000000000.,4.,4.1,5.,6.,6.3,6.6,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.]
+  # Type 259 (MODIS clear-sky WV): Some levels assigned dummy values
+  - filter: Perform Action
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 259
+    minvalue: -135
+    maxvalue: 135
+    action:
+      name: assign error
+      error function:
+        name: ObsErrorModelStepwiseLinear@ObsFunction
+        options:
+          xvar:
+            name: MetaData/air_pressure
+          xvals: [110000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          errors: [1000000000.,1000000000.,4.,4.1,5.,6.,6.3,6.6,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.]
+  # Type 260 (VIIRS LWIR): All levels assigned dummy values in prepobs_errtable.global, HOWEVER the GSI values appear
+  #                        to be a standard profile (borrowed from e.g., Type=244). Using the standard profile here.
+  #                        It's possibly that my prepobs_errtable.global file is out-of-date.
+  - filter: Perform Action
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 260
+    minvalue: -135
+    maxvalue: 135
+    action:
+      name: assign error
+      error function:
+        name: ObsErrorModelStepwiseLinear@ObsFunction
+        options:
+          xvar:
+            name: MetaData/air_pressure
+          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          errors: [3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.9,3.9,4.,4.,4.1,5.,6.,6.3,6.6,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.]
+obs prior filters:
+  #
+  # sanity-check criteria
+  #
+  # Observation Range Sanity Check
+  # NOT EXPLICITLY CLEARED: No obs in this range in file, so 0 Bounds Check rejects (which is correct) but essentially untested
+  - filter: Bounds Check
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    minvalue: -130
+    maxvalue: 130
+    action:
+      name: reject
+  # Velocity Sanity Check
+  # NOT EXPLICITLY CLEARED: No obs in this range in file, so 0 Bounds Check rejects (which is correct) but essentially untested
   - filter: Bounds Check
     filter variables:
     - name: eastward_wind
     - name: northward_wind
     test variables:
+    - name: Velocity@ObsFunction
+    maxvalue: 130.0
+    action:
+      name: reject
+#
+# preQC (read_satwnd) criteria
+#
+# EUMETSAT winds: satelliteIdentifer [50–79] (>49, <80)
+  # Reject obs with satelliteZenithAngle > 68 deg
+  # NOT EXPLICITLY CLEARED: No obs in this range in file, so 0 Bounds Check rejects (which is correct) but essentially untested
+  - filter: Bounds Check
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: MetaData/satelliteIdentifier
+      minvalue: 49
+      maxvalue: 80
+    test variables:
+    - name: MetaData/satelliteZenithAngle
+    maxvalue: 68.
+    action:
+      name: reject
+  # Reject obs with windComputationMethod = 5 (clear-sky WV AMV)
+  # CLEARED
+  - filter: Bounds Check
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: MetaData/satelliteIdentifier
+      minvalue: 49
+      maxvalue: 80
+    test variables:
+    - name: MetaData/windComputationMethod
+    maxvalue: 4.
+    action:
+      name: reject
+  # Reject obs with qualityInformationWithoutForecast < 85.
+  # CLEARED
+  - filter: Bounds Check
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: MetaData/satelliteIdentifier
+      minvalue: 49
+      maxvalue: 80
+    test variables:
+    - name: MetaData/qualityInformationWithoutForecast 
+    minvalue: 85.
+    action:
+      name: reject
+# JMA: satelliteIdentifier [100–199] (>99, <200)
+  # Reject obs with satelliteZenithAngle > 68 deg
+  # NOT EXPLICITLY CLEARED: No obs in this range in file, so 0 Bounds Check rejects (which is correct) but essentially untested
+  - filter: Bounds Check
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: MetaData/satelliteIdentifier
+      minvalue: 99
+      maxvalue: 200
+    test variables:
+    - name: MetaData/satelliteZenithAngle
+    maxvalue: 68.
+    action:
+      name: reject
+  # Reject obs with windComputationMethod = 5 (clear-sky WV AMV)
+  # NOT EXPLICITLY CLEARED: No obs in this range in file, so 0 Bounds Check rejects (which is correct) but essentially untested
+  - filter: Bounds Check
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: MetaData/satelliteIdentifier
+      minvalue: 99
+      maxvalue: 200
+    test variables:
+    - name: MetaData/windComputationMethod
+    maxvalue: 4.
+    action:
+      name: reject
+  # Reject obs with qualityInformationWithoutForecast < 85.
+  # CLEARED
+  - filter: Bounds Check
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: MetaData/satelliteIdentifier
+      minvalue: 99
+      maxvalue: 200
+    test variables:
+    - name: MetaData/qualityInformationWithoutForecast
+    minvalue: 85.
+    action:
+      name: reject
+# NESDIS: satelliteIdentifier [250–299] (>249, <300)
+  # Reject obs with satelliteZenithAngle > 68 deg
+  # NOT EXPLICITLY CLEARED: No obs in this range in file, so 0 Bounds Check rejects (which is correct) but essentially untested
+  - filter: Bounds Check
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: MetaData/satelliteIdentifier
+      minvalue: 249
+      maxvalue: 300
+    test variables:
+    - name: MetaData/satelliteZenithAngle
+    maxvalue: 68.
+    action:
+      name: reject
+  # Reject obs with qualityInformationWithoutForecast < 90. OR > 100.
+  # CLEARED
+  - filter: Bounds Check
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: MetaData/satelliteIdentifier
+      minvalue: 249
+      maxvalue: 300
+    test variables:
+    - name: MetaData/qualityInformationWithoutForecast
+    minvalue: 90.
+    maxvalue: 100.
+    action:
+      name: reject
+  # Reject obs with air_pressure < 15000.
+  # CLEARED
+  - filter: Bounds Check
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: MetaData/satelliteIdentifier
+      minvalue: 249
+      maxvalue: 300
+    test variables:
+    - name: MetaData/air_pressure
+    minvalue: 15000.
+    action: 
+      name: reject
+  # Reject obs with air_pressure < 70000. when Type=251
+  # NOT EXPLICITLY CLEARED: No obs in this range in file, so 0 Bounds Check rejects (which is correct) but essentially untested
+  - filter: Bounds Check
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: MetaData/satelliteIdentifier
+      minvalue: 249
+      maxvalue: 300
+    - variable: ObsType/eastward_wind
+      is_in: 251
+    test variables:
+    - name: MetaData/air_pressure
+    minvalue: 70000.
+    action:
+      name: reject
+  # Reject obs with air_pressure > 30000. when Type=246
+  # CLEARED
+  - filter: Bounds Check
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: MetaData/satelliteIdentifier
+      minvalue: 249
+      maxvalue: 300
+    - variable: ObsType/eastward_wind
+      is_in: 246
+    test variables:
+    - name: MetaData/air_pressure
+    maxvalue: 30000.
+    action:
+      name: reject
+  # Reject obs with air_pressure > 85000. when isli=1 (land surface)
+  # CLEARED
+  - filter: Bounds Check
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: MetaData/satelliteIdentifier
+      minvalue: 249
+      maxvalue: 300
+    - variable: land_type_index_NPOESS@GeoVaLs
+      minvalue: 1.
+      maxvalue: 1.
+    test variables:
+    - name: MetaData/air_pressure
+    maxvalue: 85000.
+    action:
+      name: reject
+  # Reject obs with pct1 (Coeff. of Var.) outside of 0.04–0.5, Type [240,245,246,251] ONLY
+  # CLEARED
+  - filter: Bounds Check
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: MetaData/satelliteIdentifier
+      minvalue: 249
+      maxvalue: 300
+    - variable: ObsType/eastward_wind
+      is_in: 240,245,246,251
+    test variables:
+    - name: MetaData/coefficientOfVariation
+    minvalue: 0.04
+    maxvalue: 0.5
+    action:
+      name: reject
+# NESDIS obs are also subject to the experr_norm test defined as:
+#
+# if (10. - 0.1*(expectedError))/(ob_speed)>0.9, or ob_speed<0.1, reject, applies to Types [240,245,246,247,251]
+#
+# This is not implemented in the YAML file because we do not have the capability to compute
+# the norm, lacking the required math operators. Instead, this will likely have to be
+# implemented as an ObsFunction like the SatWindsLNVDCheck test.
+#
+# setupw criteria
+#
+  # Reject any ob Type [240–260] when pressure greater than 950 mb.
+  # CLEARED: minvalue/maxvalue are >=/<=, not >/<, so editing range by 1 Pa
+  - filter: Bounds Check
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 240-260
+    test variables:
+    - name: MetaData/air_pressure
+    maxvalue: 95001
+    action:
+      name: reject
+  # GOES IR (245) reject when pressure between 399 and 801 mb.
+  # CLEARED: minvalue/maxvalue are >=/<=, not >/<, so editing range by 1 Pa
+  - filter: Perform Action
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: MetaData/air_pressure
+      minvalue: 39901
+      maxvalue: 80099
+    - variable: ObsType/eastward_wind
+      is_in: 245
+    action:
+      name: reject
+  # JMA IR (252) reject when pressure between 499 and 801 mb.
+  # CLEARED: minvalue/maxvalue are >=/<=, not >/<, so editing range by 1 Pa
+  - filter: Perform Action
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: MetaData/air_pressure
+      minvalue: 49901
+      maxvalue: 80099
+    - variable: ObsType/eastward_wind
+      is_in: 252
+    action:
+      name: reject
+  # EUMETSAT IR (253) reject when pressure between 401 and 801 mb.
+  # CLEARED: minvalue/maxvalue are >=/<=, not >/<, so editing range by 1 Pa
+  - filter: Perform Action
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: MetaData/air_pressure
+      minvalue: 40101
+      maxvalue: 80099
+    - variable: ObsType/eastward_wind
+      is_in: 253
+    action:
+      name: reject
+  # GOES WV (246, 250, 254), reject when pressure greater than 399 mb.
+  # CLEARED: maxvalue is rejecting >, not >= as per a Perform Action, so threshold is unchanged
+  - filter: Bounds Check
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 246, 250, 254
+    test variables:
+    - name: MetaData/air_pressure
+    maxvalue: 39900
+    action:
+      name: reject
+  # EUMET (242) and JMA (243) vis, reject when pressure less than 700 mb.
+  # CLEARED: minvalue is rejecting <, not <= as per a Perform Action, so threshold is unchanged
+  - filter: Bounds Check
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 242, 243
+    test variables:
+    - name: MetaData/air_pressure
+    minvalue: 70000
+    action:
+      name: reject
+  # MODIS-Aqua/Terra (257) and (259), reject when pressure less than 249 mb.
+  # CLEARED: minvalue is rejecting <, not <= as per a Perform Action, so threshold is unchanged
+  - filter: Bounds Check
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 257,259
+    test variables:
+    - name: MetaData/air_pressure
+    minvalue: 24900
+    action:
+      name: reject
+  # MODIS-Aqua/Terra (258) and (259), reject when pressure greater than 600 mb.
+  # NOT EXPLICITLY CLEARED: No obs in this range in file, so 0 Bounds Check rejects (which is correct) but essentially untested
+  # maxvalue is rejecting >, not >= as per a Perform Action, so threshold is unchanged
+  - filter: Bounds Check
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 258, 259
+    test variables:
+    - name: MetaData/air_pressure
+    maxvalue: 60000
+    action:
+      name: reject
+  # Multiple satellite platforms, reject when pressure is more than 50 mb above tropopause.
+  # CLEARED: minvalue is rejecting <, not <= as per a Perform Action, so threshold is unchanged
+  - filter: Difference Check
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    reference: tropopause_pressure@GeoVaLs
+    value: MetaData/air_pressure
+    minvalue: -5000                    # 50 hPa above tropopause level, negative p-diff
+    action:
+      name: reject
+  # GOES (247) reject any observation with a /=0 surface type (non-water 
+  # surface) within 110 hPa of the surface pressure (as part of the LNVD
+  # check).
+  # NOT EXPLICITLY CLEARED: No obs in this range in file, so 0 Bounds Check rejects (which is correct) but essentially untested
+  - filter: Difference Check
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable:
+        name: land_type_index_NPOESS@GeoVaLs
+      minvalue: 1
+    - variable:
+        name: ObsType/eastward_wind
+      is_in: 247
+    reference: surface_pressure@GeoVaLs
+    value: MetaData/air_pressure
+    maxvalue: -11000                    # within 110 hPa above surface pressure, negative p-diff
+    action:
+      name: reject
+  # AVHRR (244), MODIS (257,258,259), and VIIRS (260) reject any 
+  # observation with a /=0 surface type (non-water surface) within
+  # 200 hPa of the surface pressure (as part of the LNVD check).
+  # CLEARED: maxvalue is rejecting >, not >= as per a Perform Action, so threshold is unchanged
+  - filter: Difference Check
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable:
+        name: land_type_index_NPOESS@GeoVaLs
+      minvalue: 1
+    - variable:
+        name: ObsType/eastward_wind
+      is_in: 244, 257-260
+    reference: surface_pressure@GeoVaLs
+    value: MetaData/air_pressure
+    maxvalue: -20000                    # within 200 hPa above surface pressure, negative p-diff
+    action:
+      name: reject
+obs post filters:
+  # Reject GOES (247) when difference of wind direction is more than 50 degrees.
+  # CLEARED: maxvalue is rejecting >, not >= as per a Perform Action, so threshold is unchanged
+  - filter: Bounds Check
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 247
+    test variables:
     - name: WindDirAngleDiff@ObsFunction
-      options:
-        minimum_uv: 3.5
     maxvalue: 50.0
     action:
       name: reject
-    defer to post: true
   # AVHRR (244), MODIS (257,258,259), VIIRS (260), GOES (247) use a LNVD check.
+  # CLEARED: maxvalue is rejecting >, not >= as per a Perform Action, so threshold is unchanged
   - filter: Bounds Check
     filter variables:
     - name: eastward_wind
     - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 244, 247, 257-260
     test variables:
     - name: SatWindsLNVDCheck@ObsFunction
     maxvalue: 3
-    where:
-    - variable:
-        name: ObsType/eastward_wind
-      is_in: 244, 247, 257-260
     action:
       name: reject
-    defer to post: true
-  # AVHRR and MODIS (ObsType=244,257,258,259) use a SPDB check.
-  - filter: Bounds Check
-    filter variables:
-    - name: eastward_wind
-    - name: northward_wind
-    test variables:
-    - name: SatWindsSPDBCheck@ObsFunction
-      options:
-        error_min: 1.4
-        error_max: 20.0
-    maxvalue: 1.75
-    where:
-      - variable:
-          name: ObsType/eastward_wind
-        is_in: 244, 257, 258, 259
-    action:
-      name: reject
-    defer to post: true
-  # GOES (ObsType=245,246,253,254) use a SPDB check only between 300-400 mb.
-  - filter: Bounds Check
-    filter variables:
-    - name: eastward_wind
-    - name: northward_wind
-    test variables:
-    - name: SatWindsSPDBCheck@ObsFunction
-      options:
-        error_min: 1.4
-        error_max: 20.0
-    maxvalue: 1.75
-    where:
-      - variable:
-          name: ObsType/eastward_wind
-        is_in: 244, 257, 258, 259
-      - variable:
-          name: MetaData/air_pressure
-        minvalue: 30000
-        maxvalue: 40000
-    action:
-      name: reject
-    defer to post: true
-  # Gross error check with (O - B) / ObsError greater than threshold.
-  - filter: Background Check
-    filter variables:
-    - name: eastward_wind
-    - name: northward_wind
-    threshold: 6.0
-    action:
-      name: reject
+  #
+  # All satwinds subject to a SPDB check (function may be broken?)
+  #   We are ignoring this filter for now, and will come back to
+  #   the issue of how to handle this SPDB check later. For now,
+  #   observations that are GSI-rejected based on this test are
+  #   not being considered when checking acceptance compliance.
+  #- filter: Bounds Check
+  #  filter variables:
+  #  - name: eastward_wind
+  #  - name: northward_wind
+  #  test variables:
+  #  - name: SatWindsSPDBCheck@ObsFunction
+  #    options:
+  #      error_min: 1.4
+  #      error_max: 20.0
+  #  maxvalue: 1.75
+  #  action:
+  #    name: reject
+  #  defer to post: true
+linear obs operator:
+  name: Identity
+

--- a/parm/atm/obs/config/satwind.yaml
+++ b/parm/atm/obs/config/satwind.yaml
@@ -27,8 +27,8 @@ obs pre filters:
     where:
     - variable: ObsType/eastward_wind
       is_in: 240
-    minvalue: -135
-    maxvalue: 135
+    minvalue: -135.
+    maxvalue: 135.
     action:
       name: assign error
       error function:
@@ -36,7 +36,7 @@ obs pre filters:
         options:
           xvar:
             name: MetaData/air_pressure
-          xvals: [110000,0]   #Pressure (Pa)
+          xvals: [110000.,0.]   #Pressure (Pa)
           errors: [1000000000.,1000000000.]
   # Type 241 (Multi Spec. Imager LWIR): Assigned all dummy values
   - filter: Perform Action
@@ -46,8 +46,8 @@ obs pre filters:
     where:
     - variable: ObsType/eastward_wind
       is_in: 241
-    minvalue: -135
-    maxvalue: 135
+    minvalue: -135.
+    maxvalue: 135.
     action:
       name: assign error
       error function:
@@ -55,7 +55,7 @@ obs pre filters:
         options:
           xvar:
             name: MetaData/air_pressure
-          xvals: [110000,0]   #Pressure (Pa)
+          xvals: [110000.,0.]   #Pressure (Pa)
           errors: [1000000000.,1000000000.]
   # Type 242 (Himawari VIS)
   - filter: Perform Action
@@ -65,8 +65,8 @@ obs pre filters:
     where:
     - variable: ObsType/eastward_wind
       is_in: 242
-    minvalue: -135
-    maxvalue: 135
+    minvalue: -135.
+    maxvalue: 135.
     action:
       name: assign error
       error function:
@@ -74,7 +74,7 @@ obs pre filters:
         options:
           xvar:
             name: MetaData/air_pressure
-          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          xvals: [110000.,105000.,100000.,95000.,90000.,85000.,80000.,75000.,70000.,65000.,60000.,55000.,50000.,45000.,40000.,35000.,30000.,25000.,20000.,15000.,10000.,7500.,5000.,4000.,3000.,2000.,1000.,500.,400.,300.,200.,100.,0.]   #Pressure (Pa)
           errors: [3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.9,3.9,4.,4.,4.1,5.,6.,6.3,6.6,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.]
   # Type 243  (MVIRI/SEVIRI VIS)
   - filter: Perform Action
@@ -84,8 +84,8 @@ obs pre filters:
     where:
     - variable: ObsType/eastward_wind
       is_in: 243
-    minvalue: -135
-    maxvalue: 135
+    minvalue: -135.
+    maxvalue: 135.
     action:
       name: assign error
       error function:
@@ -93,7 +93,7 @@ obs pre filters:
         options:
           xvar:
             name: MetaData/air_pressure
-          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          xvals: [110000.,105000.,100000.,95000.,90000.,85000.,80000.,75000.,70000.,65000.,60000.,55000.,50000.,45000.,40000.,35000.,30000.,25000.,20000.,15000.,10000.,7500.,5000.,4000.,3000.,2000.,1000.,500.,400.,300.,200.,100.,0.]   #Pressure (Pa)
           errors: [3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.9,3.9,4.,4.,4.1,5.,6.,6.3,6.6,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.]
   # Type 244 (AVHRR LWIR)
   - filter: Perform Action
@@ -103,8 +103,8 @@ obs pre filters:
     where:
     - variable: ObsType/eastward_wind
       is_in: 244
-    minvalue: -135
-    maxvalue: 135
+    minvalue: -135.
+    maxvalue: 135.
     action:
       name: assign error
       error function:
@@ -112,7 +112,7 @@ obs pre filters:
         options:
           xvar:
             name: MetaData/air_pressure
-          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          xvals: [110000.,105000.,100000.,95000.,90000.,85000.,80000.,75000.,70000.,65000.,60000.,55000.,50000.,45000.,40000.,35000.,30000.,25000.,20000.,15000.,10000.,7500.,5000.,4000.,3000.,2000.,1000.,500.,400.,300.,200.,100.,0.]   #Pressure (Pa)
           errors: [3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.9,3.9,4.,4.,4.1,5.,6.,6.3,6.6,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.]
   # Type 245 (GOES LWIR): I am assuming these are halved relative to prepobs_errtable.global, based on read_satwnd.f90: L1410–1416
   - filter: Perform Action
@@ -122,8 +122,8 @@ obs pre filters:
     where:
     - variable: ObsType/eastward_wind
       is_in: 245
-    minvalue: -135
-    maxvalue: 135
+    minvalue: -135.
+    maxvalue: 135.
     action:
       name: assign error
       error function:
@@ -131,7 +131,7 @@ obs pre filters:
         options:
           xvar:
             name: MetaData/air_pressure
-          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          xvals: [110000.,105000.,100000.,95000.,90000.,85000.,80000.,75000.,70000.,65000.,60000.,55000.,50000.,45000.,40000.,35000.,30000.,25000.,20000.,15000.,10000.,7500.,5000.,4000.,3000.,2000.,1000.,500.,400.,300.,200.,100.,0.]   #Pressure (Pa)
           errors: [7.6,7.6,7.6,7.6,7.6,7.6,7.6,7.6,7.8,7.8,8.,8.,8.2,10.,12.,12.6,13.2,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.]
   # Type 246 (GOES cloud-top WV): I am assuming these are halved relative to prepobs_errtable.global, based on read_satwnd.f90: L1410–1416
   - filter: Perform Action
@@ -141,8 +141,8 @@ obs pre filters:
     where:
     - variable: ObsType/eastward_wind
       is_in: 246
-    minvalue: -135
-    maxvalue: 135
+    minvalue: -135.
+    maxvalue: 135.
     action:
       name: assign error
       error function:
@@ -150,7 +150,7 @@ obs pre filters:
         options:
           xvar:
             name: MetaData/air_pressure
-          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          xvals: [110000.,105000.,100000.,95000.,90000.,85000.,80000.,75000.,70000.,65000.,60000.,55000.,50000.,45000.,40000.,35000.,30000.,25000.,20000.,15000.,10000.,7500.,5000.,4000.,3000.,2000.,1000.,500.,400.,300.,200.,100.,0.]   #Pressure (Pa)
           errors: [7.6,7.6,7.6,7.6,7.6,7.6,7.6,7.6,7.8,7.8,8.,8.,8.2,10.,12.,12.6,13.2,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.]
   # Type 247 (GOES clear-sky WV): I am assuming these are halved relative to prepobs_errtable.global, based on read_satwnd.f90: L1410–1416
   - filter: Perform Action
@@ -160,8 +160,8 @@ obs pre filters:
     where:
     - variable: ObsType/eastward_wind
       is_in: 247
-    minvalue: -135
-    maxvalue: 135
+    minvalue: -135.
+    maxvalue: 135.
     action:
       name: assign error
       error function:
@@ -169,7 +169,7 @@ obs pre filters:
         options:
           xvar:
             name: MetaData/air_pressure
-          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          xvals: [110000.,105000.,100000.,95000.,90000.,85000.,80000.,75000.,70000.,65000.,60000.,55000.,50000.,45000.,40000.,35000.,30000.,25000.,20000.,15000.,10000.,7500.,5000.,4000.,3000.,2000.,1000.,500.,400.,300.,200.,100.,0.]   #Pressure (Pa)
           errors: [7.6,7.6,7.6,7.6,7.6,7.6,7.6,7.6,7.8,7.8,8.,8.,8.2,10.,12.,12.6,13.2,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.]
   # Type 248 (GOES Sounder cloud-top WV): Assigned all dummy values
   - filter: Perform Action
@@ -179,8 +179,8 @@ obs pre filters:
     where:
     - variable: ObsType/eastward_wind
       is_in: 248
-    minvalue: -135
-    maxvalue: 135
+    minvalue: -135.
+    maxvalue: 135.
     action:
       name: assign error
       error function:
@@ -188,7 +188,7 @@ obs pre filters:
         options:
           xvar:
             name: MetaData/air_pressure
-          xvals: [110000,0]   #Pressure (Pa)
+          xvals: [110000.,0.]   #Pressure (Pa)
           errors: [1000000000.,1000000000.]
   # Type 249 (GOES Sounder clear-sky WV): Assigned all dummy values
   - filter: Perform Action
@@ -198,8 +198,8 @@ obs pre filters:
     where:
     - variable: ObsType/eastward_wind
       is_in: 249
-    minvalue: -135
-    maxvalue: 135
+    minvalue: -135.
+    maxvalue: 135.
     action:
       name: assign error
       error function:
@@ -207,7 +207,7 @@ obs pre filters:
         options:
           xvar:
             name: MetaData/air_pressure
-          xvals: [110000,0]   #Pressure (Pa)
+          xvals: [110000.,0.]   #Pressure (Pa)
           errors: [1000000000.,1000000000.]
   # Type 250 (Himawari AHI WV, cloud-top or clear-sky)
   - filter: Perform Action
@@ -217,8 +217,8 @@ obs pre filters:
     where:
     - variable: ObsType/eastward_wind
       is_in: 250
-    minvalue: -135
-    maxvalue: 135
+    minvalue: -135.
+    maxvalue: 135.
     action:
       name: assign error
       error function:
@@ -226,7 +226,7 @@ obs pre filters:
         options:
           xvar:
             name: MetaData/air_pressure
-          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          xvals: [110000.,105000.,100000.,95000.,90000.,85000.,80000.,75000.,70000.,65000.,60000.,55000.,50000.,45000.,40000.,35000.,30000.,25000.,20000.,15000.,10000.,7500.,5000.,4000.,3000.,2000.,1000.,500.,400.,300.,200.,100.,0.]   #Pressure (Pa)
           errors: [3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.9,3.9,4.,4.,4.1,5.,7.,7.3,7.6,8.,8.,8.,8.,8.,8.,8.,8.,8.,8.,8.,8.,8.,8.,8.,8.]
   # Type 251 (GOES VIS): Assigned all dummy values
   - filter: Perform Action
@@ -236,8 +236,8 @@ obs pre filters:
     where:
     - variable: ObsType/eastward_wind
       is_in: 251
-    minvalue: -135
-    maxvalue: 135
+    minvalue: -135.
+    maxvalue: 135.
     action:
       name: assign error
       error function:
@@ -245,7 +245,7 @@ obs pre filters:
         options:
           xvar:
             name: MetaData/air_pressure
-          xvals: [110000,0]   #Pressure (Pa)
+          xvals: [110000.,0.]   #Pressure (Pa)
           errors: [1000000000.,1000000000.]
   # Type 252 (Himawari AHI LWIR)
   - filter: Perform Action
@@ -255,8 +255,8 @@ obs pre filters:
     where:
     - variable: ObsType/eastward_wind
       is_in: 252
-    minvalue: -135
-    maxvalue: 135
+    minvalue: -135.
+    maxvalue: 135.
     action:
       name: assign error
       error function:
@@ -264,7 +264,7 @@ obs pre filters:
         options:
           xvar:
             name: MetaData/air_pressure
-          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          xvals: [110000.,105000.,100000.,95000.,90000.,85000.,80000.,75000.,70000.,65000.,60000.,55000.,50000.,45000.,40000.,35000.,30000.,25000.,20000.,15000.,10000.,7500.,5000.,4000.,3000.,2000.,1000.,500.,400.,300.,200.,100.,0.]   #Pressure (Pa)
           errors: [3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.9,3.9,4.,4.,4.1,5.,6.,6.3,6.6,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.]
   # Type 253 (MVIRI/SEVERI LWIR)
   - filter: Perform Action
@@ -274,8 +274,8 @@ obs pre filters:
     where:
     - variable: ObsType/eastward_wind
       is_in: 253
-    minvalue: -135
-    maxvalue: 135
+    minvalue: -135.
+    maxvalue: 135.
     action: 
       name: assign error
       error function:
@@ -283,7 +283,7 @@ obs pre filters:
         options:
           xvar:
             name: MetaData/air_pressure
-          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          xvals: [110000.,105000.,100000.,95000.,90000.,85000.,80000.,75000.,70000.,65000.,60000.,55000.,50000.,45000.,40000.,35000.,30000.,25000.,20000.,15000.,10000.,7500.,5000.,4000.,3000.,2000.,1000.,500.,400.,300.,200.,100.,0.]   #Pressure (Pa)
           errors: [3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.9,3.9,4.,4.,4.1,5.,6.,6.3,6.6,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.]
   # Type 254 (MVIRI/SEVIRI WV, both cloud-top and clear-sky)
   - filter: Perform Action
@@ -293,8 +293,8 @@ obs pre filters:
     where:
     - variable: ObsType/eastward_wind
       is_in: 254
-    minvalue: -135
-    maxvalue: 135
+    minvalue: -135.
+    maxvalue: 135.
     action:
       name: assign error
       error function:
@@ -302,7 +302,7 @@ obs pre filters:
         options:
           xvar:
             name: MetaData/air_pressure
-          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          xvals: [110000.,105000.,100000.,95000.,90000.,85000.,80000.,75000.,70000.,65000.,60000.,55000.,50000.,45000.,40000.,35000.,30000.,25000.,20000.,15000.,10000.,7500.,5000.,4000.,3000.,2000.,1000.,500.,400.,300.,200.,100.,0.]   #Pressure (Pa)
           errors: [3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.9,3.9,4.,4.5,6.1,6.,6.5,7.3,7.6,7.,7.5,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.]
   # Type 255 (GOES low-level picture triplet cloud drift): According to prepbufr table this should no longer exist??
   - filter: Perform Action
@@ -312,8 +312,8 @@ obs pre filters:
     where:
     - variable: ObsType/eastward_wind
       is_in: 255
-    minvalue: -135
-    maxvalue: 135
+    minvalue: -135.
+    maxvalue: 135.
     action:
       name: assign error
       error function:
@@ -321,7 +321,7 @@ obs pre filters:
         options:
           xvar:
             name: MetaData/air_pressure
-          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          xvals: [110000.,105000.,100000.,95000.,90000.,85000.,80000.,75000.,70000.,65000.,60000.,55000.,50000.,45000.,40000.,35000.,30000.,25000.,20000.,15000.,10000.,7500.,5000.,4000.,3000.,2000.,1000.,500.,400.,300.,200.,100.,0.]   #Pressure (Pa)
           errors: [3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.9,3.9,4.,4.,4.1,5.,6.,6.3,6.6,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.]
   # Type 256 (Multi Spec. Imager WV, both clear-sky and cloud-top): Assigned all dummy values
   - filter: Perform Action
@@ -331,8 +331,8 @@ obs pre filters:
     where:
     - variable: ObsType/eastward_wind
       is_in: 256
-    minvalue: -135
-    maxvalue: 135
+    minvalue: -135.
+    maxvalue: 135.
     action:
       name: assign error
       error function:
@@ -340,7 +340,7 @@ obs pre filters:
         options:
           xvar:
             name: MetaData/air_pressure
-          xvals: [110000,0]   #Pressure (Pa)
+          xvals: [110000.,0.]   #Pressure (Pa)
           errors: [1000000000.,1000000000.]
   # Type 257 (MODIS LWIR)
   - filter: Perform Action
@@ -350,8 +350,8 @@ obs pre filters:
     where:
     - variable: ObsType/eastward_wind
       is_in: 257
-    minvalue: -135
-    maxvalue: 135
+    minvalue: -135.
+    maxvalue: 135.
     action: 
       name: assign error
       error function:
@@ -359,7 +359,7 @@ obs pre filters:
         options:
           xvar:
             name: MetaData/air_pressure
-          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          xvals: [110000.,105000.,100000.,95000.,90000.,85000.,80000.,75000.,70000.,65000.,60000.,55000.,50000.,45000.,40000.,35000.,30000.,25000.,20000.,15000.,10000.,7500.,5000.,4000.,3000.,2000.,1000.,500.,400.,300.,200.,100.,0.]   #Pressure (Pa)
           errors: [3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.9,3.9,4.,4.,4.1,5.,6.,6.3,6.6,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.]
   # Type 258 (MODIS cloud-top WV): Some levels assigned dummy values
   - filter: Perform Action
@@ -369,8 +369,8 @@ obs pre filters:
     where:
     - variable: ObsType/eastward_wind
       is_in: 258
-    minvalue: -135
-    maxvalue: 135
+    minvalue: -135.
+    maxvalue: 135.
     action:
       name: assign error
       error function:
@@ -378,7 +378,7 @@ obs pre filters:
         options:
           xvar:
             name: MetaData/air_pressure
-          xvals: [110000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          xvals: [110000.,60000.,55000.,50000.,45000.,40000.,35000.,30000.,25000.,20000.,15000.,10000.,7500.,5000.,4000.,3000.,2000.,1000.,500.,400.,300.,200.,100.,0.]   #Pressure (Pa)
           errors: [1000000000.,1000000000.,4.,4.1,5.,6.,6.3,6.6,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.]
   # Type 259 (MODIS clear-sky WV): Some levels assigned dummy values
   - filter: Perform Action
@@ -388,8 +388,8 @@ obs pre filters:
     where:
     - variable: ObsType/eastward_wind
       is_in: 259
-    minvalue: -135
-    maxvalue: 135
+    minvalue: -135.
+    maxvalue: 135.
     action:
       name: assign error
       error function:
@@ -397,7 +397,7 @@ obs pre filters:
         options:
           xvar:
             name: MetaData/air_pressure
-          xvals: [110000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          xvals: [110000.,60000.,55000.,50000.,45000.,40000.,35000.,30000.,25000.,20000.,15000.,10000.,7500.,5000.,4000.,3000.,2000.,1000.,500.,400.,300.,200.,100.,0.]   #Pressure (Pa)
           errors: [1000000000.,1000000000.,4.,4.1,5.,6.,6.3,6.6,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.]
   # Type 260 (VIIRS LWIR): All levels assigned dummy values in prepobs_errtable.global, HOWEVER the GSI values appear
   #                        to be a standard profile (borrowed from e.g., Type=244). Using the standard profile here.
@@ -409,8 +409,8 @@ obs pre filters:
     where:
     - variable: ObsType/eastward_wind
       is_in: 260
-    minvalue: -135
-    maxvalue: 135
+    minvalue: -135.
+    maxvalue: 135.
     action:
       name: assign error
       error function:
@@ -418,7 +418,7 @@ obs pre filters:
         options:
           xvar:
             name: MetaData/air_pressure
-          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          xvals: [110000.,105000.,100000.,95000.,90000.,85000.,80000.,75000.,70000.,65000.,60000.,55000.,50000.,45000.,40000.,35000.,30000.,25000.,20000.,15000.,10000.,7500.,5000.,4000.,3000.,2000.,1000.,500.,400.,300.,200.,100.,0.]   #Pressure (Pa)
           errors: [3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.9,3.9,4.,4.,4.1,5.,6.,6.3,6.6,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.]
 obs prior filters:
   #
@@ -430,8 +430,8 @@ obs prior filters:
     filter variables:
     - name: eastward_wind
     - name: northward_wind
-    minvalue: -130
-    maxvalue: 130
+    minvalue: -130.
+    maxvalue: 130.
     action:
       name: reject
   # Velocity Sanity Check
@@ -442,7 +442,7 @@ obs prior filters:
     - name: northward_wind
     test variables:
     - name: Velocity@ObsFunction
-    maxvalue: 130.0
+    maxvalue: 130.
     action:
       name: reject
 #
@@ -457,8 +457,8 @@ obs prior filters:
     - name: northward_wind
     where:
     - variable: MetaData/satelliteIdentifier
-      minvalue: 49
-      maxvalue: 80
+      minvalue: 49.
+      maxvalue: 80.
     test variables:
     - name: MetaData/satelliteZenithAngle
     maxvalue: 68.
@@ -472,8 +472,8 @@ obs prior filters:
     - name: northward_wind
     where:
     - variable: MetaData/satelliteIdentifier
-      minvalue: 49
-      maxvalue: 80
+      minvalue: 49.
+      maxvalue: 80.
     test variables:
     - name: MetaData/windComputationMethod
     maxvalue: 4.
@@ -487,8 +487,8 @@ obs prior filters:
     - name: northward_wind
     where:
     - variable: MetaData/satelliteIdentifier
-      minvalue: 49
-      maxvalue: 80
+      minvalue: 49.
+      maxvalue: 80.
     test variables:
     - name: MetaData/qualityInformationWithoutForecast 
     minvalue: 85.
@@ -503,8 +503,8 @@ obs prior filters:
     - name: northward_wind
     where:
     - variable: MetaData/satelliteIdentifier
-      minvalue: 99
-      maxvalue: 200
+      minvalue: 99.
+      maxvalue: 200.
     test variables:
     - name: MetaData/satelliteZenithAngle
     maxvalue: 68.
@@ -518,8 +518,8 @@ obs prior filters:
     - name: northward_wind
     where:
     - variable: MetaData/satelliteIdentifier
-      minvalue: 99
-      maxvalue: 200
+      minvalue: 99.
+      maxvalue: 200.
     test variables:
     - name: MetaData/windComputationMethod
     maxvalue: 4.
@@ -533,8 +533,8 @@ obs prior filters:
     - name: northward_wind
     where:
     - variable: MetaData/satelliteIdentifier
-      minvalue: 99
-      maxvalue: 200
+      minvalue: 99.
+      maxvalue: 200.
     test variables:
     - name: MetaData/qualityInformationWithoutForecast
     minvalue: 85.
@@ -549,8 +549,8 @@ obs prior filters:
     - name: northward_wind
     where:
     - variable: MetaData/satelliteIdentifier
-      minvalue: 249
-      maxvalue: 300
+      minvalue: 249.
+      maxvalue: 300.
     test variables:
     - name: MetaData/satelliteZenithAngle
     maxvalue: 68.
@@ -564,8 +564,8 @@ obs prior filters:
     - name: northward_wind
     where:
     - variable: MetaData/satelliteIdentifier
-      minvalue: 249
-      maxvalue: 300
+      minvalue: 249.
+      maxvalue: 300.
     test variables:
     - name: MetaData/qualityInformationWithoutForecast
     minvalue: 90.
@@ -580,8 +580,8 @@ obs prior filters:
     - name: northward_wind
     where:
     - variable: MetaData/satelliteIdentifier
-      minvalue: 249
-      maxvalue: 300
+      minvalue: 249.
+      maxvalue: 300.
     test variables:
     - name: MetaData/air_pressure
     minvalue: 15000.
@@ -595,8 +595,8 @@ obs prior filters:
     - name: northward_wind
     where:
     - variable: MetaData/satelliteIdentifier
-      minvalue: 249
-      maxvalue: 300
+      minvalue: 249.
+      maxvalue: 300.
     - variable: ObsType/eastward_wind
       is_in: 251
     test variables:
@@ -612,8 +612,8 @@ obs prior filters:
     - name: northward_wind
     where:
     - variable: MetaData/satelliteIdentifier
-      minvalue: 249
-      maxvalue: 300
+      minvalue: 249.
+      maxvalue: 300.
     - variable: ObsType/eastward_wind
       is_in: 246
     test variables:
@@ -629,8 +629,8 @@ obs prior filters:
     - name: northward_wind
     where:
     - variable: MetaData/satelliteIdentifier
-      minvalue: 249
-      maxvalue: 300
+      minvalue: 249.
+      maxvalue: 300.
     - variable: land_type_index_NPOESS@GeoVaLs
       minvalue: 1.
       maxvalue: 1.
@@ -647,8 +647,8 @@ obs prior filters:
     - name: northward_wind
     where:
     - variable: MetaData/satelliteIdentifier
-      minvalue: 249
-      maxvalue: 300
+      minvalue: 249.
+      maxvalue: 300.
     - variable: ObsType/eastward_wind
       is_in: 240,245,246,251
     test variables:
@@ -678,7 +678,7 @@ obs prior filters:
       is_in: 240-260
     test variables:
     - name: MetaData/air_pressure
-    maxvalue: 95001
+    maxvalue: 95001.
     action:
       name: reject
   # GOES IR (245) reject when pressure between 399 and 801 mb.
@@ -689,8 +689,8 @@ obs prior filters:
     - name: northward_wind
     where:
     - variable: MetaData/air_pressure
-      minvalue: 39901
-      maxvalue: 80099
+      minvalue: 39901.
+      maxvalue: 80099.
     - variable: ObsType/eastward_wind
       is_in: 245
     action:
@@ -703,8 +703,8 @@ obs prior filters:
     - name: northward_wind
     where:
     - variable: MetaData/air_pressure
-      minvalue: 49901
-      maxvalue: 80099
+      minvalue: 49901.
+      maxvalue: 80099.
     - variable: ObsType/eastward_wind
       is_in: 252
     action:
@@ -717,8 +717,8 @@ obs prior filters:
     - name: northward_wind
     where:
     - variable: MetaData/air_pressure
-      minvalue: 40101
-      maxvalue: 80099
+      minvalue: 40101.
+      maxvalue: 80099.
     - variable: ObsType/eastward_wind
       is_in: 253
     action:
@@ -734,7 +734,7 @@ obs prior filters:
       is_in: 246, 250, 254
     test variables:
     - name: MetaData/air_pressure
-    maxvalue: 39900
+    maxvalue: 39900.
     action:
       name: reject
   # EUMET (242) and JMA (243) vis, reject when pressure less than 700 mb.
@@ -748,7 +748,7 @@ obs prior filters:
       is_in: 242, 243
     test variables:
     - name: MetaData/air_pressure
-    minvalue: 70000
+    minvalue: 70000.
     action:
       name: reject
   # MODIS-Aqua/Terra (257) and (259), reject when pressure less than 249 mb.
@@ -762,7 +762,7 @@ obs prior filters:
       is_in: 257,259
     test variables:
     - name: MetaData/air_pressure
-    minvalue: 24900
+    minvalue: 24900.
     action:
       name: reject
   # MODIS-Aqua/Terra (258) and (259), reject when pressure greater than 600 mb.
@@ -777,7 +777,7 @@ obs prior filters:
       is_in: 258, 259
     test variables:
     - name: MetaData/air_pressure
-    maxvalue: 60000
+    maxvalue: 60000.
     action:
       name: reject
   # Multiple satellite platforms, reject when pressure is more than 50 mb above tropopause.
@@ -788,7 +788,7 @@ obs prior filters:
     - name: northward_wind
     reference: tropopause_pressure@GeoVaLs
     value: MetaData/air_pressure
-    minvalue: -5000                    # 50 hPa above tropopause level, negative p-diff
+    minvalue: -5000.                   # 50 hPa above tropopause level, negative p-diff
     action:
       name: reject
   # GOES (247) reject any observation with a /=0 surface type (non-water 
@@ -802,13 +802,13 @@ obs prior filters:
     where:
     - variable:
         name: land_type_index_NPOESS@GeoVaLs
-      minvalue: 1
+      minvalue: 1.
     - variable:
         name: ObsType/eastward_wind
       is_in: 247
     reference: surface_pressure@GeoVaLs
     value: MetaData/air_pressure
-    maxvalue: -11000                    # within 110 hPa above surface pressure, negative p-diff
+    maxvalue: -11000.                   # within 110 hPa above surface pressure, negative p-diff
     action:
       name: reject
   # AVHRR (244), MODIS (257,258,259), and VIIRS (260) reject any 
@@ -822,13 +822,13 @@ obs prior filters:
     where:
     - variable:
         name: land_type_index_NPOESS@GeoVaLs
-      minvalue: 1
+      minvalue: 1.
     - variable:
         name: ObsType/eastward_wind
       is_in: 244, 257-260
     reference: surface_pressure@GeoVaLs
     value: MetaData/air_pressure
-    maxvalue: -20000                    # within 200 hPa above surface pressure, negative p-diff
+    maxvalue: -20000.                   # within 200 hPa above surface pressure, negative p-diff
     action:
       name: reject
 obs post filters:
@@ -843,7 +843,7 @@ obs post filters:
       is_in: 247
     test variables:
     - name: WindDirAngleDiff@ObsFunction
-    maxvalue: 50.0
+    maxvalue: 50.
     action:
       name: reject
   # AVHRR (244), MODIS (257,258,259), VIIRS (260), GOES (247) use a LNVD check.
@@ -857,7 +857,7 @@ obs post filters:
       is_in: 244, 247, 257-260
     test variables:
     - name: SatWindsLNVDCheck@ObsFunction
-    maxvalue: 3
+    maxvalue: 3.
     action:
       name: reject
   #

--- a/parm/atm/obs/testing/satwind.yaml
+++ b/parm/atm/obs/testing/satwind.yaml
@@ -27,8 +27,8 @@ obs pre filters:
     where:
     - variable: ObsType/eastward_wind
       is_in: 240
-    minvalue: -135
-    maxvalue: 135
+    minvalue: -135.
+    maxvalue: 135.
     action:
       name: assign error
       error function:
@@ -36,7 +36,7 @@ obs pre filters:
         options:
           xvar:
             name: MetaData/air_pressure
-          xvals: [110000,0]   #Pressure (Pa)
+          xvals: [110000.,0.]   #Pressure (Pa)
           errors: [1000000000.,1000000000.]
   # Type 241 (Multi Spec. Imager LWIR): Assigned all dummy values
   - filter: Perform Action
@@ -46,8 +46,8 @@ obs pre filters:
     where:
     - variable: ObsType/eastward_wind
       is_in: 241
-    minvalue: -135
-    maxvalue: 135
+    minvalue: -135.
+    maxvalue: 135.
     action:
       name: assign error
       error function:
@@ -55,7 +55,7 @@ obs pre filters:
         options:
           xvar:
             name: MetaData/air_pressure
-          xvals: [110000,0]   #Pressure (Pa)
+          xvals: [110000.,0.]   #Pressure (Pa)
           errors: [1000000000.,1000000000.]
   # Type 242 (Himawari VIS)
   - filter: Perform Action
@@ -65,8 +65,8 @@ obs pre filters:
     where:
     - variable: ObsType/eastward_wind
       is_in: 242
-    minvalue: -135
-    maxvalue: 135
+    minvalue: -135.
+    maxvalue: 135.
     action:
       name: assign error
       error function:
@@ -74,7 +74,7 @@ obs pre filters:
         options:
           xvar:
             name: MetaData/air_pressure
-          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          xvals: [110000.,105000.,100000.,95000.,90000.,85000.,80000.,75000.,70000.,65000.,60000.,55000.,50000.,45000.,40000.,35000.,30000.,25000.,20000.,15000.,10000.,7500.,5000.,4000.,3000.,2000.,1000.,500.,400.,300.,200.,100.,0.]   #Pressure (Pa)
           errors: [3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.9,3.9,4.,4.,4.1,5.,6.,6.3,6.6,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.]
   # Type 243  (MVIRI/SEVIRI VIS)
   - filter: Perform Action
@@ -84,8 +84,8 @@ obs pre filters:
     where:
     - variable: ObsType/eastward_wind
       is_in: 243
-    minvalue: -135
-    maxvalue: 135
+    minvalue: -135.
+    maxvalue: 135.
     action:
       name: assign error
       error function:
@@ -93,7 +93,7 @@ obs pre filters:
         options:
           xvar:
             name: MetaData/air_pressure
-          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          xvals: [110000.,105000.,100000.,95000.,90000.,85000.,80000.,75000.,70000.,65000.,60000.,55000.,50000.,45000.,40000.,35000.,30000.,25000.,20000.,15000.,10000.,7500.,5000.,4000.,3000.,2000.,1000.,500.,400.,300.,200.,100.,0.]   #Pressure (Pa)
           errors: [3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.9,3.9,4.,4.,4.1,5.,6.,6.3,6.6,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.]
   # Type 244 (AVHRR LWIR)
   - filter: Perform Action
@@ -103,8 +103,8 @@ obs pre filters:
     where:
     - variable: ObsType/eastward_wind
       is_in: 244
-    minvalue: -135
-    maxvalue: 135
+    minvalue: -135.
+    maxvalue: 135.
     action:
       name: assign error
       error function:
@@ -112,7 +112,7 @@ obs pre filters:
         options:
           xvar:
             name: MetaData/air_pressure
-          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          xvals: [110000.,105000.,100000.,95000.,90000.,85000.,80000.,75000.,70000.,65000.,60000.,55000.,50000.,45000.,40000.,35000.,30000.,25000.,20000.,15000.,10000.,7500.,5000.,4000.,3000.,2000.,1000.,500.,400.,300.,200.,100.,0.]   #Pressure (Pa)
           errors: [3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.9,3.9,4.,4.,4.1,5.,6.,6.3,6.6,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.]
   # Type 245 (GOES LWIR): I am assuming these are halved relative to prepobs_errtable.global, based on read_satwnd.f90: L1410–1416
   - filter: Perform Action
@@ -122,8 +122,8 @@ obs pre filters:
     where:
     - variable: ObsType/eastward_wind
       is_in: 245
-    minvalue: -135
-    maxvalue: 135
+    minvalue: -135.
+    maxvalue: 135.
     action:
       name: assign error
       error function:
@@ -131,7 +131,7 @@ obs pre filters:
         options:
           xvar:
             name: MetaData/air_pressure
-          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          xvals: [110000.,105000.,100000.,95000.,90000.,85000.,80000.,75000.,70000.,65000.,60000.,55000.,50000.,45000.,40000.,35000.,30000.,25000.,20000.,15000.,10000.,7500.,5000.,4000.,3000.,2000.,1000.,500.,400.,300.,200.,100.,0.]   #Pressure (Pa)
           errors: [7.6,7.6,7.6,7.6,7.6,7.6,7.6,7.6,7.8,7.8,8.,8.,8.2,10.,12.,12.6,13.2,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.]
   # Type 246 (GOES cloud-top WV): I am assuming these are halved relative to prepobs_errtable.global, based on read_satwnd.f90: L1410–1416
   - filter: Perform Action
@@ -141,8 +141,8 @@ obs pre filters:
     where:
     - variable: ObsType/eastward_wind
       is_in: 246
-    minvalue: -135
-    maxvalue: 135
+    minvalue: -135.
+    maxvalue: 135.
     action:
       name: assign error
       error function:
@@ -150,7 +150,7 @@ obs pre filters:
         options:
           xvar:
             name: MetaData/air_pressure
-          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          xvals: [110000.,105000.,100000.,95000.,90000.,85000.,80000.,75000.,70000.,65000.,60000.,55000.,50000.,45000.,40000.,35000.,30000.,25000.,20000.,15000.,10000.,7500.,5000.,4000.,3000.,2000.,1000.,500.,400.,300.,200.,100.,0.]   #Pressure (Pa)
           errors: [7.6,7.6,7.6,7.6,7.6,7.6,7.6,7.6,7.8,7.8,8.,8.,8.2,10.,12.,12.6,13.2,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.]
   # Type 247 (GOES clear-sky WV): I am assuming these are halved relative to prepobs_errtable.global, based on read_satwnd.f90: L1410–1416
   - filter: Perform Action
@@ -160,8 +160,8 @@ obs pre filters:
     where:
     - variable: ObsType/eastward_wind
       is_in: 247
-    minvalue: -135
-    maxvalue: 135
+    minvalue: -135.
+    maxvalue: 135.
     action:
       name: assign error
       error function:
@@ -169,7 +169,7 @@ obs pre filters:
         options:
           xvar:
             name: MetaData/air_pressure
-          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          xvals: [110000.,105000.,100000.,95000.,90000.,85000.,80000.,75000.,70000.,65000.,60000.,55000.,50000.,45000.,40000.,35000.,30000.,25000.,20000.,15000.,10000.,7500.,5000.,4000.,3000.,2000.,1000.,500.,400.,300.,200.,100.,0.]   #Pressure (Pa)
           errors: [7.6,7.6,7.6,7.6,7.6,7.6,7.6,7.6,7.8,7.8,8.,8.,8.2,10.,12.,12.6,13.2,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.]
   # Type 248 (GOES Sounder cloud-top WV): Assigned all dummy values
   - filter: Perform Action
@@ -179,8 +179,8 @@ obs pre filters:
     where:
     - variable: ObsType/eastward_wind
       is_in: 248
-    minvalue: -135
-    maxvalue: 135
+    minvalue: -135.
+    maxvalue: 135.
     action:
       name: assign error
       error function:
@@ -188,7 +188,7 @@ obs pre filters:
         options:
           xvar:
             name: MetaData/air_pressure
-          xvals: [110000,0]   #Pressure (Pa)
+          xvals: [110000.,0.]   #Pressure (Pa)
           errors: [1000000000.,1000000000.]
   # Type 249 (GOES Sounder clear-sky WV): Assigned all dummy values
   - filter: Perform Action
@@ -198,8 +198,8 @@ obs pre filters:
     where:
     - variable: ObsType/eastward_wind
       is_in: 249
-    minvalue: -135
-    maxvalue: 135
+    minvalue: -135.
+    maxvalue: 135.
     action:
       name: assign error
       error function:
@@ -207,7 +207,7 @@ obs pre filters:
         options:
           xvar:
             name: MetaData/air_pressure
-          xvals: [110000,0]   #Pressure (Pa)
+          xvals: [110000.,0.]   #Pressure (Pa)
           errors: [1000000000.,1000000000.]
   # Type 250 (Himawari AHI WV, cloud-top or clear-sky)
   - filter: Perform Action
@@ -217,8 +217,8 @@ obs pre filters:
     where:
     - variable: ObsType/eastward_wind
       is_in: 250
-    minvalue: -135
-    maxvalue: 135
+    minvalue: -135.
+    maxvalue: 135.
     action:
       name: assign error
       error function:
@@ -226,7 +226,7 @@ obs pre filters:
         options:
           xvar:
             name: MetaData/air_pressure
-          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          xvals: [110000.,105000.,100000.,95000.,90000.,85000.,80000.,75000.,70000.,65000.,60000.,55000.,50000.,45000.,40000.,35000.,30000.,25000.,20000.,15000.,10000.,7500.,5000.,4000.,3000.,2000.,1000.,500.,400.,300.,200.,100.,0.]   #Pressure (Pa)
           errors: [3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.9,3.9,4.,4.,4.1,5.,7.,7.3,7.6,8.,8.,8.,8.,8.,8.,8.,8.,8.,8.,8.,8.,8.,8.,8.,8.]
   # Type 251 (GOES VIS): Assigned all dummy values
   - filter: Perform Action
@@ -236,8 +236,8 @@ obs pre filters:
     where:
     - variable: ObsType/eastward_wind
       is_in: 251
-    minvalue: -135
-    maxvalue: 135
+    minvalue: -135.
+    maxvalue: 135.
     action:
       name: assign error
       error function:
@@ -245,7 +245,7 @@ obs pre filters:
         options:
           xvar:
             name: MetaData/air_pressure
-          xvals: [110000,0]   #Pressure (Pa)
+          xvals: [110000.,0.]   #Pressure (Pa)
           errors: [1000000000.,1000000000.]
   # Type 252 (Himawari AHI LWIR)
   - filter: Perform Action
@@ -255,8 +255,8 @@ obs pre filters:
     where:
     - variable: ObsType/eastward_wind
       is_in: 252
-    minvalue: -135
-    maxvalue: 135
+    minvalue: -135.
+    maxvalue: 135.
     action:
       name: assign error
       error function:
@@ -264,7 +264,7 @@ obs pre filters:
         options:
           xvar:
             name: MetaData/air_pressure
-          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          xvals: [110000.,105000.,100000.,95000.,90000.,85000.,80000.,75000.,70000.,65000.,60000.,55000.,50000.,45000.,40000.,35000.,30000.,25000.,20000.,15000.,10000.,7500.,5000.,4000.,3000.,2000.,1000.,500.,400.,300.,200.,100.,0.]   #Pressure (Pa)
           errors: [3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.9,3.9,4.,4.,4.1,5.,6.,6.3,6.6,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.]
   # Type 253 (MVIRI/SEVERI LWIR)
   - filter: Perform Action
@@ -274,8 +274,8 @@ obs pre filters:
     where:
     - variable: ObsType/eastward_wind
       is_in: 253
-    minvalue: -135
-    maxvalue: 135
+    minvalue: -135.
+    maxvalue: 135.
     action: 
       name: assign error
       error function:
@@ -283,7 +283,7 @@ obs pre filters:
         options:
           xvar:
             name: MetaData/air_pressure
-          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          xvals: [110000.,105000.,100000.,95000.,90000.,85000.,80000.,75000.,70000.,65000.,60000.,55000.,50000.,45000.,40000.,35000.,30000.,25000.,20000.,15000.,10000.,7500.,5000.,4000.,3000.,2000.,1000.,500.,400.,300.,200.,100.,0.]   #Pressure (Pa)
           errors: [3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.9,3.9,4.,4.,4.1,5.,6.,6.3,6.6,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.]
   # Type 254 (MVIRI/SEVIRI WV, both cloud-top and clear-sky)
   - filter: Perform Action
@@ -293,8 +293,8 @@ obs pre filters:
     where:
     - variable: ObsType/eastward_wind
       is_in: 254
-    minvalue: -135
-    maxvalue: 135
+    minvalue: -135.
+    maxvalue: 135.
     action:
       name: assign error
       error function:
@@ -302,7 +302,7 @@ obs pre filters:
         options:
           xvar:
             name: MetaData/air_pressure
-          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          xvals: [110000.,105000.,100000.,95000.,90000.,85000.,80000.,75000.,70000.,65000.,60000.,55000.,50000.,45000.,40000.,35000.,30000.,25000.,20000.,15000.,10000.,7500.,5000.,4000.,3000.,2000.,1000.,500.,400.,300.,200.,100.,0.]   #Pressure (Pa)
           errors: [3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.9,3.9,4.,4.5,6.1,6.,6.5,7.3,7.6,7.,7.5,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.]
   # Type 255 (GOES low-level picture triplet cloud drift): According to prepbufr table this should no longer exist??
   - filter: Perform Action
@@ -312,8 +312,8 @@ obs pre filters:
     where:
     - variable: ObsType/eastward_wind
       is_in: 255
-    minvalue: -135
-    maxvalue: 135
+    minvalue: -135.
+    maxvalue: 135.
     action:
       name: assign error
       error function:
@@ -321,7 +321,7 @@ obs pre filters:
         options:
           xvar:
             name: MetaData/air_pressure
-          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          xvals: [110000.,105000.,100000.,95000.,90000.,85000.,80000.,75000.,70000.,65000.,60000.,55000.,50000.,45000.,40000.,35000.,30000.,25000.,20000.,15000.,10000.,7500.,5000.,4000.,3000.,2000.,1000.,500.,400.,300.,200.,100.,0.]   #Pressure (Pa)
           errors: [3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.9,3.9,4.,4.,4.1,5.,6.,6.3,6.6,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.]
   # Type 256 (Multi Spec. Imager WV, both clear-sky and cloud-top): Assigned all dummy values
   - filter: Perform Action
@@ -331,8 +331,8 @@ obs pre filters:
     where:
     - variable: ObsType/eastward_wind
       is_in: 256
-    minvalue: -135
-    maxvalue: 135
+    minvalue: -135.
+    maxvalue: 135.
     action:
       name: assign error
       error function:
@@ -340,7 +340,7 @@ obs pre filters:
         options:
           xvar:
             name: MetaData/air_pressure
-          xvals: [110000,0]   #Pressure (Pa)
+          xvals: [110000.,0.]   #Pressure (Pa)
           errors: [1000000000.,1000000000.]
   # Type 257 (MODIS LWIR)
   - filter: Perform Action
@@ -350,8 +350,8 @@ obs pre filters:
     where:
     - variable: ObsType/eastward_wind
       is_in: 257
-    minvalue: -135
-    maxvalue: 135
+    minvalue: -135.
+    maxvalue: 135.
     action: 
       name: assign error
       error function:
@@ -359,7 +359,7 @@ obs pre filters:
         options:
           xvar:
             name: MetaData/air_pressure
-          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          xvals: [110000.,105000.,100000.,95000.,90000.,85000.,80000.,75000.,70000.,65000.,60000.,55000.,50000.,45000.,40000.,35000.,30000.,25000.,20000.,15000.,10000.,7500.,5000.,4000.,3000.,2000.,1000.,500.,400.,300.,200.,100.,0.]   #Pressure (Pa)
           errors: [3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.9,3.9,4.,4.,4.1,5.,6.,6.3,6.6,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.]
   # Type 258 (MODIS cloud-top WV): Some levels assigned dummy values
   - filter: Perform Action
@@ -369,8 +369,8 @@ obs pre filters:
     where:
     - variable: ObsType/eastward_wind
       is_in: 258
-    minvalue: -135
-    maxvalue: 135
+    minvalue: -135.
+    maxvalue: 135.
     action:
       name: assign error
       error function:
@@ -378,7 +378,7 @@ obs pre filters:
         options:
           xvar:
             name: MetaData/air_pressure
-          xvals: [110000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          xvals: [110000.,60000.,55000.,50000.,45000.,40000.,35000.,30000.,25000.,20000.,15000.,10000.,7500.,5000.,4000.,3000.,2000.,1000.,500.,400.,300.,200.,100.,0.]   #Pressure (Pa)
           errors: [1000000000.,1000000000.,4.,4.1,5.,6.,6.3,6.6,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.]
   # Type 259 (MODIS clear-sky WV): Some levels assigned dummy values
   - filter: Perform Action
@@ -388,8 +388,8 @@ obs pre filters:
     where:
     - variable: ObsType/eastward_wind
       is_in: 259
-    minvalue: -135
-    maxvalue: 135
+    minvalue: -135.
+    maxvalue: 135.
     action:
       name: assign error
       error function:
@@ -397,7 +397,7 @@ obs pre filters:
         options:
           xvar:
             name: MetaData/air_pressure
-          xvals: [110000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          xvals: [110000.,60000.,55000.,50000.,45000.,40000.,35000.,30000.,25000.,20000.,15000.,10000.,7500.,5000.,4000.,3000.,2000.,1000.,500.,400.,300.,200.,100.,0.]   #Pressure (Pa)
           errors: [1000000000.,1000000000.,4.,4.1,5.,6.,6.3,6.6,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.]
   # Type 260 (VIIRS LWIR): All levels assigned dummy values in prepobs_errtable.global, HOWEVER the GSI values appear
   #                        to be a standard profile (borrowed from e.g., Type=244). Using the standard profile here.
@@ -409,8 +409,8 @@ obs pre filters:
     where:
     - variable: ObsType/eastward_wind
       is_in: 260
-    minvalue: -135
-    maxvalue: 135
+    minvalue: -135.
+    maxvalue: 135.
     action:
       name: assign error
       error function:
@@ -418,7 +418,7 @@ obs pre filters:
         options:
           xvar:
             name: MetaData/air_pressure
-          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          xvals: [110000.,105000.,100000.,95000.,90000.,85000.,80000.,75000.,70000.,65000.,60000.,55000.,50000.,45000.,40000.,35000.,30000.,25000.,20000.,15000.,10000.,7500.,5000.,4000.,3000.,2000.,1000.,500.,400.,300.,200.,100.,0.]   #Pressure (Pa)
           errors: [3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.9,3.9,4.,4.,4.1,5.,6.,6.3,6.6,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.]
 obs prior filters:
   #
@@ -430,8 +430,8 @@ obs prior filters:
     filter variables:
     - name: eastward_wind
     - name: northward_wind
-    minvalue: -130
-    maxvalue: 130
+    minvalue: -130.
+    maxvalue: 130.
     action:
       name: reject
   # Velocity Sanity Check
@@ -442,7 +442,7 @@ obs prior filters:
     - name: northward_wind
     test variables:
     - name: Velocity@ObsFunction
-    maxvalue: 130.0
+    maxvalue: 130.
     action:
       name: reject
 #
@@ -457,8 +457,8 @@ obs prior filters:
     - name: northward_wind
     where:
     - variable: MetaData/satelliteIdentifier
-      minvalue: 49
-      maxvalue: 80
+      minvalue: 49.
+      maxvalue: 80.
     test variables:
     - name: MetaData/satelliteZenithAngle
     maxvalue: 68.
@@ -472,8 +472,8 @@ obs prior filters:
     - name: northward_wind
     where:
     - variable: MetaData/satelliteIdentifier
-      minvalue: 49
-      maxvalue: 80
+      minvalue: 49.
+      maxvalue: 80.
     test variables:
     - name: MetaData/windComputationMethod
     maxvalue: 4.
@@ -487,8 +487,8 @@ obs prior filters:
     - name: northward_wind
     where:
     - variable: MetaData/satelliteIdentifier
-      minvalue: 49
-      maxvalue: 80
+      minvalue: 49.
+      maxvalue: 80.
     test variables:
     - name: MetaData/qualityInformationWithoutForecast 
     minvalue: 85.
@@ -503,8 +503,8 @@ obs prior filters:
     - name: northward_wind
     where:
     - variable: MetaData/satelliteIdentifier
-      minvalue: 99
-      maxvalue: 200
+      minvalue: 99.
+      maxvalue: 200.
     test variables:
     - name: MetaData/satelliteZenithAngle
     maxvalue: 68.
@@ -518,8 +518,8 @@ obs prior filters:
     - name: northward_wind
     where:
     - variable: MetaData/satelliteIdentifier
-      minvalue: 99
-      maxvalue: 200
+      minvalue: 99.
+      maxvalue: 200.
     test variables:
     - name: MetaData/windComputationMethod
     maxvalue: 4.
@@ -533,8 +533,8 @@ obs prior filters:
     - name: northward_wind
     where:
     - variable: MetaData/satelliteIdentifier
-      minvalue: 99
-      maxvalue: 200
+      minvalue: 99.
+      maxvalue: 200.
     test variables:
     - name: MetaData/qualityInformationWithoutForecast
     minvalue: 85.
@@ -549,8 +549,8 @@ obs prior filters:
     - name: northward_wind
     where:
     - variable: MetaData/satelliteIdentifier
-      minvalue: 249
-      maxvalue: 300
+      minvalue: 249.
+      maxvalue: 300.
     test variables:
     - name: MetaData/satelliteZenithAngle
     maxvalue: 68.
@@ -564,8 +564,8 @@ obs prior filters:
     - name: northward_wind
     where:
     - variable: MetaData/satelliteIdentifier
-      minvalue: 249
-      maxvalue: 300
+      minvalue: 249.
+      maxvalue: 300.
     test variables:
     - name: MetaData/qualityInformationWithoutForecast
     minvalue: 90.
@@ -580,8 +580,8 @@ obs prior filters:
     - name: northward_wind
     where:
     - variable: MetaData/satelliteIdentifier
-      minvalue: 249
-      maxvalue: 300
+      minvalue: 249.
+      maxvalue: 300.
     test variables:
     - name: MetaData/air_pressure
     minvalue: 15000.
@@ -595,8 +595,8 @@ obs prior filters:
     - name: northward_wind
     where:
     - variable: MetaData/satelliteIdentifier
-      minvalue: 249
-      maxvalue: 300
+      minvalue: 249.
+      maxvalue: 300.
     - variable: ObsType/eastward_wind
       is_in: 251
     test variables:
@@ -612,8 +612,8 @@ obs prior filters:
     - name: northward_wind
     where:
     - variable: MetaData/satelliteIdentifier
-      minvalue: 249
-      maxvalue: 300
+      minvalue: 249.
+      maxvalue: 300.
     - variable: ObsType/eastward_wind
       is_in: 246
     test variables:
@@ -629,8 +629,8 @@ obs prior filters:
     - name: northward_wind
     where:
     - variable: MetaData/satelliteIdentifier
-      minvalue: 249
-      maxvalue: 300
+      minvalue: 249.
+      maxvalue: 300.
     - variable: land_type_index_NPOESS@GeoVaLs
       minvalue: 1.
       maxvalue: 1.
@@ -647,8 +647,8 @@ obs prior filters:
     - name: northward_wind
     where:
     - variable: MetaData/satelliteIdentifier
-      minvalue: 249
-      maxvalue: 300
+      minvalue: 249.
+      maxvalue: 300.
     - variable: ObsType/eastward_wind
       is_in: 240,245,246,251
     test variables:
@@ -678,7 +678,7 @@ obs prior filters:
       is_in: 240-260
     test variables:
     - name: MetaData/air_pressure
-    maxvalue: 95001
+    maxvalue: 95001.
     action:
       name: reject
   # GOES IR (245) reject when pressure between 399 and 801 mb.
@@ -689,8 +689,8 @@ obs prior filters:
     - name: northward_wind
     where:
     - variable: MetaData/air_pressure
-      minvalue: 39901
-      maxvalue: 80099
+      minvalue: 39901.
+      maxvalue: 80099.
     - variable: ObsType/eastward_wind
       is_in: 245
     action:
@@ -703,8 +703,8 @@ obs prior filters:
     - name: northward_wind
     where:
     - variable: MetaData/air_pressure
-      minvalue: 49901
-      maxvalue: 80099
+      minvalue: 49901.
+      maxvalue: 80099.
     - variable: ObsType/eastward_wind
       is_in: 252
     action:
@@ -717,8 +717,8 @@ obs prior filters:
     - name: northward_wind
     where:
     - variable: MetaData/air_pressure
-      minvalue: 40101
-      maxvalue: 80099
+      minvalue: 40101.
+      maxvalue: 80099.
     - variable: ObsType/eastward_wind
       is_in: 253
     action:
@@ -734,7 +734,7 @@ obs prior filters:
       is_in: 246, 250, 254
     test variables:
     - name: MetaData/air_pressure
-    maxvalue: 39900
+    maxvalue: 39900.
     action:
       name: reject
   # EUMET (242) and JMA (243) vis, reject when pressure less than 700 mb.
@@ -748,7 +748,7 @@ obs prior filters:
       is_in: 242, 243
     test variables:
     - name: MetaData/air_pressure
-    minvalue: 70000
+    minvalue: 70000.
     action:
       name: reject
   # MODIS-Aqua/Terra (257) and (259), reject when pressure less than 249 mb.
@@ -762,7 +762,7 @@ obs prior filters:
       is_in: 257,259
     test variables:
     - name: MetaData/air_pressure
-    minvalue: 24900
+    minvalue: 24900.
     action:
       name: reject
   # MODIS-Aqua/Terra (258) and (259), reject when pressure greater than 600 mb.
@@ -777,7 +777,7 @@ obs prior filters:
       is_in: 258, 259
     test variables:
     - name: MetaData/air_pressure
-    maxvalue: 60000
+    maxvalue: 60000.
     action:
       name: reject
   # Multiple satellite platforms, reject when pressure is more than 50 mb above tropopause.
@@ -788,7 +788,7 @@ obs prior filters:
     - name: northward_wind
     reference: tropopause_pressure@GeoVaLs
     value: MetaData/air_pressure
-    minvalue: -5000                    # 50 hPa above tropopause level, negative p-diff
+    minvalue: -5000.                   # 50 hPa above tropopause level, negative p-diff
     action:
       name: reject
   # GOES (247) reject any observation with a /=0 surface type (non-water 
@@ -802,13 +802,13 @@ obs prior filters:
     where:
     - variable:
         name: land_type_index_NPOESS@GeoVaLs
-      minvalue: 1
+      minvalue: 1.
     - variable:
         name: ObsType/eastward_wind
       is_in: 247
     reference: surface_pressure@GeoVaLs
     value: MetaData/air_pressure
-    maxvalue: -11000                    # within 110 hPa above surface pressure, negative p-diff
+    maxvalue: -11000.                   # within 110 hPa above surface pressure, negative p-diff
     action:
       name: reject
   # AVHRR (244), MODIS (257,258,259), and VIIRS (260) reject any 
@@ -822,13 +822,13 @@ obs prior filters:
     where:
     - variable:
         name: land_type_index_NPOESS@GeoVaLs
-      minvalue: 1
+      minvalue: 1.
     - variable:
         name: ObsType/eastward_wind
       is_in: 244, 257-260
     reference: surface_pressure@GeoVaLs
     value: MetaData/air_pressure
-    maxvalue: -20000                    # within 200 hPa above surface pressure, negative p-diff
+    maxvalue: -20000.                   # within 200 hPa above surface pressure, negative p-diff
     action:
       name: reject
 obs post filters:
@@ -843,7 +843,7 @@ obs post filters:
       is_in: 247
     test variables:
     - name: WindDirAngleDiff@ObsFunction
-    maxvalue: 50.0
+    maxvalue: 50.
     action:
       name: reject
   # AVHRR (244), MODIS (257,258,259), VIIRS (260), GOES (247) use a LNVD check.
@@ -857,7 +857,7 @@ obs post filters:
       is_in: 244, 247, 257-260
     test variables:
     - name: SatWindsLNVDCheck@ObsFunction
-    maxvalue: 3
+    maxvalue: 3.
     action:
       name: reject
   #

--- a/parm/atm/obs/testing/satwind.yaml
+++ b/parm/atm/obs/testing/satwind.yaml
@@ -8,8 +8,6 @@ obs space:
     engine:
       type: H5File
       obsfile: satwind_diag_$(OBS_DATE).nc4
-  io pool:
-    max pool size: 1
   simulated variables: [eastward_wind, northward_wind]
 geovals:
   filename: satwind_geoval_$(OBS_DATE).nc4

--- a/satwind.yaml
+++ b/satwind.yaml
@@ -17,13 +17,10 @@ vector ref: GsiHofXBc
 tolerance: 0.01
 obs operator:
   name: VertInterp
-# Temporarily forcing pre filters as only filters, to change back and add prior/post filters,
-# replace 'obs filters' with 'obs pre filters' in this section
-#obs pre filters:
-obs filters:
-  # Assign the initial observation error, based on height/pressure
-  # Hard-wiring to prepobs_errtable.global by Type
-  # ObsError is currently not updating, but passes directly to EffectiveError when no inflation is specified in YAML
+obs pre filters:
+# Assign the initial observation error, based on height/pressure
+# Hard-wiring to prepobs_errtable.global by Type
+# ObsError is currently not updating in diag file, but passes directly to EffectiveError when no inflation is specified in YAML
   # Type 240 (GOES SWIR): Assigned all dummy values in prepobs_errtable.global
   - filter: Perform Action
     filter variables:
@@ -404,7 +401,9 @@ obs filters:
             name: MetaData/air_pressure
           xvals: [110000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
           errors: [1000000000.,1000000000.,4.,4.1,5.,6.,6.3,6.6,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.]
-  # Type 260 (VIIRS LWIR): All levels assigned dummy values
+  # Type 260 (VIIRS LWIR): All levels assigned dummy values in prepobs_errtable.global, HOWEVER the GSI values appear
+  #                        to be a standard profile (borrowed from e.g., Type=244). Using the standard profile here.
+  #                        It's possibly that my prepobs_errtable.global file is out-of-date.
   - filter: Perform Action
     filter variables:
     - name: eastward_wind
@@ -421,432 +420,448 @@ obs filters:
         options:
           xvar:
             name: MetaData/air_pressure
-          xvals: [110000,0]   #Pressure (Pa)
-          errors: [1000000000.,1000000000.]
-#obs prior filters:
+          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          errors: [3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.9,3.9,4.,4.,4.1,5.,6.,6.3,6.6,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.]
+obs prior filters:
   #
   # sanity-check criteria
   #
   # Observation Range Sanity Check
-#  - filter: Bounds Check
-#    filter variables:
-#    - name: eastward_wind
-#    - name: northward_wind
-#    minvalue: -130
-#    maxvalue: 130
-#    action:
-#      name: reject
+  # NOT EXPLICITLY CLEARED: No obs in this range in file, so 0 Bounds Check rejects (which is correct) but essentially untested
+  - filter: Bounds Check
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    minvalue: -130
+    maxvalue: 130
+    action:
+      name: reject
   # Velocity Sanity Check
-#  - filter: Bounds Check
-#    filter variables:
-#    - name: eastward_wind
-#    - name: northward_wind
-#    test variables:
-#    - name: Velocity@ObsFunction
-#    maxvalue: 130.0
-#    action:
-#      name: reject
-  # Reject any ob with PreQC of 9, 12, or 15
-  #   These are flags inherited from read_satwnd.f90 based on
-  #   multiple criteria. Eventually that criteria should be
-  #   replicated in JEDI instead of being read in from GSI,
-  #   but for now we will use the provided PreQC flags
-#  - filter: Perform Action
-#    filter variables:
-#    - name: eastward_wind
-#    - name: northward_wind
-#    where:
-#    - variable: PreQC/eastward_wind
-#      is_in: 9, 12, 15
-#    action:
-#      name: reject
+  # NOT EXPLICITLY CLEARED: No obs in this range in file, so 0 Bounds Check rejects (which is correct) but essentially untested
+  - filter: Bounds Check
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    test variables:
+    - name: Velocity@ObsFunction
+    maxvalue: 130.0
+    action:
+      name: reject
 #
 # preQC (read_satwnd) criteria
 #
-# EUMETSAT winds: satelliteIdentifer [50–99]
+# EUMETSAT winds: satelliteIdentifer [50–79] (>49, <80)
   # Reject obs with satelliteZenithAngle > 68 deg
-#  - filter: Bounds Check
-#    filter variables:
-#    - name: eastward_wind
-#    - name: northward_wind
-#    where:
-#    - variable: MetaData/satelliteIdentifier
-#      minvalue: 50
-#      maxvalue: 79
-#    test variables:
-#    - name: MetaData/satelliteZenithAngle
-#    maxvalue: 68.
-#    action:
-#      name: reject
+  # NOT EXPLICITLY CLEARED: No obs in this range in file, so 0 Bounds Check rejects (which is correct) but essentially untested
+  - filter: Bounds Check
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: MetaData/satelliteIdentifier
+      minvalue: 49
+      maxvalue: 80
+    test variables:
+    - name: MetaData/satelliteZenithAngle
+    maxvalue: 68.
+    action:
+      name: reject
   # Reject obs with windComputationMethod = 5 (clear-sky WV AMV)
-#  - filter: Bounds Check
-#    filter variables:
-#    - name: eastward_wind
-#    - name: northward_wind
-#    where:
-#    - variable: MetaData/satelliteIdentifier
-#      minvalue: 50
-#      maxvalue: 79
-#    test variables:
-#    - name: MetaData/windComputationMethod
-#    maxvalue: 4.
-#    action:
-#      name: reject
+  # CLEARED
+  - filter: Bounds Check
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: MetaData/satelliteIdentifier
+      minvalue: 49
+      maxvalue: 80
+    test variables:
+    - name: MetaData/windComputationMethod
+    maxvalue: 4.
+    action:
+      name: reject
   # Reject obs with qualityInformationWithoutForecast < 85.
-#  - filter: Bounds Check
-#    filter variables:
-#    - name: eastward_wind
-#    - name: northward_wind
-#    where:
-#    - variable: MetaData/satelliteIdentifier
-#      minvalue: 50
-#      maxvalue: 79
-#    test variables:
-#    - name: MetaData/qualityInformationWithoutForecast 
-#    minvalue: 85.
-#    action:
-#      name: reject
-# JMA: satelliteIdentifier [100–199]
+  # CLEARED
+  - filter: Bounds Check
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: MetaData/satelliteIdentifier
+      minvalue: 49
+      maxvalue: 80
+    test variables:
+    - name: MetaData/qualityInformationWithoutForecast 
+    minvalue: 85.
+    action:
+      name: reject
+# JMA: satelliteIdentifier [100–199] (>99, <200)
   # Reject obs with satelliteZenithAngle > 68 deg
-#  - filter: Bounds Check
-#    filter variables:
-#    - name: eastward_wind
-#    - name: northward_wind
-#    where:
-#    - variable: MetaData/satelliteIdentifier
-#      minvalue: 100
-#      maxvalue: 199
-#    test variables:
-#    - name: MetaData/satelliteZenithAngle
-#    maxvalue: 68.
-#    action:
-#      name: reject
+  # NOT EXPLICITLY CLEARED: No obs in this range in file, so 0 Bounds Check rejects (which is correct) but essentially untested
+  - filter: Bounds Check
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: MetaData/satelliteIdentifier
+      minvalue: 99
+      maxvalue: 200
+    test variables:
+    - name: MetaData/satelliteZenithAngle
+    maxvalue: 68.
+    action:
+      name: reject
   # Reject obs with windComputationMethod = 5 (clear-sky WV AMV)
-#  - filter: Bounds Check
-#    filter variables:
-#    - name: eastward_wind
-#    - name: northward_wind
-#    where:
-#    - variable: MetaData/satelliteIdentifier
-#      minvalue: 100
-#      maxvalue: 199
-#    test variables:
-#    - name: MetaData/windComputationMethod
-#    maxvalue: 4.
-#    action:
-#      name: reject
+  # NOT EXPLICITLY CLEARED: No obs in this range in file, so 0 Bounds Check rejects (which is correct) but essentially untested
+  - filter: Bounds Check
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: MetaData/satelliteIdentifier
+      minvalue: 99
+      maxvalue: 200
+    test variables:
+    - name: MetaData/windComputationMethod
+    maxvalue: 4.
+    action:
+      name: reject
   # Reject obs with qualityInformationWithoutForecast < 85.
-#  - filter: Bounds Check
-#    filter variables:
-#    - name: eastward_wind
-#    - name: northward_wind
-#    where:
-#    - variable: MetaData/satelliteIdentifier
-#      minvalue: 100
-#      maxvalue: 199
-#    test variables:
-#    - name: MetaData/qualityInformationWithoutForecast
-#    minvalue: 85.
-#    action:
-#      name: reject
-# NESDIS: satelliteIdentifier [250–299]
+  # CLEARED
+  - filter: Bounds Check
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: MetaData/satelliteIdentifier
+      minvalue: 99
+      maxvalue: 200
+    test variables:
+    - name: MetaData/qualityInformationWithoutForecast
+    minvalue: 85.
+    action:
+      name: reject
+# NESDIS: satelliteIdentifier [250–299] (>249, <300)
   # Reject obs with satelliteZenithAngle > 68 deg
-#  - filter: Bounds Check
-#    filter variables:
-#    - name: eastward_wind
-#    - name: northward_wind
-#    where:
-#    - variable: MetaData/satelliteIdentifier
-#      minvalue: 250
-#      maxvalue: 299
-#    test variables:
-#    - name: MetaData/satelliteZenithAngle
-#    maxvalue: 68.
-#    action:
-#      name: reject
+  # NOT EXPLICITLY CLEARED: No obs in this range in file, so 0 Bounds Check rejects (which is correct) but essentially untested
+  - filter: Bounds Check
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: MetaData/satelliteIdentifier
+      minvalue: 249
+      maxvalue: 300
+    test variables:
+    - name: MetaData/satelliteZenithAngle
+    maxvalue: 68.
+    action:
+      name: reject
   # Reject obs with qualityInformationWithoutForecast < 90. OR > 100.
-#  - filter: Bounds Check
-#    filter variables:
-#    - name: eastward_wind
-#    - name: northward_wind
-#    where:
-#    - variable: MetaData/satelliteIdentifier
-#      minvalue: 250
-#      maxvalue: 299
-#    test variables:
-#    - name: MetaData/qualityInformationWithoutForecast
-#    minvalue: 90.
-#    maxvalue: 100.
-#    action:
-#      name: reject
+  # CLEARED
+  - filter: Bounds Check
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: MetaData/satelliteIdentifier
+      minvalue: 249
+      maxvalue: 300
+    test variables:
+    - name: MetaData/qualityInformationWithoutForecast
+    minvalue: 90.
+    maxvalue: 100.
+    action:
+      name: reject
   # Reject obs with air_pressure < 15000.
-#  - filter: Bounds Check
-#    filter variables:
-#    - name: eastward_wind
-#    - name: northward_wind
-#    where:
-#    - variable: MetaData/satelliteIdentifier
-#      minvalue: 250
-#      maxvalue: 299
-#    test variables:
-#    - name: MetaData/air_pressure
-#    minvalue: 15000.
-#    action: 
-#      name: reject
+  # CLEARED
+  - filter: Bounds Check
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: MetaData/satelliteIdentifier
+      minvalue: 249
+      maxvalue: 300
+    test variables:
+    - name: MetaData/air_pressure
+    minvalue: 15000.
+    action: 
+      name: reject
   # Reject obs with air_pressure < 70000. when Type=251
-#  - filter: Bounds Check
-#    filter variables:
-#    - name: eastward_wind
-#    - name: northward_wind
-#    where:
-#    - variable: MetaData/satelliteIdentifier
-#      minvalue: 250
-#      maxvalue: 299
-#    - variable: ObsType/eastward_wind
-#      is_in: 251
-#    test variables:
-#    - name: MetaData/air_pressure
-#    minvalue: 70000.
-#    action:
-#      name: reject
+  # NOT EXPLICITLY CLEARED: No obs in this range in file, so 0 Bounds Check rejects (which is correct) but essentially untested
+  - filter: Bounds Check
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: MetaData/satelliteIdentifier
+      minvalue: 249
+      maxvalue: 300
+    - variable: ObsType/eastward_wind
+      is_in: 251
+    test variables:
+    - name: MetaData/air_pressure
+    minvalue: 70000.
+    action:
+      name: reject
   # Reject obs with air_pressure > 30000. when Type=246
-#  - filter: Bounds Check
-#    filter variables:
-#    - name: eastward_wind
-#    - name: northward_wind
-#    where:
-#    - variable: MetaData/satelliteIdentifier
-#      minvalue: 250
-#      maxvalue: 299
-#    - variable: ObsType/eastward_wind
-#      is_in: 246
-#    test variables:
-#    - name: MetaData/air_pressure
-#    maxvalue: 30000.
-#    action:
-#      name: reject
+  # CLEARED
+  - filter: Bounds Check
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: MetaData/satelliteIdentifier
+      minvalue: 249
+      maxvalue: 300
+    - variable: ObsType/eastward_wind
+      is_in: 246
+    test variables:
+    - name: MetaData/air_pressure
+    maxvalue: 30000.
+    action:
+      name: reject
   # Reject obs with air_pressure > 85000. when isli=1 (land surface)
-#  - filter: Bounds Check
-#    filter variables:
-#    - name: eastward_wind
-#    - name: northward_wind
-#    where:
-#    - variable: MetaData/satelliteIdentifier
-#      minvalue: 250
-#      maxvalue: 299
-#    - variable: land_type_index_NPOESS@GeoVaLs
-#      minvalue: 1.
-#      maxvalue: 1.
-#    test variables:
-#    - name: MetaData/air_pressure
-#    minvalue: 85000.
-#    action:
-#      name: reject
+  # CLEARED
+  - filter: Bounds Check
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: MetaData/satelliteIdentifier
+      minvalue: 249
+      maxvalue: 300
+    - variable: land_type_index_NPOESS@GeoVaLs
+      minvalue: 1.
+      maxvalue: 1.
+    test variables:
+    - name: MetaData/air_pressure
+    maxvalue: 85000.
+    action:
+      name: reject
   # Reject obs with pct1 (Coeff. of Var.) outside of 0.04–0.5, Type [240,245,246,251] ONLY
-#  - filter: Bounds Check
-#    filter variables:
-#    - name: eastward_wind
-#    - name: northward_wind
-#    where:
-#    - variable: MetaData/satelliteIdentifier
-#      minvalue: 250
-#      maxvalue: 299
-#    - variable: ObsType/eastward_wind
-#      is_in: 240,245,246,251
-#    test variables:
-#    - name: MetaData/coefficientOfVariation
-#    minvalue: 0.04
-#    maxvalue: 0.5
-#    action:
-#      name: reject
+  # CLEARED
+  - filter: Bounds Check
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: MetaData/satelliteIdentifier
+      minvalue: 249
+      maxvalue: 300
+    - variable: ObsType/eastward_wind
+      is_in: 240,245,246,251
+    test variables:
+    - name: MetaData/coefficientOfVariation
+    minvalue: 0.04
+    maxvalue: 0.5
+    action:
+      name: reject
+# NESDIS obs are also subject to the experr_norm test defined as:
+#
+# if (10. - 0.1*(expectedError))/(ob_speed)>0.9, or ob_speed<0.1, reject, applies to Types [240,245,246,247,251]
+#
+# This is not implemented in the YAML file because we do not have the capability to compute
+# the norm, lacking the required math operators. Instead, this will likely have to be
+# implemented as an ObsFunction like the SatWindsLNVDCheck test.
 #
 # setupw criteria
 #
-  # Reject any ob when pressure greater than 950 mb.
-#  - filter: Bounds Check
-#    filter variables:
-#    - name: eastward_wind
-#    - name: northward_wind
-#    test variables:
-#    - name: MetaData/air_pressure
-#    maxvalue: 95000
-#    action:
-#      name: reject
+  # Reject any ob Type [240–260] when pressure greater than 950 mb.
+  # CLEARED: minvalue/maxvalue are >=/<=, not >/<, so editing range by 1 Pa
+  - filter: Bounds Check
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 240-260
+    test variables:
+    - name: MetaData/air_pressure
+    maxvalue: 95001
+    action:
+      name: reject
   # GOES IR (245) reject when pressure between 399 and 801 mb.
-#  - filter: Perform Action
-#    filter variables:
-#    - name: eastward_wind
-#    - name: northward_wind
-#    where:
-#    - variable: MetaData/air_pressure
-#      minvalue: 39900
-#      maxvalue: 80100
-#    where:
-#    - variable: ObsType/eastward_wind
-#      is_in: 245
-#    action:
-#      name: reject
+  # CLEARED: minvalue/maxvalue are >=/<=, not >/<, so editing range by 1 Pa
+  - filter: Perform Action
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: MetaData/air_pressure
+      minvalue: 39901
+      maxvalue: 80099
+    - variable: ObsType/eastward_wind
+      is_in: 245
+    action:
+      name: reject
   # JMA IR (252) reject when pressure between 499 and 801 mb.
-#  - filter: Perform Action
-#    filter variables:
-#    - name: eastward_wind
-#    - name: northward_wind
-#    where:
-#    - variable: MetaData/air_pressure
-#      minvalue: 49900
-#      maxvalue: 80100
-#    where:
-#    - variable: ObsType/eastward_wind
-#      is_in: 252
-#    action:
-#      name: reject
+  # CLEARED: minvalue/maxvalue are >=/<=, not >/<, so editing range by 1 Pa
+  - filter: Perform Action
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: MetaData/air_pressure
+      minvalue: 49901
+      maxvalue: 80099
+    - variable: ObsType/eastward_wind
+      is_in: 252
+    action:
+      name: reject
   # EUMETSAT IR (253) reject when pressure between 401 and 801 mb.
-#  - filter: Perform Action
-#    filter variables:
-#    - name: eastward_wind
-#    - name: northward_wind
-#    where:
-#    - variable: MetaData/air_pressure
-#      minvalue: 40100
-#      maxvalue: 80100
-#    where:
-#    - variable: ObsType/eastward_wind
-#      is_in: 253
-#    action:
-#      name: reject
+  # CLEARED: minvalue/maxvalue are >=/<=, not >/<, so editing range by 1 Pa
+  - filter: Perform Action
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: MetaData/air_pressure
+      minvalue: 40101
+      maxvalue: 80099
+    - variable: ObsType/eastward_wind
+      is_in: 253
+    action:
+      name: reject
   # GOES WV (246, 250, 254), reject when pressure greater than 399 mb.
-#  - filter: Bounds Check
-#    filter variables:
-#    - name: eastward_wind
-#    - name: northward_wind
-#    test variables:
-#    - name: MetaData/air_pressure
-#    maxvalue: 39900
-#    where:
-#    - variable:
-#        name: ObsType/eastward_wind
-#      is_in: 246, 250, 254
-#    action:
-#      name: reject
+  # CLEARED: maxvalue is rejecting >, not >= as per a Perform Action, so threshold is unchanged
+  - filter: Bounds Check
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 246, 250, 254
+    test variables:
+    - name: MetaData/air_pressure
+    maxvalue: 39900
+    action:
+      name: reject
   # EUMET (242) and JMA (243) vis, reject when pressure less than 700 mb.
-#  - filter: Bounds Check
-#    filter variables:
-#    - name: eastward_wind
-#    - name: northward_wind
-#    test variables:
-#    - name: MetaData/air_pressure
-#    minvalue: 70000
-#    where:
-#    - variable:
-#        name: ObsType/eastward_wind
-#      is_in: 242, 243
-#    action:
-#      name: reject
+  # CLEARED: minvalue is rejecting <, not <= as per a Perform Action, so threshold is unchanged
+  - filter: Bounds Check
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 242, 243
+    test variables:
+    - name: MetaData/air_pressure
+    minvalue: 70000
+    action:
+      name: reject
   # MODIS-Aqua/Terra (257) and (259), reject when pressure less than 249 mb.
-#  - filter: Bounds Check
-#    filter variables:
-#    - name: eastward_wind
-#    - name: northward_wind
-#    test variables:
-#    - name: MetaData/air_pressure
-#    minvalue: 24900
-#    where:
-#    - variable:
-#        name: ObsType/eastward_wind
-#      is_in: 257,259
-#    action:
-#      name: reject
+  # CLEARED: minvalue is rejecting <, not <= as per a Perform Action, so threshold is unchanged
+  - filter: Bounds Check
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 257,259
+    test variables:
+    - name: MetaData/air_pressure
+    minvalue: 24900
+    action:
+      name: reject
   # MODIS-Aqua/Terra (258) and (259), reject when pressure greater than 600 mb.
-#  - filter: Bounds Check
-#    filter variables:
-#    - name: eastward_wind
-#    - name: northward_wind
-#    test variables:
-#    - name: MetaData/air_pressure
-#    maxvalue: 60000
-#    where:
-#    - variable:
-#        name: ObsType/eastward_wind
-#      is_in: 258, 259
-#    action:
-#      name: reject
+  # NOT EXPLICITLY CLEARED: No obs in this range in file, so 0 Bounds Check rejects (which is correct) but essentially untested
+  # maxvalue is rejecting >, not >= as per a Perform Action, so threshold is unchanged
+  - filter: Bounds Check
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 258, 259
+    test variables:
+    - name: MetaData/air_pressure
+    maxvalue: 60000
+    action:
+      name: reject
   # Multiple satellite platforms, reject when pressure is more than 50 mb above tropopause.
-#  - filter: Difference Check
-#    filter variables:
-#    - name: eastward_wind
-#    - name: northward_wind
-#    reference: tropopause_pressure@GeoVaLs
-#    value: MetaData/air_pressure
-#    minvalue: -5000                    # 50 hPa above tropopause level, negative p-diff
-#    action:
-#      name: reject
+  # CLEARED: minvalue is rejecting <, not <= as per a Perform Action, so threshold is unchanged
+  - filter: Difference Check
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    reference: tropopause_pressure@GeoVaLs
+    value: MetaData/air_pressure
+    minvalue: -5000                    # 50 hPa above tropopause level, negative p-diff
+    action:
+      name: reject
   # GOES (247) reject any observation with a /=0 surface type (non-water 
   # surface) within 110 hPa of the surface pressure (as part of the LNVD
   # check).
-#  - filter: Difference Check
-#    filter variables:
-#    - name: eastward_wind
-#    - name: northward_wind
-#    reference: surface_pressure@GeoVaLs
-#    value: MetaData/air_pressure
-#    maxvalue: -11000                    # within 110 hPa above surface pressure, negative p-diff
-#    where:
-#    - variable:
-#        name: land_type_index_NPOESS@GeoVaLs
-#      minvalue: 1
-#    - variable:
-#        name: ObsType/eastward_wind
-#      is_in: 247
-#    action:
-#      name: reject
+  # NOT EXPLICITLY CLEARED: No obs in this range in file, so 0 Bounds Check rejects (which is correct) but essentially untested
+  - filter: Difference Check
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable:
+        name: land_type_index_NPOESS@GeoVaLs
+      minvalue: 1
+    - variable:
+        name: ObsType/eastward_wind
+      is_in: 247
+    reference: surface_pressure@GeoVaLs
+    value: MetaData/air_pressure
+    maxvalue: -11000                    # within 110 hPa above surface pressure, negative p-diff
+    action:
+      name: reject
   # AVHRR (244), MODIS (257,258,259), and VIIRS (260) reject any 
   # observation with a /=0 surface type (non-water surface) within
   # 200 hPa of the surface pressure (as part of the LNVD check).
-#  - filter: Difference Check
-#    filter variables:
-#    - name: eastward_wind
-#    - name: northward_wind
-#    reference: surface_pressure@GeoVaLs
-#    value: MetaData/air_pressure
-#    maxvalue: -20000                    # within 200 hPa above surface pressure, negative p-diff
-#    where:
-#    - variable:
-#        name: land_type_index_NPOESS@GeoVaLs
-#      minvalue: 1
-#    - variable:
-#        name: ObsType/eastward_wind
-#      is_in: 244, 257-260
-#    action:
-#      name: reject
-#obs post filters:
+  # CLEARED: maxvalue is rejecting >, not >= as per a Perform Action, so threshold is unchanged
+  - filter: Difference Check
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable:
+        name: land_type_index_NPOESS@GeoVaLs
+      minvalue: 1
+    - variable:
+        name: ObsType/eastward_wind
+      is_in: 244, 257-260
+    reference: surface_pressure@GeoVaLs
+    value: MetaData/air_pressure
+    maxvalue: -20000                    # within 200 hPa above surface pressure, negative p-diff
+    action:
+      name: reject
+obs post filters:
   # Reject GOES (247) when difference of wind direction is more than 50 degrees.
-#  - filter: Bounds Check
-#    filter variables:
-#    - name: eastward_wind
-#    - name: northward_wind
-#    test variables:
-#    - name: WindDirAngleDiff@ObsFunction
-#    maxvalue: 50.0
-#    where:
-#    - variable:
-#        name: ObsType/eastward_wind
-#      is_in: 247
-#    action:
-#      name: reject
+  # CLEARED: maxvalue is rejecting >, not >= as per a Perform Action, so threshold is unchanged
+  - filter: Bounds Check
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 247
+    test variables:
+    - name: WindDirAngleDiff@ObsFunction
+    maxvalue: 50.0
+    action:
+      name: reject
   # AVHRR (244), MODIS (257,258,259), VIIRS (260), GOES (247) use a LNVD check.
-#  - filter: Bounds Check
-#    filter variables:
-#    - name: eastward_wind
-#    - name: northward_wind
-#    test variables:
-#    - name: SatWindsLNVDCheck@ObsFunction
-#    maxvalue: 3
-#    where:
-#    - variable:
-#        name: ObsType/eastward_wind
-#      is_in: 244, 247, 257-260
-#    action:
-#      name: reject
+  # CLEARED: maxvalue is rejecting >, not >= as per a Perform Action, so threshold is unchanged
+  - filter: Bounds Check
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 244, 247, 257-260
+    test variables:
+    - name: SatWindsLNVDCheck@ObsFunction
+    maxvalue: 3
+    action:
+      name: reject
   #
   # All satwinds subject to a SPDB check (function may be broken?)
   #   We are ignoring this filter for now, and will come back to

--- a/satwind.yaml
+++ b/satwind.yaml
@@ -1,0 +1,871 @@
+obs space:
+  name: satwind
+  obsdatain:
+    engine:
+      type: H5File
+      obsfile: satwind_obs_$(OBS_DATE).nc4
+  obsdataout:
+    engine:
+      type: H5File
+      obsfile: satwind_diag_$(OBS_DATE).nc4
+  io pool:
+    max pool size: 1
+  simulated variables: [eastward_wind, northward_wind]
+geovals:
+  filename: satwind_geoval_$(OBS_DATE).nc4
+vector ref: GsiHofXBc
+tolerance: 0.01
+obs operator:
+  name: VertInterp
+# Temporarily forcing pre filters as only filters, to change back and add prior/post filters,
+# replace 'obs filters' with 'obs pre filters' in this section
+#obs pre filters:
+obs filters:
+  # Assign the initial observation error, based on height/pressure
+  # Hard-wiring to prepobs_errtable.global by Type
+  # ObsError is currently not updating, but passes directly to EffectiveError when no inflation is specified in YAML
+  # Type 240 (GOES SWIR): Assigned all dummy values in prepobs_errtable.global
+  - filter: Perform Action
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 240
+    minvalue: -135
+    maxvalue: 135
+    action:
+      name: assign error
+      error function:
+        name: ObsErrorModelStepwiseLinear@ObsFunction
+        options:
+          xvar:
+            name: MetaData/air_pressure
+          xvals: [110000,0]   #Pressure (Pa)
+          errors: [1000000000.,1000000000.]
+  # Type 241 (Multi Spec. Imager LWIR): Assigned all dummy values
+  - filter: Perform Action
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 241
+    minvalue: -135
+    maxvalue: 135
+    action:
+      name: assign error
+      error function:
+        name: ObsErrorModelStepwiseLinear@ObsFunction
+        options:
+          xvar:
+            name: MetaData/air_pressure
+          xvals: [110000,0]   #Pressure (Pa)
+          errors: [1000000000.,1000000000.]
+  # Type 242 (Himawari VIS)
+  - filter: Perform Action
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 242
+    minvalue: -135
+    maxvalue: 135
+    action:
+      name: assign error
+      error function:
+        name: ObsErrorModelStepwiseLinear@ObsFunction
+        options:
+          xvar:
+            name: MetaData/air_pressure
+          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          errors: [3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.9,3.9,4.,4.,4.1,5.,6.,6.3,6.6,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.]
+  # Type 243  (MVIRI/SEVIRI VIS)
+  - filter: Perform Action
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 243
+    minvalue: -135
+    maxvalue: 135
+    action:
+      name: assign error
+      error function:
+        name: ObsErrorModelStepwiseLinear@ObsFunction
+        options:
+          xvar:
+            name: MetaData/air_pressure
+          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          errors: [3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.9,3.9,4.,4.,4.1,5.,6.,6.3,6.6,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.]
+  # Type 244 (AVHRR LWIR)
+  - filter: Perform Action
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 244
+    minvalue: -135
+    maxvalue: 135
+    action:
+      name: assign error
+      error function:
+        name: ObsErrorModelStepwiseLinear@ObsFunction
+        options:
+          xvar:
+            name: MetaData/air_pressure
+          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          errors: [3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.9,3.9,4.,4.,4.1,5.,6.,6.3,6.6,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.]
+  # Type 245 (GOES LWIR): I am assuming these are halved relative to prepobs_errtable.global, based on read_satwnd.f90: L1410–1416
+  - filter: Perform Action
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 245
+    minvalue: -135
+    maxvalue: 135
+    action:
+      name: assign error
+      error function:
+        name: ObsErrorModelStepwiseLinear@ObsFunction
+        options:
+          xvar:
+            name: MetaData/air_pressure
+          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          errors: [7.6,7.6,7.6,7.6,7.6,7.6,7.6,7.6,7.8,7.8,8.,8.,8.2,10.,12.,12.6,13.2,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.]
+  # Type 246 (GOES cloud-top WV): I am assuming these are halved relative to prepobs_errtable.global, based on read_satwnd.f90: L1410–1416
+  - filter: Perform Action
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 246
+    minvalue: -135
+    maxvalue: 135
+    action:
+      name: assign error
+      error function:
+        name: ObsErrorModelStepwiseLinear@ObsFunction
+        options:
+          xvar:
+            name: MetaData/air_pressure
+          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          errors: [7.6,7.6,7.6,7.6,7.6,7.6,7.6,7.6,7.8,7.8,8.,8.,8.2,10.,12.,12.6,13.2,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.]
+  # Type 247 (GOES clear-sky WV): I am assuming these are halved relative to prepobs_errtable.global, based on read_satwnd.f90: L1410–1416
+  - filter: Perform Action
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 247
+    minvalue: -135
+    maxvalue: 135
+    action:
+      name: assign error
+      error function:
+        name: ObsErrorModelStepwiseLinear@ObsFunction
+        options:
+          xvar:
+            name: MetaData/air_pressure
+          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          errors: [7.6,7.6,7.6,7.6,7.6,7.6,7.6,7.6,7.8,7.8,8.,8.,8.2,10.,12.,12.6,13.2,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.,14.]
+  # Type 248 (GOES Sounder cloud-top WV): Assigned all dummy values
+  - filter: Perform Action
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 248
+    minvalue: -135
+    maxvalue: 135
+    action:
+      name: assign error
+      error function:
+        name: ObsErrorModelStepwiseLinear@ObsFunction
+        options:
+          xvar:
+            name: MetaData/air_pressure
+          xvals: [110000,0]   #Pressure (Pa)
+          errors: [1000000000.,1000000000.]
+  # Type 249 (GOES Sounder clear-sky WV): Assigned all dummy values
+  - filter: Perform Action
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 249
+    minvalue: -135
+    maxvalue: 135
+    action:
+      name: assign error
+      error function:
+        name: ObsErrorModelStepwiseLinear@ObsFunction
+        options:
+          xvar:
+            name: MetaData/air_pressure
+          xvals: [110000,0]   #Pressure (Pa)
+          errors: [1000000000.,1000000000.]
+  # Type 250 (Himawari AHI WV, cloud-top or clear-sky)
+  - filter: Perform Action
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 250
+    minvalue: -135
+    maxvalue: 135
+    action:
+      name: assign error
+      error function:
+        name: ObsErrorModelStepwiseLinear@ObsFunction
+        options:
+          xvar:
+            name: MetaData/air_pressure
+          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          errors: [3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.9,3.9,4.,4.,4.1,5.,7.,7.3,7.6,8.,8.,8.,8.,8.,8.,8.,8.,8.,8.,8.,8.,8.,8.,8.,8.]
+  # Type 251 (GOES VIS): Assigned all dummy values
+  - filter: Perform Action
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 251
+    minvalue: -135
+    maxvalue: 135
+    action:
+      name: assign error
+      error function:
+        name: ObsErrorModelStepwiseLinear@ObsFunction
+        options:
+          xvar:
+            name: MetaData/air_pressure
+          xvals: [110000,0]   #Pressure (Pa)
+          errors: [1000000000.,1000000000.]
+  # Type 252 (Himawari AHI LWIR)
+  - filter: Perform Action
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 252
+    minvalue: -135
+    maxvalue: 135
+    action:
+      name: assign error
+      error function:
+        name: ObsErrorModelStepwiseLinear@ObsFunction
+        options:
+          xvar:
+            name: MetaData/air_pressure
+          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          errors: [3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.9,3.9,4.,4.,4.1,5.,6.,6.3,6.6,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.]
+  # Type 253 (MVIRI/SEVERI LWIR)
+  - filter: Perform Action
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 253
+    minvalue: -135
+    maxvalue: 135
+    action: 
+      name: assign error
+      error function:
+        name: ObsErrorModelStepwiseLinear@ObsFunction
+        options:
+          xvar:
+            name: MetaData/air_pressure
+          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          errors: [3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.9,3.9,4.,4.,4.1,5.,6.,6.3,6.6,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.]
+  # Type 254 (MVIRI/SEVIRI WV, both cloud-top and clear-sky)
+  - filter: Perform Action
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 254
+    minvalue: -135
+    maxvalue: 135
+    action:
+      name: assign error
+      error function:
+        name: ObsErrorModelStepwiseLinear@ObsFunction
+        options:
+          xvar:
+            name: MetaData/air_pressure
+          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          errors: [3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.9,3.9,4.,4.5,6.1,6.,6.5,7.3,7.6,7.,7.5,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.]
+  # Type 255 (GOES low-level picture triplet cloud drift): According to prepbufr table this should no longer exist??
+  - filter: Perform Action
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 255
+    minvalue: -135
+    maxvalue: 135
+    action:
+      name: assign error
+      error function:
+        name: ObsErrorModelStepwiseLinear@ObsFunction
+        options:
+          xvar:
+            name: MetaData/air_pressure
+          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          errors: [3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.9,3.9,4.,4.,4.1,5.,6.,6.3,6.6,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.]
+  # Type 256 (Multi Spec. Imager WV, both clear-sky and cloud-top): Assigned all dummy values
+  - filter: Perform Action
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 256
+    minvalue: -135
+    maxvalue: 135
+    action:
+      name: assign error
+      error function:
+        name: ObsErrorModelStepwiseLinear@ObsFunction
+        options:
+          xvar:
+            name: MetaData/air_pressure
+          xvals: [110000,0]   #Pressure (Pa)
+          errors: [1000000000.,1000000000.]
+  # Type 257 (MODIS LWIR)
+  - filter: Perform Action
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 257
+    minvalue: -135
+    maxvalue: 135
+    action: 
+      name: assign error
+      error function:
+        name: ObsErrorModelStepwiseLinear@ObsFunction
+        options:
+          xvar:
+            name: MetaData/air_pressure
+          xvals: [110000,105000,100000,95000,90000,85000,80000,75000,70000,65000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          errors: [3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.9,3.9,4.,4.,4.1,5.,6.,6.3,6.6,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.]
+  # Type 258 (MODIS cloud-top WV): Some levels assigned dummy values
+  - filter: Perform Action
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 258
+    minvalue: -135
+    maxvalue: 135
+    action:
+      name: assign error
+      error function:
+        name: ObsErrorModelStepwiseLinear@ObsFunction
+        options:
+          xvar:
+            name: MetaData/air_pressure
+          xvals: [110000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          errors: [1000000000.,1000000000.,4.,4.1,5.,6.,6.3,6.6,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.]
+  # Type 259 (MODIS clear-sky WV): Some levels assigned dummy values
+  - filter: Perform Action
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 259
+    minvalue: -135
+    maxvalue: 135
+    action:
+      name: assign error
+      error function:
+        name: ObsErrorModelStepwiseLinear@ObsFunction
+        options:
+          xvar:
+            name: MetaData/air_pressure
+          xvals: [110000,60000,55000,50000,45000,40000,35000,30000,25000,20000,15000,10000,7500,5000,4000,3000,2000,1000,500,400,300,200,100,0]   #Pressure (Pa)
+          errors: [1000000000.,1000000000.,4.,4.1,5.,6.,6.3,6.6,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.]
+  # Type 260 (VIIRS LWIR): All levels assigned dummy values
+  - filter: Perform Action
+    filter variables:
+    - name: eastward_wind
+    - name: northward_wind
+    where:
+    - variable: ObsType/eastward_wind
+      is_in: 260
+    minvalue: -135
+    maxvalue: 135
+    action:
+      name: assign error
+      error function:
+        name: ObsErrorModelStepwiseLinear@ObsFunction
+        options:
+          xvar:
+            name: MetaData/air_pressure
+          xvals: [110000,0]   #Pressure (Pa)
+          errors: [1000000000.,1000000000.]
+#obs prior filters:
+  #
+  # sanity-check criteria
+  #
+  # Observation Range Sanity Check
+#  - filter: Bounds Check
+#    filter variables:
+#    - name: eastward_wind
+#    - name: northward_wind
+#    minvalue: -130
+#    maxvalue: 130
+#    action:
+#      name: reject
+  # Velocity Sanity Check
+#  - filter: Bounds Check
+#    filter variables:
+#    - name: eastward_wind
+#    - name: northward_wind
+#    test variables:
+#    - name: Velocity@ObsFunction
+#    maxvalue: 130.0
+#    action:
+#      name: reject
+  # Reject any ob with PreQC of 9, 12, or 15
+  #   These are flags inherited from read_satwnd.f90 based on
+  #   multiple criteria. Eventually that criteria should be
+  #   replicated in JEDI instead of being read in from GSI,
+  #   but for now we will use the provided PreQC flags
+#  - filter: Perform Action
+#    filter variables:
+#    - name: eastward_wind
+#    - name: northward_wind
+#    where:
+#    - variable: PreQC/eastward_wind
+#      is_in: 9, 12, 15
+#    action:
+#      name: reject
+#
+# preQC (read_satwnd) criteria
+#
+# EUMETSAT winds: satelliteIdentifer [50–99]
+  # Reject obs with satelliteZenithAngle > 68 deg
+#  - filter: Bounds Check
+#    filter variables:
+#    - name: eastward_wind
+#    - name: northward_wind
+#    where:
+#    - variable: MetaData/satelliteIdentifier
+#      minvalue: 50
+#      maxvalue: 79
+#    test variables:
+#    - name: MetaData/satelliteZenithAngle
+#    maxvalue: 68.
+#    action:
+#      name: reject
+  # Reject obs with windComputationMethod = 5 (clear-sky WV AMV)
+#  - filter: Bounds Check
+#    filter variables:
+#    - name: eastward_wind
+#    - name: northward_wind
+#    where:
+#    - variable: MetaData/satelliteIdentifier
+#      minvalue: 50
+#      maxvalue: 79
+#    test variables:
+#    - name: MetaData/windComputationMethod
+#    maxvalue: 4.
+#    action:
+#      name: reject
+  # Reject obs with qualityInformationWithoutForecast < 85.
+#  - filter: Bounds Check
+#    filter variables:
+#    - name: eastward_wind
+#    - name: northward_wind
+#    where:
+#    - variable: MetaData/satelliteIdentifier
+#      minvalue: 50
+#      maxvalue: 79
+#    test variables:
+#    - name: MetaData/qualityInformationWithoutForecast 
+#    minvalue: 85.
+#    action:
+#      name: reject
+# JMA: satelliteIdentifier [100–199]
+  # Reject obs with satelliteZenithAngle > 68 deg
+#  - filter: Bounds Check
+#    filter variables:
+#    - name: eastward_wind
+#    - name: northward_wind
+#    where:
+#    - variable: MetaData/satelliteIdentifier
+#      minvalue: 100
+#      maxvalue: 199
+#    test variables:
+#    - name: MetaData/satelliteZenithAngle
+#    maxvalue: 68.
+#    action:
+#      name: reject
+  # Reject obs with windComputationMethod = 5 (clear-sky WV AMV)
+#  - filter: Bounds Check
+#    filter variables:
+#    - name: eastward_wind
+#    - name: northward_wind
+#    where:
+#    - variable: MetaData/satelliteIdentifier
+#      minvalue: 100
+#      maxvalue: 199
+#    test variables:
+#    - name: MetaData/windComputationMethod
+#    maxvalue: 4.
+#    action:
+#      name: reject
+  # Reject obs with qualityInformationWithoutForecast < 85.
+#  - filter: Bounds Check
+#    filter variables:
+#    - name: eastward_wind
+#    - name: northward_wind
+#    where:
+#    - variable: MetaData/satelliteIdentifier
+#      minvalue: 100
+#      maxvalue: 199
+#    test variables:
+#    - name: MetaData/qualityInformationWithoutForecast
+#    minvalue: 85.
+#    action:
+#      name: reject
+# NESDIS: satelliteIdentifier [250–299]
+  # Reject obs with satelliteZenithAngle > 68 deg
+#  - filter: Bounds Check
+#    filter variables:
+#    - name: eastward_wind
+#    - name: northward_wind
+#    where:
+#    - variable: MetaData/satelliteIdentifier
+#      minvalue: 250
+#      maxvalue: 299
+#    test variables:
+#    - name: MetaData/satelliteZenithAngle
+#    maxvalue: 68.
+#    action:
+#      name: reject
+  # Reject obs with qualityInformationWithoutForecast < 90. OR > 100.
+#  - filter: Bounds Check
+#    filter variables:
+#    - name: eastward_wind
+#    - name: northward_wind
+#    where:
+#    - variable: MetaData/satelliteIdentifier
+#      minvalue: 250
+#      maxvalue: 299
+#    test variables:
+#    - name: MetaData/qualityInformationWithoutForecast
+#    minvalue: 90.
+#    maxvalue: 100.
+#    action:
+#      name: reject
+  # Reject obs with air_pressure < 15000.
+#  - filter: Bounds Check
+#    filter variables:
+#    - name: eastward_wind
+#    - name: northward_wind
+#    where:
+#    - variable: MetaData/satelliteIdentifier
+#      minvalue: 250
+#      maxvalue: 299
+#    test variables:
+#    - name: MetaData/air_pressure
+#    minvalue: 15000.
+#    action: 
+#      name: reject
+  # Reject obs with air_pressure < 70000. when Type=251
+#  - filter: Bounds Check
+#    filter variables:
+#    - name: eastward_wind
+#    - name: northward_wind
+#    where:
+#    - variable: MetaData/satelliteIdentifier
+#      minvalue: 250
+#      maxvalue: 299
+#    - variable: ObsType/eastward_wind
+#      is_in: 251
+#    test variables:
+#    - name: MetaData/air_pressure
+#    minvalue: 70000.
+#    action:
+#      name: reject
+  # Reject obs with air_pressure > 30000. when Type=246
+#  - filter: Bounds Check
+#    filter variables:
+#    - name: eastward_wind
+#    - name: northward_wind
+#    where:
+#    - variable: MetaData/satelliteIdentifier
+#      minvalue: 250
+#      maxvalue: 299
+#    - variable: ObsType/eastward_wind
+#      is_in: 246
+#    test variables:
+#    - name: MetaData/air_pressure
+#    maxvalue: 30000.
+#    action:
+#      name: reject
+  # Reject obs with air_pressure > 85000. when isli=1 (land surface)
+#  - filter: Bounds Check
+#    filter variables:
+#    - name: eastward_wind
+#    - name: northward_wind
+#    where:
+#    - variable: MetaData/satelliteIdentifier
+#      minvalue: 250
+#      maxvalue: 299
+#    - variable: land_type_index_NPOESS@GeoVaLs
+#      minvalue: 1.
+#      maxvalue: 1.
+#    test variables:
+#    - name: MetaData/air_pressure
+#    minvalue: 85000.
+#    action:
+#      name: reject
+  # Reject obs with pct1 (Coeff. of Var.) outside of 0.04–0.5, Type [240,245,246,251] ONLY
+#  - filter: Bounds Check
+#    filter variables:
+#    - name: eastward_wind
+#    - name: northward_wind
+#    where:
+#    - variable: MetaData/satelliteIdentifier
+#      minvalue: 250
+#      maxvalue: 299
+#    - variable: ObsType/eastward_wind
+#      is_in: 240,245,246,251
+#    test variables:
+#    - name: MetaData/coefficientOfVariation
+#    minvalue: 0.04
+#    maxvalue: 0.5
+#    action:
+#      name: reject
+#
+# setupw criteria
+#
+  # Reject any ob when pressure greater than 950 mb.
+#  - filter: Bounds Check
+#    filter variables:
+#    - name: eastward_wind
+#    - name: northward_wind
+#    test variables:
+#    - name: MetaData/air_pressure
+#    maxvalue: 95000
+#    action:
+#      name: reject
+  # GOES IR (245) reject when pressure between 399 and 801 mb.
+#  - filter: Perform Action
+#    filter variables:
+#    - name: eastward_wind
+#    - name: northward_wind
+#    where:
+#    - variable: MetaData/air_pressure
+#      minvalue: 39900
+#      maxvalue: 80100
+#    where:
+#    - variable: ObsType/eastward_wind
+#      is_in: 245
+#    action:
+#      name: reject
+  # JMA IR (252) reject when pressure between 499 and 801 mb.
+#  - filter: Perform Action
+#    filter variables:
+#    - name: eastward_wind
+#    - name: northward_wind
+#    where:
+#    - variable: MetaData/air_pressure
+#      minvalue: 49900
+#      maxvalue: 80100
+#    where:
+#    - variable: ObsType/eastward_wind
+#      is_in: 252
+#    action:
+#      name: reject
+  # EUMETSAT IR (253) reject when pressure between 401 and 801 mb.
+#  - filter: Perform Action
+#    filter variables:
+#    - name: eastward_wind
+#    - name: northward_wind
+#    where:
+#    - variable: MetaData/air_pressure
+#      minvalue: 40100
+#      maxvalue: 80100
+#    where:
+#    - variable: ObsType/eastward_wind
+#      is_in: 253
+#    action:
+#      name: reject
+  # GOES WV (246, 250, 254), reject when pressure greater than 399 mb.
+#  - filter: Bounds Check
+#    filter variables:
+#    - name: eastward_wind
+#    - name: northward_wind
+#    test variables:
+#    - name: MetaData/air_pressure
+#    maxvalue: 39900
+#    where:
+#    - variable:
+#        name: ObsType/eastward_wind
+#      is_in: 246, 250, 254
+#    action:
+#      name: reject
+  # EUMET (242) and JMA (243) vis, reject when pressure less than 700 mb.
+#  - filter: Bounds Check
+#    filter variables:
+#    - name: eastward_wind
+#    - name: northward_wind
+#    test variables:
+#    - name: MetaData/air_pressure
+#    minvalue: 70000
+#    where:
+#    - variable:
+#        name: ObsType/eastward_wind
+#      is_in: 242, 243
+#    action:
+#      name: reject
+  # MODIS-Aqua/Terra (257) and (259), reject when pressure less than 249 mb.
+#  - filter: Bounds Check
+#    filter variables:
+#    - name: eastward_wind
+#    - name: northward_wind
+#    test variables:
+#    - name: MetaData/air_pressure
+#    minvalue: 24900
+#    where:
+#    - variable:
+#        name: ObsType/eastward_wind
+#      is_in: 257,259
+#    action:
+#      name: reject
+  # MODIS-Aqua/Terra (258) and (259), reject when pressure greater than 600 mb.
+#  - filter: Bounds Check
+#    filter variables:
+#    - name: eastward_wind
+#    - name: northward_wind
+#    test variables:
+#    - name: MetaData/air_pressure
+#    maxvalue: 60000
+#    where:
+#    - variable:
+#        name: ObsType/eastward_wind
+#      is_in: 258, 259
+#    action:
+#      name: reject
+  # Multiple satellite platforms, reject when pressure is more than 50 mb above tropopause.
+#  - filter: Difference Check
+#    filter variables:
+#    - name: eastward_wind
+#    - name: northward_wind
+#    reference: tropopause_pressure@GeoVaLs
+#    value: MetaData/air_pressure
+#    minvalue: -5000                    # 50 hPa above tropopause level, negative p-diff
+#    action:
+#      name: reject
+  # GOES (247) reject any observation with a /=0 surface type (non-water 
+  # surface) within 110 hPa of the surface pressure (as part of the LNVD
+  # check).
+#  - filter: Difference Check
+#    filter variables:
+#    - name: eastward_wind
+#    - name: northward_wind
+#    reference: surface_pressure@GeoVaLs
+#    value: MetaData/air_pressure
+#    maxvalue: -11000                    # within 110 hPa above surface pressure, negative p-diff
+#    where:
+#    - variable:
+#        name: land_type_index_NPOESS@GeoVaLs
+#      minvalue: 1
+#    - variable:
+#        name: ObsType/eastward_wind
+#      is_in: 247
+#    action:
+#      name: reject
+  # AVHRR (244), MODIS (257,258,259), and VIIRS (260) reject any 
+  # observation with a /=0 surface type (non-water surface) within
+  # 200 hPa of the surface pressure (as part of the LNVD check).
+#  - filter: Difference Check
+#    filter variables:
+#    - name: eastward_wind
+#    - name: northward_wind
+#    reference: surface_pressure@GeoVaLs
+#    value: MetaData/air_pressure
+#    maxvalue: -20000                    # within 200 hPa above surface pressure, negative p-diff
+#    where:
+#    - variable:
+#        name: land_type_index_NPOESS@GeoVaLs
+#      minvalue: 1
+#    - variable:
+#        name: ObsType/eastward_wind
+#      is_in: 244, 257-260
+#    action:
+#      name: reject
+#obs post filters:
+  # Reject GOES (247) when difference of wind direction is more than 50 degrees.
+#  - filter: Bounds Check
+#    filter variables:
+#    - name: eastward_wind
+#    - name: northward_wind
+#    test variables:
+#    - name: WindDirAngleDiff@ObsFunction
+#    maxvalue: 50.0
+#    where:
+#    - variable:
+#        name: ObsType/eastward_wind
+#      is_in: 247
+#    action:
+#      name: reject
+  # AVHRR (244), MODIS (257,258,259), VIIRS (260), GOES (247) use a LNVD check.
+#  - filter: Bounds Check
+#    filter variables:
+#    - name: eastward_wind
+#    - name: northward_wind
+#    test variables:
+#    - name: SatWindsLNVDCheck@ObsFunction
+#    maxvalue: 3
+#    where:
+#    - variable:
+#        name: ObsType/eastward_wind
+#      is_in: 244, 247, 257-260
+#    action:
+#      name: reject
+  #
+  # All satwinds subject to a SPDB check (function may be broken?)
+  #   We are ignoring this filter for now, and will come back to
+  #   the issue of how to handle this SPDB check later. For now,
+  #   observations that are GSI-rejected based on this test are
+  #   not being considered when checking acceptance compliance.
+  #- filter: Bounds Check
+  #  filter variables:
+  #  - name: eastward_wind
+  #  - name: northward_wind
+  #  test variables:
+  #  - name: SatWindsSPDBCheck@ObsFunction
+  #    options:
+  #      error_min: 1.4
+  #      error_max: 20.0
+  #  maxvalue: 1.75
+  #  action:
+  #    name: reject
+  #  defer to post: true
+linear obs operator:
+  name: Identity
+


### PR DESCRIPTION
A YAML file has been produced to perform initial ob-error assignment and perform QC on satwinds. This file has been checked-out in GDASApp using test data for the 2020080100 analysis period.

Errors match GSI initial errors for all assimilated winds, there are outstanding satwind obs with `_FillValue` missing-values but they are only affecting `Type=240` (GOES shortwave IR) winds that are not assimilated in GSI and likely are not carrying over error information from GSI into the diag file.

Acceptance checks out for all observations except for a subset that are fully accounted-for. Accounting is detailed in [JEDI-T20 issue 40](https://github.com/NOAA-EMC/JEDI-T2O/issues/40#issuecomment-1281538609).