### PR TITLE
parted out dbuoyprof and mbuoybprof salt and temp in soca tests

### DIFF
--- a/parm/soca/obs/config/salt_bufr_dbuoyprof.yaml
+++ b/parm/soca/obs/config/salt_bufr_dbuoyprof.yaml
@@ -1,0 +1,15 @@
+obs space:
+  name: salt_bufr_dbuoyprof
+  obsdatain:
+    engine:
+      type: H5File
+      obsfile: ${OBS_DIR}/${OBS_PREFIX}salt_bufr_dbuoyprof.${OBS_DATE}.nc4
+  obsdataout:
+    engine:
+      type: H5File
+      obsfile: ${DIAG_DIR}/salt_bufr_dbuoyprof.${OBS_DATE}.nc4
+  simulated variables: [sea_water_salinity]
+obs operator:
+  name: Identity
+obs error:
+  covariance model: diagonal

--- a/parm/soca/obs/config/salt_bufr_mbuoybprof.yaml
+++ b/parm/soca/obs/config/salt_bufr_mbuoybprof.yaml
@@ -1,0 +1,15 @@
+obs space:
+  name: salt_bufr_mbuoybprof
+  obsdatain:
+    engine:
+      type: H5File
+      obsfile: ${OBS_DIR}/${OBS_PREFIX}salt_bufr_mbuoybprof.${OBS_DATE}.nc4
+  obsdataout:
+    engine:
+      type: H5File
+      obsfile: ${DIAG_DIR}/salt_bufr_mbuoybprof.${OBS_DATE}.nc4
+  simulated variables: [sea_water_salinity]
+obs operator:
+  name: Identity
+obs error:
+  covariance model: diagonal

--- a/parm/soca/obs/config/temp_bufr_dbuoyprof.yaml
+++ b/parm/soca/obs/config/temp_bufr_dbuoyprof.yaml
@@ -1,13 +1,13 @@
 obs space:
-  name: bufr_mbuoybprof
+  name: temp_bufr_dbuoyprof
   obsdatain:
     engine:
       type: H5File
-      obsfile: ${OBS_DIR}/${OBS_PREFIX}bufr_mbuoybprof.${OBS_DATE}.nc4
+      obsfile: ${OBS_DIR}/${OBS_PREFIX}temp_bufr_dbuoyprof.${OBS_DATE}.nc4
   obsdataout:
     engine:
       type: H5File
-      obsfile: ${DIAG_DIR}/bufr_mbuoybprof.${OBS_DATE}.nc4
+      obsfile: ${DIAG_DIR}/temp_bufr_dbuoyprof.${OBS_DATE}.nc4
   simulated variables: [sea_water_temperature]
 obs operator:
   name: Identity

--- a/parm/soca/obs/config/temp_bufr_mbuoybprof.yaml
+++ b/parm/soca/obs/config/temp_bufr_mbuoybprof.yaml
@@ -1,13 +1,13 @@
 obs space:
-  name: bufr_dbuoyprof
+  name: temp_bufr_mbuoybprof
   obsdatain:
     engine:
       type: H5File
-      obsfile: ${OBS_DIR}/${OBS_PREFIX}bufr_dbuoyprof.${OBS_DATE}.nc4
+      obsfile: ${OBS_DIR}/${OBS_PREFIX}temp_bufr_mbuoybprof.${OBS_DATE}.nc4
   obsdataout:
     engine:
       type: H5File
