### PR TITLE
Changes to build script and some preparation for CRTM 2.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ if(BUILD_GDASBUNDLE)
   ecbuild_bundle( PROJECT atlas GIT "https://github.com/ecmwf/atlas.git" TAG 0.29.0 )
 
 # External (required) observation operators
-  option("BUNDLE_SKIP_CRTM" "Don't build CRTM" "ON") # Don't build crtm unless user passes -DBUNDLE_SKIP_CRTM=OFF
+  option("BUNDLE_SKIP_CRTM" "Don't build CRTM" "OFF") # Don't build crtm unless user passes -DBUNDLE_SKIP_CRTM=OFF
   ecbuild_bundle( PROJECT crtm GIT "https://github.com/jcsda/crtm.git"   TAG v2.3-jedi.3 )
 
 # Build GSI-B

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ if(BUILD_GDASBUNDLE)
   ecbuild_bundle( PROJECT atlas GIT "https://github.com/ecmwf/atlas.git" TAG 0.29.0 )
 
 # External (required) observation operators
+  option("BUNDLE_SKIP_CRTM" "Don't build CRTM" "ON") # Don't build crtm unless user passes -DBUNDLE_SKIP_CRTM=OFF
   ecbuild_bundle( PROJECT crtm GIT "https://github.com/jcsda/crtm.git"   TAG v2.3-jedi.3 )
 
 # Build GSI-B

--- a/build.sh
+++ b/build.sh
@@ -36,7 +36,7 @@ BUILD_VERBOSE="NO"
 CLONE_JCSDADATA="NO"
 CLEAN_BUILD="NO"
 
-while getopts "p:t:c:hvd" opt; do
+while getopts "p:t:c:hvdf" opt; do
   case $opt in
     p)
       INSTALL_PREFIX=$OPTARG

--- a/build.sh
+++ b/build.sh
@@ -21,6 +21,7 @@ usage() {
   echo "  -v  build with verbose output       DEFAULT: NO"
   echo "  -f  force a clean build             DEFAULT: NO"
   echo "  -d  include JCSDA ctest data        DEFAULT: NO"
+  echo "  -a  build everything in bundle      DEFAULT: NO"
   echo "  -h  display this message and quit"
   echo
   exit 1
@@ -35,8 +36,9 @@ BUILD_TARGET="$(hostname)"
 BUILD_VERBOSE="NO"
 CLONE_JCSDADATA="NO"
 CLEAN_BUILD="NO"
+BUILD_JCSDA="NO"
 
-while getopts "p:t:c:hvdf" opt; do
+while getopts "p:t:c:hvdfa" opt; do
   case $opt in
     p)
       INSTALL_PREFIX=$OPTARG
@@ -55,6 +57,9 @@ while getopts "p:t:c:hvdf" opt; do
       ;;
     f)
       CLEAN_BUILD=YES
+      ;;
+    a)
+      BUILD_JCSDA=YES
       ;;
     h|\?|:)
       usage
@@ -102,13 +107,17 @@ set +x
 
 # Build
 echo "Building ..."
-builddirs="fv3-jedi soca iodaconv"
 set -x
-for b in $builddirs; do
-  cd $b
+if [[ $BUILD_JCSDA == 'YES' ]]; then
   make -j ${BUILD_JOBS:-6} VERBOSE=$BUILD_VERBOSE
-  cd ../
-done
+else
+  builddirs="fv3-jedi soca iodaconv"
+  for b in $builddirs; do
+    cd $b
+    make -j ${BUILD_JOBS:-6} VERBOSE=$BUILD_VERBOSE
+    cd ../
+  done
+fi
 set +x
 
 # Install

--- a/modulefiles/GDAS/hera.lua
+++ b/modulefiles/GDAS/hera.lua
@@ -63,7 +63,7 @@ load("ncview/2.1.8")
 load("netcdf-cxx4/4.3.1")
 load("json/3.10.5")
 load("py-pybind11/2.8.1")
-load("crtm/v2.3-jedi.4")
+--load("crtm/v2.4_jedi")
 
 load("hpc/1.2.0")
 load("miniconda3/4.6.14")

--- a/modulefiles/GDAS/hera.lua
+++ b/modulefiles/GDAS/hera.lua
@@ -63,6 +63,7 @@ load("ncview/2.1.8")
 load("netcdf-cxx4/4.3.1")
 load("json/3.10.5")
 load("py-pybind11/2.8.1")
+load("crtm/v2.3-jedi.4")
 
 load("hpc/1.2.0")
 load("miniconda3/4.6.14")

--- a/modulefiles/GDAS/orion.lua
+++ b/modulefiles/GDAS/orion.lua
@@ -57,6 +57,7 @@ load("udunits/2.2.28")
 load("ncview/2.1.8")
 load("netcdf-cxx4/4.3.1")
 load("py-pybind11/2.8.1")
+load("crtm/v2.3-jedi.4")
 
 load("hpc/1.2.0")
 load("miniconda3/4.6.14")

--- a/modulefiles/GDAS/orion.lua
+++ b/modulefiles/GDAS/orion.lua
@@ -57,7 +57,7 @@ load("udunits/2.2.28")
 load("ncview/2.1.8")
 load("netcdf-cxx4/4.3.1")
 load("py-pybind11/2.8.1")
-load("crtm/v2.3-jedi.4")
+--load("crtm/v2.4_jedi")
 
 load("hpc/1.2.0")
 load("miniconda3/4.6.14")


### PR DESCRIPTION
This PR does 3 main things:

1. Make the build script have an option (`-f` off by default) to clean the build directory. This way the default behavior should now only rebuild what is necessary 
2. The build script now no longer runs `make` in the root build directory, but rather within fv3-jedi, soca, and iodaconv. This is to speed up build time and not build unnecessary tests and other things from the other repositories that we only need as libraries. To build everything, use option `-a`
3. Places pieces in modulefiles and CMakeLists.txt to prepare for using CRTM2.4 from the spack-stack rather than cloning/building CRTM