### PR TITLE
Adding bufr2ioda test output to r2d2 database in soca test

### DIFF
--- a/test/soca/CMakeLists.txt
+++ b/test/soca/CMakeLists.txt
@@ -1,14 +1,3 @@
-# Create a test R2D2 database for obs
-# -----------------------------------
-file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/test/soca/obs)
-set( OBS_DIR ${PROJECT_BINARY_DIR}/test/testdata )
-add_test(NAME test_gdasapp_soca_obsdb
-         COMMAND ${PROJECT_SOURCE_DIR}/test/soca/create_obsdb.py
-         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/soca/obs/)
-set_tests_properties(test_gdasapp_soca_obsdb
-    PROPERTIES
-    ENVIRONMENT "PYTHONPATH=${PROJECT_BINARY_DIR}/ush:$ENV{PYTHONPATH};OBS_DIR=${OBS_DIR}")
-
 # Copy the bkg files
 # ------------------
 set( TESTDATA ${PROJECT_BINARY_DIR}/test/testdata )
@@ -69,6 +58,17 @@ if(BUILD_GDASBUNDLE)
   # install
   install(FILES ${test_input}
           DESTINATION "test/testinput/")
+
+# Create a test R2D2 database for obs
+# -----------------------------------
+file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/test/soca/obs)
+set( OBS_DIR ${PROJECT_BINARY_DIR}/test/testdata )
+add_test(NAME test_gdasapp_soca_obsdb
+         COMMAND ${PROJECT_SOURCE_DIR}/test/soca/create_obsdb.py
+         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/soca/obs/)
+set_tests_properties(test_gdasapp_soca_obsdb
+    PROPERTIES
+    ENVIRONMENT "PYTHONPATH=${PROJECT_BINARY_DIR}/ush:$ENV{PYTHONPATH};OBS_DIR=${OBS_DIR}")
 
   # Test exgdas_global_marine_analysis_prep.py
   # ------------------------------------------

--- a/test/soca/create_obsdb.py
+++ b/test/soca/create_obsdb.py
@@ -40,9 +40,9 @@ if __name__ == "__main__":
     ufsda.r2d2.store(obsstore)
 
 # Create the test R2D2 database for output from bufr2ioda tests
-    obsstore['source_dir'] =  '../../testoutput/'
-    obsstore['source_file_fmt'] ='{source_dir}/{obs_type}_{year}{month}{day}.nc'
-    obsstore['obs_types']= ['bufr_dbuoyprof',
+    obsstore['source_dir'] = '../../testoutput/'
+    obsstore['source_file_fmt'] = '{source_dir}/{obs_type}_{year}{month}{day}.nc'
+    obsstore['obs_types'] = ['bufr_dbuoyprof',
                             'bufr_mbuoybprof',
                             'bufr_sfcships',
                             'bufr_sfcshipsu']
@@ -50,7 +50,7 @@ if __name__ == "__main__":
 
     obsstore['start'] = '2018-04-01T00:00:00Z'
     obsstore['end'] = '2018-04-01T00:00:00Z'
-    obsstore['source_file_fmt'] ='{source_dir}/{obs_type}_{year}{month}.nc'
+    obsstore['source_file_fmt'] = '{source_dir}/{obs_type}_{year}{month}.nc'
     obsstore['obs_types'] = ['bufr_tesacprof',
                              'bufr_trkobprof']
     ufsda.r2d2.store(obsstore)

--- a/test/soca/create_obsdb.py
+++ b/test/soca/create_obsdb.py
@@ -43,9 +43,9 @@ if __name__ == "__main__":
     obsstore['source_dir'] = '../../testoutput/'
     obsstore['source_file_fmt'] = '{source_dir}/{obs_type}_{year}{month}{day}.nc'
     obsstore['obs_types'] = ['bufr_dbuoyprof',
-                            'bufr_mbuoybprof',
-                            'bufr_sfcships',
-                            'bufr_sfcshipsu']
+                             'bufr_mbuoybprof',
+                             'bufr_sfcships',
+                             'bufr_sfcshipsu']
     ufsda.r2d2.store(obsstore)
 
     obsstore['start'] = '2018-04-01T00:00:00Z'

--- a/test/soca/create_obsdb.py
+++ b/test/soca/create_obsdb.py
@@ -50,7 +50,9 @@ if __name__ == "__main__":
                          'provider': 'gdasapp',
                          'experiment': 'soca',
                          'obs_types': ['bufr_dbuoyprof',
-                                       'bufr_mbuoybprof']})
+                                       'bufr_mbuoybprof',
+                                       'bufr_sfcships',
+                                       'bufr_sfcshipsu']})
     ufsda.r2d2.store(obsstore)
 
 # Create the test R2D2 database for output from bufr2ioda tests

--- a/test/soca/create_obsdb.py
+++ b/test/soca/create_obsdb.py
@@ -37,5 +37,33 @@ if __name__ == "__main__":
                                        'salt_profile_fnmoc',
                                        'icec_EMC',
                                        'icefb_GDR']})
-
     ufsda.r2d2.store(obsstore)
