### PR TITLE
Feature/gsibec

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -60,7 +60,7 @@ case ${BUILD_TARGET} in
     module purge
     module use $dir_root/modulefiles
     module load GDAS/$BUILD_TARGET
-    CMAKE_OPTS+=" -DMPIEXEC_EXECUTABLE=$MPIEXEC_EXEC -DMPIEXEC_NUMPROC_FLAG=$MPIEXEC_NPROC"
+    CMAKE_OPTS+=" -DMPIEXEC_EXECUTABLE=$MPIEXEC_EXEC -DMPIEXEC_NUMPROC_FLAG=$MPIEXEC_NPROC -DBUILD_GSIBEC=ON"
     module list
     set -e
     ;;

--- a/parm/atm/berror/staticb_gsibec.yaml
+++ b/parm/atm/berror/staticb_gsibec.yaml
@@ -1,0 +1,38 @@
+background error:
+  covariance model: hybrid
+  components:
+  - covariance:
+      covariance model: SABER
+      saber blocks:
+      - saber block name: gsi covariance
+        saber central block: true
+        input variables: &control_vars [eastward_wind,northward_wind,air_temperature,surface_pressure,
+                                 specific_humidity,mole_fraction_of_ozone_in_air]
+        output variables: *control_vars
+        gsi akbk: &akbk $(fv3jedi_fix_dir)/akbk.nc4
+        gsi error covariance file: &gsiberr $(fv3jedi_staticb_dir)/gsi-coeffs-gfs-global-l127x192y96.nc4
+        gsi berror namelist file: &gsibnml $(fv3jedi_staticb_dir)/gfs_gsi_global.nml
+        processor layout x direction: 3
+        processor layout y direction: 2
+        debugging mode: false
+      - saber block name: gsi interpolation to model grid
+        input variables: *control_vars
+        output variables: *control_vars
+        gsi akbk: *akbk
+        gsi error covariance file: *gsiberr
+        gsi berror namelist file: *gsibnml
+        processor layout x direction: 3
+        processor layout y direction: 2
+        debugging mode: false
+      linear variable change:
+        linear variable change name: Control2Analysis
+        input variables: *control_vars
+        output variables: &3dvars_anal [ua,va,t,ps,sphum,o3mr]
+    weight:
+      value: 1.00
+  - covariance:
+      covariance model: FV3JEDI-ID
+      date: $(window_begin)
+    weight:
+      value: 0.0
+

--- a/parm/atm/berror/staticb_gsibec.yaml
+++ b/parm/atm/berror/staticb_gsibec.yaml
@@ -1,39 +1,29 @@
-background error:
-  covariance model: hybrid
-  components:
-  - covariance:
-      covariance model: SABER
-      saber blocks:
-      - saber block name: gsi covariance
-        saber central block: true
-        input variables: &control_vars [eastward_wind,northward_wind,air_temperature,surface_pressure,
-                                 specific_humidity,cloud_liquid_ice,cloud_liquid_water,
-                                 mole_fraction_of_ozone_in_air]
-        output variables: *control_vars
-        gsi akbk: &akbk $(fv3jedi_fix_dir)/akbk.nc4
-        gsi error covariance file: &gsiberr $(fv3jedi_staticb_dir)/gsi-coeffs-gfs-global-l127x192y96.nc4
-        gsi berror namelist file: &gsibnml $(fv3jedi_staticb_dir)/gfs_gsi_global.nml
-        processor layout x direction: 3
-        processor layout y direction: 2
-        debugging mode: false
-      - saber block name: gsi interpolation to model grid
-        input variables: *control_vars
-        output variables: *control_vars
-        gsi akbk: *akbk
-        gsi error covariance file: *gsiberr
-        gsi berror namelist file: *gsibnml
-        processor layout x direction: 3
-        processor layout y direction: 2
-        debugging mode: false
-      linear variable change:
-        linear variable change name: Control2Analysis
-        input variables: *control_vars
-        output variables: &3dvars_anal [ua,va,t,ps,sphum,ice_wat,liq_wat,o3mr]
-    weight:
-      value: 1.00
-  - covariance:
-      covariance model: FV3JEDI-ID
-      date: $(window_begin)
-    weight:
-      value: 0.0
-
+covariance model: SABER
+full inverse: true
+saber blocks:
+- saber block name: gsi covariance
+  saber central block: true
+  input variables: &control_vars [eastward_wind,northward_wind,air_temperature,surface_pressure,
+                           specific_humidity,cloud_liquid_ice,cloud_liquid_water,
+                           mole_fraction_of_ozone_in_air]
+  output variables: *control_vars
+  gsi akbk: &akbk $(fv3jedi_fix_dir)/akbk.nc4
+  gsi error covariance file: &gsiberr $(fv3jedi_staticb_dir)/gsi-coeffs-gfs-global.nc4
+# gsi error covariance file: &gsiberr $(fv3jedi_staticb_dir)/global_berror.f77
+  gsi berror namelist file: &gsibnml $(fv3jedi_staticb_dir)/gfs_gsi_global.nml
+  processor layout x direction: &layout_gsib_x 3
+  processor layout y direction: &layout_gsib_y 2
+  debugging mode: false
+- saber block name: gsi interpolation to model grid
+  input variables: *control_vars
+  output variables: *control_vars
+  gsi akbk: *akbk
+  gsi error covariance file: *gsiberr
+  gsi berror namelist file: *gsibnml
+  processor layout x direction: *layout_gsib_x
+  processor layout y direction: *layout_gsib_y
+  debugging mode: false
+linear variable change:
+  linear variable change name: Control2Analysis
+  input variables: *control_vars
+  output variables: &3dvars_anal [ua,va,t,ps,sphum,ice_wat,liq_wat,o3mr]

