### PR TITLE
Make cloning JCSDA test data repositories optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,16 +136,6 @@ if(CLONE_JCSDADATA)
                       BRANCH ${GIT_BRANCH_FUNC} )
     endif()
 
-  # same procedure for saber-data
-    find_branch_name(REPO_DIR_NAME saber)
-    if( NOT DEFINED ENV{LOCAL_PATH_JEDI_TESTFILES} AND NOT DEFINED GIT_TAG_FUNC )
-      ecbuild_bundle( PROJECT saber-data GIT "https://github.com/JCSDA-internal/saber-data.git" BRANCH develop UPDATE )
-
-      # If saber's current branch is available in saber-data repo, that branch will be checked out
-      branch_checkout (REPO_DIR_NAME saber-data
-                      BRANCH ${GIT_BRANCH_FUNC} )
-    endif()
-
   endif(CLONE_JCSDADATA)
 
 endif(BUILD_GDASBUNDLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ set( ENABLE_MPI ON CACHE BOOL "Compile with MPI" )
 
 # Handle user options.
 option(BUILD_GDASBUNDLE "Build GDAS Bundle" ON)
+option(CLONE_JCSDADATA "Clone JCSDA test data repositories" OFF)
 
 # Initialize bundle
 # -----------------
@@ -96,53 +97,56 @@ if(BUILD_GDASBUNDLE)
 
 # ioda, ufo, fv3-jedi, and saber test data
 #---------------------------------
+if(CLONE_JCSDADATA)
 
-# If IODA branch is being built set GIT_BRANCH_FUNC to IODA's current branch.
-# If a tagged version of IODA is being built set GIT_TAG_FUNC to ioda's current tag. In this case,
-# IODA test files will be download from UCAR DASH and ioda-data repo will not be cloned.
-# When LOCAL_PATH_JEDI_TESTFILES is set to the directory of IODA test files stored
-# in a local directory, ioda-data repo will not be cloned
+  # If IODA branch is being built set GIT_BRANCH_FUNC to IODA's current branch.
+  # If a tagged version of IODA is being built set GIT_TAG_FUNC to ioda's current tag. In this case,
+  # IODA test files will be download from UCAR DASH and ioda-data repo will not be cloned.
+  # When LOCAL_PATH_JEDI_TESTFILES is set to the directory of IODA test files stored
+  # in a local directory, ioda-data repo will not be cloned
 
-  find_branch_name(REPO_DIR_NAME ioda)
-# When LOCAL_PATH_JEDI_TESTFILES is set to the directory of IODA test files stored
-# in a local directory, ioda-data repo will not be cloned
-  if( NOT DEFINED ENV{LOCAL_PATH_JEDI_TESTFILES} AND NOT DEFINED GIT_TAG_FUNC )
-    ecbuild_bundle( PROJECT ioda-data GIT "https://github.com/JCSDA-internal/ioda-data.git" BRANCH develop UPDATE )
+    find_branch_name(REPO_DIR_NAME ioda)
+  # When LOCAL_PATH_JEDI_TESTFILES is set to the directory of IODA test files stored
+  # in a local directory, ioda-data repo will not be cloned
+    if( NOT DEFINED ENV{LOCAL_PATH_JEDI_TESTFILES} AND NOT DEFINED GIT_TAG_FUNC )
+      ecbuild_bundle( PROJECT ioda-data GIT "https://github.com/JCSDA-internal/ioda-data.git" BRANCH develop UPDATE )
 
-    # If IODA's current branch is available in ioda-data repo, that branch will be checked out
-    branch_checkout (REPO_DIR_NAME ioda-data
-                    BRANCH ${GIT_BRANCH_FUNC} )
-  endif()
+      # If IODA's current branch is available in ioda-data repo, that branch will be checked out
+      branch_checkout (REPO_DIR_NAME ioda-data
+                      BRANCH ${GIT_BRANCH_FUNC} )
+    endif()
 
-# same procedure for ufo-data
-  find_branch_name(REPO_DIR_NAME ufo)
-  if( NOT DEFINED ENV{LOCAL_PATH_JEDI_TESTFILES} AND NOT DEFINED GIT_TAG_FUNC )
-    ecbuild_bundle( PROJECT ufo-data GIT "https://github.com/JCSDA-internal/ufo-data.git" BRANCH develop UPDATE )
+  # same procedure for ufo-data
+    find_branch_name(REPO_DIR_NAME ufo)
+    if( NOT DEFINED ENV{LOCAL_PATH_JEDI_TESTFILES} AND NOT DEFINED GIT_TAG_FUNC )
+      ecbuild_bundle( PROJECT ufo-data GIT "https://github.com/JCSDA-internal/ufo-data.git" BRANCH develop UPDATE )
 
-    # If UFO's current branch is available in ioda-data repo, that branch will be checked out
-    branch_checkout (REPO_DIR_NAME ufo-data
-                    BRANCH ${GIT_BRANCH_FUNC} )
-  endif()
+      # If UFO's current branch is available in ioda-data repo, that branch will be checked out
+      branch_checkout (REPO_DIR_NAME ufo-data
+                      BRANCH ${GIT_BRANCH_FUNC} )
+    endif()
 
-# same procedure for fv3-jedi-data
-  find_branch_name(REPO_DIR_NAME fv3-jedi)
-  if( NOT DEFINED ENV{LOCAL_PATH_JEDI_TESTFILES} AND NOT DEFINED GIT_TAG_FUNC )
-    ecbuild_bundle( PROJECT fv3-jedi-data GIT "https://github.com/JCSDA-internal/fv3-jedi-data.git" BRANCH develop UPDATE )
+  # same procedure for fv3-jedi-data
+    find_branch_name(REPO_DIR_NAME fv3-jedi)
+    if( NOT DEFINED ENV{LOCAL_PATH_JEDI_TESTFILES} AND NOT DEFINED GIT_TAG_FUNC )
+      ecbuild_bundle( PROJECT fv3-jedi-data GIT "https://github.com/JCSDA-internal/fv3-jedi-data.git" BRANCH develop UPDATE )
 
-    # If fv3-jedi's current branch is available in ioda-data repo, that branch will be checked out
-    branch_checkout (REPO_DIR_NAME fv3-jedi-data
-                    BRANCH ${GIT_BRANCH_FUNC} )
-  endif()
+      # If fv3-jedi's current branch is available in ioda-data repo, that branch will be checked out
+      branch_checkout (REPO_DIR_NAME fv3-jedi-data
+                      BRANCH ${GIT_BRANCH_FUNC} )
+    endif()
 
-# same procedure for saber-data
-  find_branch_name(REPO_DIR_NAME saber)
-  if( NOT DEFINED ENV{LOCAL_PATH_JEDI_TESTFILES} AND NOT DEFINED GIT_TAG_FUNC )
-    ecbuild_bundle( PROJECT saber-data GIT "https://github.com/JCSDA-internal/saber-data.git" BRANCH develop UPDATE )
+  # same procedure for saber-data
+    find_branch_name(REPO_DIR_NAME saber)
+    if( NOT DEFINED ENV{LOCAL_PATH_JEDI_TESTFILES} AND NOT DEFINED GIT_TAG_FUNC )
+      ecbuild_bundle( PROJECT saber-data GIT "https://github.com/JCSDA-internal/saber-data.git" BRANCH develop UPDATE )
 
-    # If saber's current branch is available in saber-data repo, that branch will be checked out
-    branch_checkout (REPO_DIR_NAME saber-data
-                    BRANCH ${GIT_BRANCH_FUNC} )
-  endif()
+      # If saber's current branch is available in saber-data repo, that branch will be checked out
+      branch_checkout (REPO_DIR_NAME saber-data
+                      BRANCH ${GIT_BRANCH_FUNC} )
+    endif()
+
+  endif(CLONE_JCSDADATA)
 
 endif(BUILD_GDASBUNDLE)
 

--- a/build.sh
+++ b/build.sh
@@ -19,6 +19,7 @@ usage() {
   echo "  -t  target to build for <target>    DEFAULT: $(hostname)"
   echo "  -c  additional CMake options        DEFAULT: <none>"
   echo "  -v  build with verbose output       DEFAULT: NO"
+  echo "  -d  include JCSDA ctest data        DEFAULT: NO"
   echo "  -h  display this message and quit"
   echo
   exit 1
@@ -31,8 +32,9 @@ INSTALL_PREFIX=""
 CMAKE_OPTS=""
 BUILD_TARGET="$(hostname)"
 BUILD_VERBOSE="NO"
+CLONE_JCSDADATA="NO"
 
-while getopts "p:t:c:hv" opt; do
+while getopts "p:t:c:hvd" opt; do
   case $opt in
     p)
       INSTALL_PREFIX=$OPTARG
@@ -45,6 +47,9 @@ while getopts "p:t:c:hv" opt; do
       ;;
     v)
       BUILD_VERBOSE=YES
+      ;;
+    d)
+      CLONE_JCSDADATA=YES
       ;;
     h|\?|:)
       usage
@@ -61,6 +66,7 @@ case ${BUILD_TARGET} in
     module use $dir_root/modulefiles
     module load GDAS/$BUILD_TARGET
     CMAKE_OPTS+=" -DMPIEXEC_EXECUTABLE=$MPIEXEC_EXEC -DMPIEXEC_NUMPROC_FLAG=$MPIEXEC_NPROC -DBUILD_GSIBEC=ON"
+    CMAKE_OPTS+=" -DCLONE_JCSDADATA=$CLONE_JCSDADATA"
     module list
     set -e
     ;;


### PR DESCRIPTION
In anticipation of the ability to make the building of JEDI ctests optional, this PR adds the cloning of the JCSDA test data repositories (ufo-data, fv3-jedi-data, etc.) optional. 