### PR TITLE
Minor changes to get cycling going for aerosol DA

### DIFF
--- a/parm/aero/berror/staticb_bump_aero.yaml
+++ b/parm/aero/berror/staticb_bump_aero.yaml
@@ -3,11 +3,11 @@ full inverse: true
 saber blocks:
 - saber block name: BUMP_NICAS
   saber central block: true
-  input variables: &control_vars [sulf,bc1,bc2,oc1,oc2,
+  input variables: &control_vars [so4,bc1,bc2,oc1,oc2,
                        dust1,dust2,dust3,dust4,dust5,
                        seas1,seas2,seas3,seas4]
   output variables: *control_vars
-  active variables: &active_vars [sulf,bc1,bc2,oc1,oc2,
+  active variables: &active_vars [so4,bc1,bc2,oc1,oc2,
                       dust1,dust2,dust3,dust4,dust5,
                       seas1,seas2,seas3,seas4]
   bump:
@@ -15,13 +15,14 @@ saber blocks:
     verbosity: main
     strategy: specific_univariate
     load_nicas_local: true
+    prefix: 'nicas_aero'
     universe radius:
       filetype: fms restart
       datetime: 2016-06-30T00:00:00Z 
       set datetime on read: true
       psinfile: true
       datapath: *staticb_aero_dir
-      prefix: cor/20160630.000000
+      prefix: '20160630.000000'
       filename_core: cor_rh.fv_core.res.nc
       filename_trcr: cor_rh.fv_tracer.res.nc
       filename_cplr: cor_rh.coupler.res
@@ -34,7 +35,7 @@ saber blocks:
     set datetime on read: true
     psinfile: true
     datapath: *staticb_aero_dir
-    prefix: stddev/20160630.000000
+    prefix: '20160630.000000'
     filename_core: stddev.fv_core.res.nc
     filename_trcr: stddev.fv_tracer.res.nc
     filename_cplr: stddev.coupler.res

--- a/parm/aero/obs/lists/gdas_aero_prototype.yaml
+++ b/parm/aero/obs/lists/gdas_aero_prototype.yaml
@@ -1,3 +1,3 @@
 observers:
-- $<< $(OBS_YAML_DIR)/viirs_n20_aod.yaml
+#- $<< $(OBS_YAML_DIR)/viirs_n20_aod.yaml
 - $<< $(OBS_YAML_DIR)/viirs_npp_aod.yaml

--- a/parm/aero/variational/3dvar_gfs_aero.yaml
+++ b/parm/aero/variational/3dvar_gfs_aero.yaml
@@ -41,7 +41,7 @@ final:
     geometry: $(GEOM_BKG)
     output: 
       datapath: $(ANL_DIR)
-      prefix: aeroinc. 
+      prefix: aeroinc
       filetype: fms restart
       filename_core: $(BKG_YYYYmmddHHMMSS).fv_core.res.nc
       filename_trcr: $(BKG_YYYYmmddHHMMSS).fv_tracer.res.nc


### PR DESCRIPTION
As the title says, this PR makes some minor change to get 3DVar aerosol DA cycling going within the global-workflow.

`sulf` -> `so4` for the new UFS-aerosols naming convention
`prefix` is modified in several places
VIIRS NOAA-20 is commented out since we only have NPP obs right now.