+
+# Create the test R2D2 database for output from bufr2ioda tests
+    obsstore = NiceDict({'start': '2018-04-15T00:00:00Z',
+                         'end': '2018-04-15T00:00:00Z',
+                         'step': 'PT24H',
+                         'source_dir': '../../testoutput/',
+                         'source_file_fmt': '{source_dir}/{obs_type}_{year}{month}{day}.nc',
+                         'type': 'ob',
+                         'database': 'shared',
+                         'provider': 'gdasapp',
+                         'experiment': 'soca',
+                         'obs_types': ['bufr_dbuoyprof',
+                                       'bufr_mbuoybprof']})
+    ufsda.r2d2.store(obsstore)
+
+# Create the test R2D2 database for output from bufr2ioda tests
+    obsstore = NiceDict({'start': '2018-04-01T00:00:00Z',
+                         'end': '2018-04-01T00:00:00Z',
+                         'step': 'PT24H',
+                         'source_dir': '../../testoutput/',
+                         'source_file_fmt': '{source_dir}/{obs_type}_{year}{month}.nc',
+                         'type': 'ob',
+                         'database': 'shared',
+                         'provider': 'gdasapp',
+                         'experiment': 'soca',
+                         'obs_types': ['bufr_tesacprof',
+                                       'bufr_trkobprof']})
+    ufsda.r2d2.store(obsstore)
+

--- a/test/soca/create_obsdb.py
+++ b/test/soca/create_obsdb.py
@@ -40,31 +40,17 @@ if __name__ == "__main__":
     ufsda.r2d2.store(obsstore)
 
 # Create the test R2D2 database for output from bufr2ioda tests
-    obsstore = NiceDict({'start': '2018-04-15T00:00:00Z',
-                         'end': '2018-04-15T00:00:00Z',
-                         'step': 'PT24H',
-                         'source_dir': '../../testoutput/',
-                         'source_file_fmt': '{source_dir}/{obs_type}_{year}{month}{day}.nc',
-                         'type': 'ob',
-                         'database': 'shared',
-                         'provider': 'gdasapp',
-                         'experiment': 'soca',
-                         'obs_types': ['bufr_dbuoyprof',
-                                       'bufr_mbuoybprof',
-                                       'bufr_sfcships',
-                                       'bufr_sfcshipsu']})
+    obsstore['source_dir'] =  '../../testoutput/'
+    obsstore['source_file_fmt'] ='{source_dir}/{obs_type}_{year}{month}{day}.nc'
+    obsstore['obs_types']= ['bufr_dbuoyprof',
+                            'bufr_mbuoybprof',
+                            'bufr_sfcships',
+                            'bufr_sfcshipsu']
     ufsda.r2d2.store(obsstore)
 
-# Create the test R2D2 database for output from bufr2ioda tests
-    obsstore = NiceDict({'start': '2018-04-01T00:00:00Z',
-                         'end': '2018-04-01T00:00:00Z',
-                         'step': 'PT24H',
-                         'source_dir': '../../testoutput/',
-                         'source_file_fmt': '{source_dir}/{obs_type}_{year}{month}.nc',
-                         'type': 'ob',
-                         'database': 'shared',
-                         'provider': 'gdasapp',
-                         'experiment': 'soca',
-                         'obs_types': ['bufr_tesacprof',
-                                       'bufr_trkobprof']})
+    obsstore['start'] = '2018-04-01T00:00:00Z'
+    obsstore['end'] = '2018-04-01T00:00:00Z'
+    obsstore['source_file_fmt'] ='{source_dir}/{obs_type}_{year}{month}.nc'
+    obsstore['obs_types'] = ['bufr_tesacprof',
+                             'bufr_trkobprof']
     ufsda.r2d2.store(obsstore)

--- a/test/soca/create_obsdb.py
+++ b/test/soca/create_obsdb.py
@@ -66,4 +66,3 @@ if __name__ == "__main__":
                          'obs_types': ['bufr_tesacprof',
                                        'bufr_trkobprof']})
     ufsda.r2d2.store(obsstore)
-


### PR DESCRIPTION
Adds existing bufr2ioda test output in soca test to r2d2 database

Files changed:

test/soca/CMakeLists.txt
test/soca/create_obsdb.py

Fulfills implicit requirement of https://github.com/NOAA-EMC/godas/issues/412

Comments on approach:

New dictionaries are created separately from the existing one to process into the database. This is in part to have a simple way to deal with the new ioda files being located in a different subdirectory from the existing input,  and that two of the new sources (bufr_tesacprof and bufr_trkobprof) have a slightly different filename format and are from a different date. This is done with the understanding that the the database consists of the files output into build/test/soca/obs/r2d2-shared/gdasapp/ob/soca/P1D/ and there is no other hidden output or state that is clobbered by calling ufsda.r2d2.store multiple times.

The obs_types are presumed to be ok with the format of bufr_\<source\>, which is different from the existing ones. Also, as discussed with Guillaume, the date format in the new sources are in unix epoch seconds, vs. the ISO-whatever form of existing ones. 