--- a/parm/atm/berror/staticb_gsibec.yaml
+++ b/parm/atm/berror/staticb_gsibec.yaml
@@ -7,7 +7,8 @@ background error:
       - saber block name: gsi covariance
         saber central block: true
         input variables: &control_vars [eastward_wind,northward_wind,air_temperature,surface_pressure,
-                                 specific_humidity,mole_fraction_of_ozone_in_air]
+                                 specific_humidity,cloud_liquid_ice,cloud_liquid_water,
+                                 mole_fraction_of_ozone_in_air]
         output variables: *control_vars
         gsi akbk: &akbk $(fv3jedi_fix_dir)/akbk.nc4
         gsi error covariance file: &gsiberr $(fv3jedi_staticb_dir)/gsi-coeffs-gfs-global-l127x192y96.nc4
@@ -27,7 +28,7 @@ background error:
       linear variable change:
         linear variable change name: Control2Analysis
         input variables: *control_vars
-        output variables: &3dvars_anal [ua,va,t,ps,sphum,o3mr]
+        output variables: &3dvars_anal [ua,va,t,ps,sphum,ice_wat,liq_wat,o3mr]
     weight:
       value: 1.00
   - covariance:

--- a/ush/examples/run_jedi_exe/3dvar_hera.yaml
+++ b/ush/examples/run_jedi_exe/3dvar_hera.yaml
@@ -2,7 +2,7 @@ working directory: /scratch2/NCEPDEV/stmp1/Cory.R.Martin/gdas_single_test_3dvar
 GDASApp home: /scratch1/NCEPDEV/da/Cory.R.Martin/GDASApp/work/GDASApp
 GDASApp mode: variational
 executable options:
-  berror_yaml: /scratch1/NCEPDEV/da/Cory.R.Martin/GDASApp/work/GDASApp/parm/atm/berror/staticb_bump.yaml
+  berror_yaml: /scratch1/NCEPDEV/da/Cory.R.Martin/GDASApp/work/GDASApp/parm/atm/berror/staticb_gsibec.yaml
   obs_yaml_dir: /scratch1/NCEPDEV/da/Cory.R.Martin/GDASApp/work/GDASApp/parm/atm/obs/config
   yaml_template: /scratch1/NCEPDEV/da/Cory.R.Martin/GDASApp/work/GDASApp/parm/atm/variational/3dvar_dripcg.yaml
   executable: /scratch1/NCEPDEV/da/Cory.R.Martin/GDASApp/work/GDASApp/build/bin/fv3jedi_var.x
@@ -15,8 +15,8 @@ executable options:
   valid_time: 2021-12-21T06:00:00Z
   dump: gdas
   case: C96
-  case_anl: C48
-  staticb_type: bump
+  case_anl: C96
+  staticb_type: gsibec
   dohybvar: false
   levs: 128
   interp_method: barycentric

--- a/ush/examples/run_jedi_exe/3dvar_hera.yaml
+++ b/ush/examples/run_jedi_exe/3dvar_hera.yaml
@@ -16,6 +16,7 @@ executable options:
   dump: gdas
   case: C96
   case_anl: C48
+  staticb_type: bump
   dohybvar: false
   levs: 128
   interp_method: barycentric

--- a/ush/examples/run_jedi_exe/3dvar_orion.yaml
+++ b/ush/examples/run_jedi_exe/3dvar_orion.yaml
@@ -16,6 +16,7 @@ executable options:
   dump: gdas
   case: C96
   case_anl: C48
+  staticb_type: bump
   dohybvar: false
   levs: 128
   interp_method: barycentric

--- a/ush/examples/run_jedi_exe/3dvar_orion.yaml
+++ b/ush/examples/run_jedi_exe/3dvar_orion.yaml
@@ -2,7 +2,7 @@ working directory: /work2/noaa/stmp/cmartin/gdas_single_test_3dvar
 GDASApp home: /work2/noaa/da/cmartin/GDASApp/work/GDASApp
 GDASApp mode: variational
 executable options:
-  berror_yaml: /work2/noaa/da/cmartin/GDASApp/work/GDASApp/parm/atm/berror/staticb_bump.yaml
+  berror_yaml: /work2/noaa/da/cmartin/GDASApp/work/GDASApp/parm/atm/berror/staticb_gsibec.yaml
   obs_yaml_dir: /work2/noaa/da/cmartin/GDASApp/work/GDASApp/parm/atm/obs/config
   yaml_template: /work2/noaa/da/cmartin/GDASApp/work/GDASApp/parm/atm/variational/3dvar_dripcg.yaml
   executable: /work2/noaa/da/cmartin/GDASApp/work/GDASApp/build/bin/fv3jedi_var.x