-      obsfile: ${DIAG_DIR}/bufr_dbuoyprof.${OBS_DATE}.nc4
+      obsfile: ${DIAG_DIR}/temp_bufr_mbuoybprof.${OBS_DATE}.nc4
   simulated variables: [sea_water_temperature]
 obs operator:
   name: Identity

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -50,8 +50,10 @@ list(APPEND test_input
   ${PROJECT_SOURCE_DIR}/test/testinput/check_yaml_keys_test.yaml
   ${PROJECT_SOURCE_DIR}/test/testinput/bufr_adpsfc.yaml
   ${PROJECT_SOURCE_DIR}/test/testinput/amsua_n19_ewok.yaml
-  ${PROJECT_SOURCE_DIR}/test/testinput/bufr_dbuoy.yaml
-  ${PROJECT_SOURCE_DIR}/test/testinput/bufr_mbuoyb.yaml
+  ${PROJECT_SOURCE_DIR}/test/testinput/temp_bufr_dbuoyprof.yaml
+  ${PROJECT_SOURCE_DIR}/test/testinput/salt_bufr_dbuoyprof.yaml
+  ${PROJECT_SOURCE_DIR}/test/testinput/temp_bufr_mbuoybprof.yaml
+  ${PROJECT_SOURCE_DIR}/test/testinput/salt_bufr_mbuoybprof.yaml
   ${PROJECT_SOURCE_DIR}/test/testinput/bufr_tesac.yaml
   ${PROJECT_SOURCE_DIR}/test/testinput/bufr_trkob.yaml
   ${PROJECT_SOURCE_DIR}/test/testinput/bufr_sfcships.yaml

--- a/test/soca/CMakeLists.txt
+++ b/test/soca/CMakeLists.txt
@@ -8,12 +8,20 @@ file(COPY ${bkg_diag} DESTINATION ${PROJECT_BINARY_DIR}/test/soca/bkg/RESTART)
 
 # link input file from iodaconv to test directory
 # test convert BUFR to IODA
-add_test(NAME test_gdasapp_convert_bufr_dbuoy
-         COMMAND ${PROJECT_BINARY_DIR}/bin/bufr2ioda.x ${PROJECT_BINARY_DIR}/test/testinput/bufr_dbuoy.yaml
+add_test(NAME test_gdasapp_convert_bufr_temp_dbuoy
+         COMMAND ${PROJECT_BINARY_DIR}/bin/bufr2ioda.x ${PROJECT_BINARY_DIR}/test/testinput/temp_bufr_dbuoyprof.yaml
          WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/)
 
-add_test(NAME test_gdasapp_convert_bufr_mbuoyb
-         COMMAND ${PROJECT_BINARY_DIR}/bin/bufr2ioda.x ${PROJECT_BINARY_DIR}/test/testinput/bufr_mbuoyb.yaml
+add_test(NAME test_gdasapp_convert_bufr_salt_dbuoy
+         COMMAND ${PROJECT_BINARY_DIR}/bin/bufr2ioda.x ${PROJECT_BINARY_DIR}/test/testinput/salt_bufr_dbuoyprof.yaml
+         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/)
+
+add_test(NAME test_gdasapp_convert_bufr_temp_mbuoyb
+         COMMAND ${PROJECT_BINARY_DIR}/bin/bufr2ioda.x ${PROJECT_BINARY_DIR}/test/testinput/temp_bufr_mbuoybprof.yaml
+         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/)
+
+add_test(NAME test_gdasapp_convert_bufr_salt_mbuoyb
+         COMMAND ${PROJECT_BINARY_DIR}/bin/bufr2ioda.x ${PROJECT_BINARY_DIR}/test/testinput/salt_bufr_mbuoybprof.yaml
          WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/)
 
 add_test(NAME test_gdasapp_convert_bufr_tesac

--- a/test/soca/create_obsdb.py
+++ b/test/soca/create_obsdb.py
@@ -42,8 +42,10 @@ if __name__ == "__main__":
 # Create the test R2D2 database for output from bufr2ioda tests
     obsstore['source_dir'] = '../../testoutput/'
     obsstore['source_file_fmt'] = '{source_dir}/{obs_type}_{year}{month}{day}.nc'
-    obsstore['obs_types'] = ['bufr_dbuoyprof',
-                             'bufr_mbuoybprof',
+    obsstore['obs_types'] = ['temp_bufr_dbuoyprof',
+                             'salt_bufr_dbuoyprof',
+                             'temp_bufr_mbuoybprof',
+                             'salt_bufr_mbuoybprof',
                              'bufr_sfcships',
                              'bufr_sfcshipsu']
     ufsda.r2d2.store(obsstore)

--- a/test/testinput/salt_bufr_dbuoyprof.yaml
+++ b/test/testinput/salt_bufr_dbuoyprof.yaml
@@ -21,10 +21,6 @@ observations:
             query: "*/CLAT"
           depth:
             query: "*/DTSCUR/DBSS"
-          temp:
-            query: "*/DTSCUR/STMP"
-            transforms:
-              - offset: -273.15
           saln:
             query: "*/DTSCUR/SALN"
         filters:
@@ -32,21 +28,18 @@ observations:
               variable: depth
               lowerBound: 0
               upperBound: 10000
-              variable: temp
-              lowerBound: 250.15
-              upperBound: 313.15
               variable: saln
               lowerBound: 0.0
               upperBound: 40.0
 
     ioda:
       backend: netcdf
-      obsdataout: "./testoutput/bufr_dbuoyprof_20180415.nc"
+      obsdataout: "./testoutput/salt_bufr_dbuoyprof_20180415.nc"
 
       globals:
         - name: "dataType-date"
           type: string
-          value: "Drifting Buoy Temp & Salinity Profile - 2018041512"
+          value: "Drifting Buoy Salinity Profile - 2018041512"
 
       dimensions:
         - name: nlevs
@@ -79,12 +72,6 @@ observations:
           source: variables/depth
           longName: "Depth below sea surface"
           units: "m"
-
-        - name: "sea_water_temperature@ObsValue"
-          source: variables/temp
-          longName: "Temperature at depth"
-          units: "deg C"
-          range: [-23.0, 40.0]
 
         - name: "sea_water_salinity@ObsValue"
           source: variables/saln

--- a/test/testinput/salt_bufr_mbuoybprof.yaml
+++ b/test/testinput/salt_bufr_mbuoybprof.yaml
@@ -1,0 +1,79 @@
+observations:
+  - obs space:
+      name: bufr
+      obsdatain: "./testdata/mbuoyb.20180415_subsampled"
+
+      exports:
+        group_by_variable: depth  # Optional
+        variables:
+          timestamp:
+            datetime:
+              year: "*/YEAR"
+              month: "*/MNTH"
+              day: "*/DAYS"
+              hour: "*/HOUR"
+              minute: "*/MINU"
+          stationID:
+            query: "*/RPID"
+          longitude:
+            query: "*/CLONH"
+          latitude:
+            query: "*/CLATH"
+          depth:
+            query: "*/IDMSMDBS/BBYSTSL/DBSS"
+          saln:
+            query: "*/IDMSMDBS/BBYSTSL/SALN"
+        filters:
+          - bounding:
+              variable: depth
+              lowerBound: 0
+              upperBound: 10000
+              variable: saln
+              lowerBound: 0.0
+              upperBound: 40.0
+    ioda:
+      backend: netcdf
+      obsdataout: "./testoutput/salt_bufr_mbuoybprof_20180415.nc"
+
+      globals:
+        - name: "dataType-date"
+          type: string
+          value: "Moored Buoy Salinity Profile - 2018041512"
+
+      dimensions:
+        - name: nlevs
+          path: "*/IDMSMDBS"
+
+      variables:
+        - name: "dateTime@MetaData"
+          source: variables/timestamp
+          longName: "dateTime"
+          units: "seconds since 1970-01-01T00:00:00Z"
+
+        - name: "latitude@MetaData"
+          source: variables/latitude
+          longName: "Latitude"
+          units: "degrees_north"
+          range: [-90, 90]
+
+        - name: "longitude@MetaData"
+          source: variables/longitude
+          longName: "Longitude"
+          units: "degrees_east"
+          range: [-180, 180]
+
+        - name: "stationID@MetaData"
+          source: variables/stationID
+          longName: "sgn/Report Identifier"
+          units: "N/A"
+
+        - name: "depth@MetaData"
+          source: variables/depth
+          longName: "Depth below sea surface"
+          units: "m"
+
+        - name: "sea_water_salinity@ObsValue"
+          source: variables/saln
+          longName: "Salinity at depth"
+          units: "psu"
+          range: [0.0, 40.0]

--- a/test/testinput/temp_bufr_dbuoyprof.yaml
+++ b/test/testinput/temp_bufr_dbuoyprof.yaml
@@ -1,7 +1,7 @@
 observations:
   - obs space:
       name: bufr
-      obsdatain: "./testdata/mbuoyb.20180415_subsampled"
+      obsdatain: "./testdata/dbuoy.20180415_subsampled" 
 
       exports:
         group_by_variable: depth  # Optional
@@ -16,17 +16,15 @@ observations:
           stationID:
             query: "*/RPID"
           longitude:
-            query: "*/CLONH"
+            query: "*/CLON"
           latitude:
-            query: "*/CLATH"
+            query: "*/CLAT"
           depth:
-            query: "*/IDMSMDBS/BBYSTSL/DBSS"
+            query: "*/DTSCUR/DBSS"
           temp:
-            query: "*/IDMSMDBS/BBYSTSL/SST1"
+            query: "*/DTSCUR/STMP"
             transforms:
               - offset: -273.15
-          saln:
-            query: "*/IDMSMDBS/BBYSTSL/SALN"
         filters:
           - bounding:
               variable: depth
@@ -35,21 +33,19 @@ observations:
               variable: temp
               lowerBound: 250.15
               upperBound: 313.15
-              variable: saln
-              lowerBound: 0.0
-              upperBound: 40.0
+
     ioda:
       backend: netcdf
-      obsdataout: "./testoutput/bufr_mbuoybprof_20180415.nc"
+      obsdataout: "./testoutput/temp_bufr_dbuoyprof_20180415.nc"
 
       globals:
         - name: "dataType-date"
           type: string
-          value: "Moored Buoy Temp & Salinity Profile - 2018041512"
+          value: "Drifting Buoy Temp Profile - 2018041512"
 
       dimensions:
         - name: nlevs
-          path: "*/IDMSMDBS"
+          path: "*/DTSCUR"
 
       variables:
         - name: "dateTime@MetaData"
@@ -85,8 +81,3 @@ observations:
           units: "deg C"
           range: [-23.0, 40.0]
 
-        - name: "sea_water_salinity@ObsValue"
-          source: variables/saln
-          longName: "Salinity at depth"
-          units: "psu"
-          range: [0.0, 40.0]

--- a/test/testinput/temp_bufr_mbuoybprof.yaml
+++ b/test/testinput/temp_bufr_mbuoybprof.yaml
@@ -1,0 +1,82 @@
+observations:
+  - obs space:
+      name: bufr
+      obsdatain: "./testdata/mbuoyb.20180415_subsampled"
+
+      exports:
+        group_by_variable: depth  # Optional
+        variables:
+          timestamp:
+            datetime:
+              year: "*/YEAR"
+              month: "*/MNTH"
+              day: "*/DAYS"
+              hour: "*/HOUR"
+              minute: "*/MINU"
+          stationID:
+            query: "*/RPID"
+          longitude:
+            query: "*/CLONH"
+          latitude:
+            query: "*/CLATH"
+          depth:
+            query: "*/IDMSMDBS/BBYSTSL/DBSS"
+          temp:
+            query: "*/IDMSMDBS/BBYSTSL/SST1"
+            transforms:
+              - offset: -273.15
+        filters:
+          - bounding:
+              variable: depth
+              lowerBound: 0
+              upperBound: 10000
+              variable: temp
+              lowerBound: 250.15
+              upperBound: 313.15
+    ioda:
+      backend: netcdf
+      obsdataout: "./testoutput/temp_bufr_mbuoybprof_20180415.nc"
+
+      globals:
+        - name: "dataType-date"
+          type: string
+          value: "Moored Buoy Temp Profile - 2018041512"
+
+      dimensions:
+        - name: nlevs
+          path: "*/IDMSMDBS"
+
+      variables:
+        - name: "dateTime@MetaData"
+          source: variables/timestamp
+          longName: "dateTime"
+          units: "seconds since 1970-01-01T00:00:00Z"
+
+        - name: "latitude@MetaData"
+          source: variables/latitude
+          longName: "Latitude"
+          units: "degrees_north"
+          range: [-90, 90]
+
+        - name: "longitude@MetaData"
+          source: variables/longitude
+          longName: "Longitude"
+          units: "degrees_east"
+          range: [-180, 180]
+
+        - name: "stationID@MetaData"
+          source: variables/stationID
+          longName: "sgn/Report Identifier"
+          units: "N/A"
+
+        - name: "depth@MetaData"
+          source: variables/depth
+          longName: "Depth below sea surface"
+          units: "m"
+
+        - name: "sea_water_temperature@ObsValue"
+          source: variables/temp
+          longName: "Temperature at depth"
+          units: "deg C"
+          range: [-23.0, 40.0]
+


### PR DESCRIPTION
Addresses https://github.com/NOAA-EMC/GDASApp/issues/196

Should probably not be merged until https://github.com/NOAA-EMC/GDASApp/issues/205 is resolved, to allow testing of soca prep step.

Files renamed:
rename from parm/soca/obs/config/bufr_dbuoyprof.yaml
rename to parm/soca/obs/config/temp_bufr_dbuoyprof.yaml
rename from parm/soca/obs/config/bufr_mbuoybprof.yaml
rename to parm/soca/obs/config/temp_bufr_mbuoybprof.yaml
rename from test/testinput/bufr_dbuoy.yaml
rename to test/testinput/temp_bufr_dbuoyprof.yaml
rename from test/testinput/bufr_mbuoyb.yaml
rename to test/testinput/temp_bufr_mbuoybprof.yaml

Files added:
parm/soca/obs/config/salt_bufr_dbuoyprof.yaml
parm/soca/obs/config/salt_bufr_mbuoybprof.yaml
test/testinput/salt_bufr_dbuoyprof.yaml
test/testinput/salt_bufr_mbuoybprof.yaml

Files changed:
test/CMakeLists.txt
test/soca/CMakeLists.txt
test/soca/create_obsdb.py