@@ -15,8 +15,8 @@ executable options:
   valid_time: 2021-12-21T06:00:00Z
   dump: gdas
   case: C96
-  case_anl: C48
-  staticb_type: bump
+  case_anl: C96
+  staticb_type: gsibec
   dohybvar: false
   levs: 128
   interp_method: barycentric

--- a/ush/run_jedi_exe.py
+++ b/ush/run_jedi_exe.py
@@ -73,6 +73,7 @@ def run_jedi_exe(yamlconfig):
         single_exec = True
         var_config = {
             'BERROR_YAML': executable_subconfig.get('berror_yaml', './'),
+            'STATICB_TYPE': executable_subconfig.get('staticb_type','gsibec'),
             'OBS_YAML_DIR': executable_subconfig['obs_yaml_dir'],
             'OBS_LIST': executable_subconfig['obs_list'],
             'atm': executable_subconfig.get('atm', False),

--- a/ush/run_jedi_exe.py
+++ b/ush/run_jedi_exe.py
@@ -73,7 +73,7 @@ def run_jedi_exe(yamlconfig):
         single_exec = True
         var_config = {
             'BERROR_YAML': executable_subconfig.get('berror_yaml', './'),
-            'STATICB_TYPE': executable_subconfig.get('staticb_type','gsibec'),
+            'STATICB_TYPE': executable_subconfig.get('staticb_type', 'gsibec'),
             'OBS_YAML_DIR': executable_subconfig['obs_yaml_dir'],
             'OBS_LIST': executable_subconfig['obs_list'],
             'atm': executable_subconfig.get('atm', False),

--- a/ush/ufsda/stage.py
+++ b/ush/ufsda/stage.py
@@ -34,12 +34,7 @@ def gdas_fix(input_fix_dir, working_dir, config):
     layers = int(config['LEVS'])-1
 
     # figure out staticb source
-    if config['STATICB_TYPE'] == 'bump':
-        staticb_source = 'bump'
-    elif config['STATICB_TYPE'] == 'identity':
-        staticb_source = 'identity'
-    else:
-        staticb_source = 'gsibec'
+    staticb_source = config.get('STATICB_TYPE', 'gsibec')
 
     # link staticb
     if staticb_source in ['bump', 'gsibec']:

--- a/ush/ufsda/stage.py
+++ b/ush/ufsda/stage.py
@@ -36,12 +36,15 @@ def gdas_fix(input_fix_dir, working_dir, config):
     # figure out staticb source
     if config['STATICB_TYPE'] == 'bump':
         staticb_source = 'bump'
+    elif config['STATICB_TYPE'] == 'identity':
+        staticb_source = 'identity'
     else:
         staticb_source = 'gsibec'
 
     # link staticb
-    ufsda.disk_utils.symlink(os.path.join(input_fix_dir, staticb_source, case_anl),
-                             config['fv3jedi_staticb_dir'])
+    if staticb_source in ['bump', 'gsibec']:
+        ufsda.disk_utils.symlink(os.path.join(input_fix_dir, staticb_source, case_anl),
+                                 config['fv3jedi_staticb_dir'])
 
     # link akbk file
     ufsda.disk_utils.symlink(os.path.join(input_fix_dir, 'fv3jedi',

--- a/ush/ufsda/stage.py
+++ b/ush/ufsda/stage.py
@@ -32,9 +32,17 @@ def gdas_fix(input_fix_dir, working_dir, config):
     else:
         case_anl = config['CASE_ANL']
     layers = int(config['LEVS'])-1
-    # link static B files
-    ufsda.disk_utils.symlink(os.path.join(input_fix_dir, 'bump', case_anl),
+
+    # figure out staticb source
+    if config['STATICB_TYPE'] == 'bump':
+        staticb_source = 'bump'
+    else:
+        staticb_source = 'gsibec'
+
+    # link staticb
+    ufsda.disk_utils.symlink(os.path.join(input_fix_dir, staticb_source, case_anl),
                              config['fv3jedi_staticb_dir'])
+
     # link akbk file
     ufsda.disk_utils.symlink(os.path.join(input_fix_dir, 'fv3jedi',
                                           'fv3files', f"akbk{layers}.nc4"),


### PR DESCRIPTION
This PR is opened to add GSI static B as a new option for the background error covariance used by `fv3jedi_var.x`.   

Issue #166 documents the changes in branch [`feature/gsibec`](https://github.com/NOAA-EMC/GDASApp/tree/feature/gsibec),   This branch has been built on Hera and Orion.  3dvar tests have been successfully run using GSI static B on both machines.   

Updates to the g-w to use GSI static B have been committed to g-w branch [`feature/staticb`](https://github.com/NOAA-EMC/global-workflow/tree/feature/staticb) and are documented in g-w issue [#1103](https://github.com/NOAA-EMC/global-workflow/issues/1103).   The combination of GDASApp branch `feature/gsibec` and g-w branch `feature/staticb` have been used to run a UFS DA cycling parallel on Hera.   
