### PR TITLE
Groundwork for workflow based testing

### DIFF
--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -42,6 +42,11 @@ jobs:
         git clone https://github.com/ecmwf/ecbuild.git ecbuild
         cd ecbuild
         git checkout 3.6.1
+        mkdir bootstrap
+        cd bootstrap
+        ../bin/ecbuild --prefix=$GITHUB_WORKSPACE/local/ ..
+        ctest
+        make install
 
     - name: Configure with cmake
       run: |

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -44,9 +44,8 @@ jobs:
         git checkout 3.6.1
         mkdir bootstrap
         cd bootstrap
-        ../bin/ecbuild --prefix=$GITHUB_WORKSPACE/local/ ..
-        ctest
-        make install
+        ../bin/ecbuild ..
+        sudo make install
 
     - name: Configure with cmake
       run: |

--- a/.github/workflows/unittests_g-w.yaml
+++ b/.github/workflows/unittests_g-w.yaml
@@ -54,7 +54,7 @@ jobs:
       run: |
         export ecbuild_DIR=$GITHUB_WORKSPACE/ecbuild/lib/cmake/ecbuild
         mkdir $GITHUB_WORKSPACE/global-workflow/sorc/gdas.cd/build && cd $GITHUB_WORKSPACE/global-workflow/sorc/gdas.cd/build
-        cmake -DBUILD_GDASBUNDLE=OFF $GITHUB_WORKSPACE/global-workflow/sorc/gdas.cd/
+        cmake -DBUILD_GDASBUNDLE=OFF -DWORKFLOW_TESTS=ON $GITHUB_WORKSPACE/global-workflow/sorc/gdas.cd/
 
     - name: Build GDASApp
       run: |

--- a/.github/workflows/unittests_g-w.yaml
+++ b/.github/workflows/unittests_g-w.yaml
@@ -49,10 +49,10 @@ jobs:
         git clone https://github.com/ecmwf/ecbuild.git ecbuild
         cd ecbuild
         git checkout 3.6.1
-        export ecbuild_DIR=$GITHUB_WORKSPACE/ecbuild/lib/cmake/ecbuild
 
     - name: Configure with cmake
       run: |
+        export ecbuild_DIR=$GITHUB_WORKSPACE/ecbuild/lib/cmake/ecbuild
         mkdir $GITHUB_WORKSPACE/global-workflow/sorc/gdas.cd/build && cd $GITHUB_WORKSPACE/global-workflow/sorc/gdas.cd/build
         cmake -DBUILD_GDASBUNDLE=OFF $GITHUB_WORKSPACE/global-workflow/sorc/gdas.cd/
 

--- a/.github/workflows/unittests_g-w.yaml
+++ b/.github/workflows/unittests_g-w.yaml
@@ -66,4 +66,5 @@ jobs:
       run: |
         cd $GITHUB_WORKSPACE/global-workflow/sorc/gdas.cd/build
         ctest --output-on-failure
-        ctest -VV -R setup_cycled
+        ls -l /home/runner/work/GDASApp/GDASApp/global-workflow/sorc/gdas.cd/build/test/testrun/experiments/gdas_test
+        cat /home/runner/work/GDASApp/GDASApp/global-workflow/sorc/gdas.cd/build/test/testrun/experiments/gdas_test/config.base

--- a/.github/workflows/unittests_g-w.yaml
+++ b/.github/workflows/unittests_g-w.yaml
@@ -52,8 +52,7 @@ jobs:
         git checkout 3.6.1
         mkdir bootstrap
         cd bootstrap
-        ../bin/ecbuild --prefix=$GITHUB_WORKSPACE/local/ ..
-        ctest
+        ../bin/ecbuild ..
         make install
 
     - name: Configure with cmake

--- a/.github/workflows/unittests_g-w.yaml
+++ b/.github/workflows/unittests_g-w.yaml
@@ -66,3 +66,4 @@ jobs:
       run: |
         cd $GITHUB_WORKSPACE/global-workflow/sorc/gdas.cd/build
         ctest --output-on-failure
+        ctest -VV -R setup_cycled

--- a/.github/workflows/unittests_g-w.yaml
+++ b/.github/workflows/unittests_g-w.yaml
@@ -23,6 +23,7 @@ jobs:
         tar -xvf solo-877b414.tar.gz
         cd solo && pip install . && cd ..
         cd r2d2 && pip install . && cd ..
+        sudo mkdir -p /work/noaa # to trick workflow into thinking this is RDHPCS Orion
 
     - name: Checkout workflow
       uses: actions/checkout@v3

--- a/.github/workflows/unittests_g-w.yaml
+++ b/.github/workflows/unittests_g-w.yaml
@@ -37,15 +37,15 @@ jobs:
       with:
         path: global-workflow/sorc/gdas.cd
 
-    #- name: Cache ecBuild
-    #  id: cache-ecbuild
-    #  uses: actions/cache@v2
-    #  with:
-    #    path: ecbuild
-    #    key: ${{ runner.os }}-ecbuild
+    - name: Cache ecBuild
+      id: cache-ecbuild
+      uses: actions/cache@v2
+      with:
+        path: ecbuild
+        key: ${{ runner.os }}-ecbuild
 
     - name: Install ecBuild
-      #if: steps.cache-ecbuild.outputs.cache-hit != 'true'
+      if: steps.cache-ecbuild.outputs.cache-hit != 'true'
       run: |
         git clone https://github.com/ecmwf/ecbuild.git ecbuild
         cd ecbuild

--- a/.github/workflows/unittests_g-w.yaml
+++ b/.github/workflows/unittests_g-w.yaml
@@ -37,12 +37,12 @@ jobs:
       with:
         path: global-workflow/sorc/gdas.cd
 
-    - name: Cache ecBuild
-      id: cache-ecbuild
-      uses: actions/cache@v2
-      with:
-        path: ecbuild
-        key: ${{ runner.os }}-ecbuild
+    #- name: Cache ecBuild
+    #  id: cache-ecbuild
+    #  uses: actions/cache@v2
+    #  with:
+    #    path: ecbuild
+    #    key: ${{ runner.os }}-ecbuild
 
     - name: Install ecBuild
       #if: steps.cache-ecbuild.outputs.cache-hit != 'true'

--- a/.github/workflows/unittests_g-w.yaml
+++ b/.github/workflows/unittests_g-w.yaml
@@ -25,9 +25,10 @@ jobs:
         cd r2d2 && pip install . && cd ..
 
     - name: Checkout workflow
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
-        name: NOAA-EMC/global-workflow
+        repository: NOAA-EMC/global-workflow
+        ref: develop
         path: global-workflow
 
     - name: Cache ecBuild

--- a/.github/workflows/unittests_g-w.yaml
+++ b/.github/workflows/unittests_g-w.yaml
@@ -1,0 +1,60 @@
+name: Unit Tests Within NCEP Global-Workflow
+on: [push, pull_request]
+
+jobs:
+  ctests:
+    runs-on: ubuntu-latest
+    name: Run Unit Tests inside global-workflow with ctest
+
+    steps:
+
+    - name: Install pip dependencies
+      run: |
+        pip install --upgrade pip
+        pip install pycodestyle
+        pip install netCDF4
+        pip install xarray
+
+    - name: Install other dependencies
+      run: |
+        wget https://ftp.emc.ncep.noaa.gov/static_files/public/GDASApp/r2d2-bb361c2.tar.gz
+        wget https://ftp.emc.ncep.noaa.gov/static_files/public/GDASApp/solo-877b414.tar.gz
+        tar -xvf r2d2-bb361c2.tar.gz
+        tar -xvf solo-877b414.tar.gz
+        cd solo && pip install . && cd ..
+        cd r2d2 && pip install . && cd ..
+
+    - name: Checkout workflow
+      uses: actions/checkout@v2
+      with:
+        name: NOAA-EMC/global-workflow
+        path: global-workflow
+
+    - name: Cache ecBuild
+      id: cache-ecbuild
+      uses: actions/cache@v2
+      with:
+        path: ecbuild
+        key: ${{ runner.os }}-ecbuild
+
+    - name: Install ecBuild
+      if: steps.cache-ecbuild.outputs.cache-hit != 'true'
+      run: |
+        git clone https://github.com/ecmwf/ecbuild.git ecbuild
+        cd ecbuild
+        git checkout 3.6.1
+
+    #- name: Configure with cmake
+    #  run: |
+    #    mkdir $GITHUB_WORKSPACE/build && cd $GITHUB_WORKSPACE/build
+    #    cmake -DBUILD_GDASBUNDLE=OFF $GITHUB_WORKSPACE/GDASApp
+
+    #- name: Build GDASApp
+    #  run: |
+    #    cd $GITHUB_WORKSPACE/build
+    #    make
+
+    #- name: Run ctest
+    #  run: |
+    #    cd $GITHUB_WORKSPACE/build
+    #    ctest --output-on-failure

--- a/.github/workflows/unittests_g-w.yaml
+++ b/.github/workflows/unittests_g-w.yaml
@@ -45,7 +45,7 @@ jobs:
         key: ${{ runner.os }}-ecbuild
 
     - name: Install ecBuild
-      if: steps.cache-ecbuild.outputs.cache-hit != 'true'
+      #if: steps.cache-ecbuild.outputs.cache-hit != 'true'
       run: |
         git clone https://github.com/ecmwf/ecbuild.git ecbuild
         cd ecbuild
@@ -58,7 +58,6 @@ jobs:
 
     - name: Configure with cmake
       run: |
-        export ecbuild_DIR=$GITHUB_WORKSPACE/ecbuild/lib/cmake/ecbuild
         mkdir $GITHUB_WORKSPACE/global-workflow/sorc/gdas.cd/build && cd $GITHUB_WORKSPACE/global-workflow/sorc/gdas.cd/build
         cmake -DBUILD_GDASBUNDLE=OFF -DWORKFLOW_TESTS=ON $GITHUB_WORKSPACE/global-workflow/sorc/gdas.cd/
 

--- a/.github/workflows/unittests_g-w.yaml
+++ b/.github/workflows/unittests_g-w.yaml
@@ -50,6 +50,11 @@ jobs:
         git clone https://github.com/ecmwf/ecbuild.git ecbuild
         cd ecbuild
         git checkout 3.6.1
+        mkdir bootstrap
+        cd bootstrap
+        ../bin/ecbuild --prefix=$GITHUB_WORKSPACE/local/ ..
+        ctest
+        make install
 
     - name: Configure with cmake
       run: |

--- a/.github/workflows/unittests_g-w.yaml
+++ b/.github/workflows/unittests_g-w.yaml
@@ -53,7 +53,7 @@ jobs:
         mkdir bootstrap
         cd bootstrap
         ../bin/ecbuild ..
-        make install
+        sudo make install
 
     - name: Configure with cmake
       run: |

--- a/.github/workflows/unittests_g-w.yaml
+++ b/.github/workflows/unittests_g-w.yaml
@@ -52,15 +52,15 @@ jobs:
 
     - name: Configure with cmake
       run: |
-        mkdir $GITHUB_WORKSPACE/sorc/gdas.cd/build && cd $GITHUB_WORKSPACE/sorc/gdas.cd/build
-        cmake -DBUILD_GDASBUNDLE=OFF $GITHUB_WORKSPACE/sorc/gdas.cd/
+        mkdir $GITHUB_WORKSPACE/global-workflow/sorc/gdas.cd/build && cd $GITHUB_WORKSPACE/global-workflow/sorc/gdas.cd/build
+        cmake -DBUILD_GDASBUNDLE=OFF $GITHUB_WORKSPACE/global-workflow/sorc/gdas.cd/
 
     - name: Build GDASApp
       run: |
-        cd $GITHUB_WORKSPACE/sorc/gdas.cd/build
+        cd $GITHUB_WORKSPACE/global-workflow/sorc/gdas.cd/build
         make
 
     - name: Run ctest
       run: |
-        cd $GITHUB_WORKSPACE/sorc/gdas.cd/build
+        cd $GITHUB_WORKSPACE/global-workflow/sorc/gdas.cd/build
         ctest --output-on-failure

--- a/.github/workflows/unittests_g-w.yaml
+++ b/.github/workflows/unittests_g-w.yaml
@@ -66,5 +66,3 @@ jobs:
       run: |
         cd $GITHUB_WORKSPACE/global-workflow/sorc/gdas.cd/build
         ctest --output-on-failure
-        ls -l /home/runner/work/GDASApp/GDASApp/global-workflow/sorc/gdas.cd/build/test/testrun/experiments/gdas_test
-        cat /home/runner/work/GDASApp/GDASApp/global-workflow/sorc/gdas.cd/build/test/testrun/experiments/gdas_test/config.base

--- a/.github/workflows/unittests_g-w.yaml
+++ b/.github/workflows/unittests_g-w.yaml
@@ -49,6 +49,7 @@ jobs:
         git clone https://github.com/ecmwf/ecbuild.git ecbuild
         cd ecbuild
         git checkout 3.6.1
+        export ecbuild_DIR=$GITHUB_WORKSPACE/ecbuild/lib/cmake/ecbuild
 
     - name: Configure with cmake
       run: |

--- a/.github/workflows/unittests_g-w.yaml
+++ b/.github/workflows/unittests_g-w.yaml
@@ -31,6 +31,11 @@ jobs:
         ref: develop
         path: global-workflow
 
+    - name: Checkout GDASApp
+      uses: actions/checkout@v3
+      with:
+        path: global-workflow/sorc/gdas.cd
+
     - name: Cache ecBuild
       id: cache-ecbuild
       uses: actions/cache@v2
@@ -45,17 +50,17 @@ jobs:
         cd ecbuild
         git checkout 3.6.1
 
-    #- name: Configure with cmake
-    #  run: |
-    #    mkdir $GITHUB_WORKSPACE/build && cd $GITHUB_WORKSPACE/build
-    #    cmake -DBUILD_GDASBUNDLE=OFF $GITHUB_WORKSPACE/GDASApp
+    - name: Configure with cmake
+      run: |
+        mkdir $GITHUB_WORKSPACE/sorc/gdas.cd/build && cd $GITHUB_WORKSPACE/sorc/gdas.cd/build
+        cmake -DBUILD_GDASBUNDLE=OFF $GITHUB_WORKSPACE/sorc/gdas.cd/
 
-    #- name: Build GDASApp
-    #  run: |
-    #    cd $GITHUB_WORKSPACE/build
-    #    make
+    - name: Build GDASApp
+      run: |
+        cd $GITHUB_WORKSPACE/sorc/gdas.cd/build
+        make
 
-    #- name: Run ctest
-    #  run: |
-    #    cd $GITHUB_WORKSPACE/build
-    #    ctest --output-on-failure
+    - name: Run ctest
+      run: |
+        cd $GITHUB_WORKSPACE/sorc/gdas.cd/build
+        ctest --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ set( ENABLE_MPI ON CACHE BOOL "Compile with MPI" )
 # Handle user options.
 option(BUILD_GDASBUNDLE "Build GDAS Bundle" ON)
 option(CLONE_JCSDADATA "Clone JCSDA test data repositories" OFF)
+option(WORKFLOW_TESTS "Include global-workflow dependent tests" OFF)
 
 # Initialize bundle
 # -----------------

--- a/build.sh
+++ b/build.sh
@@ -97,6 +97,10 @@ mkdir -p ${BUILD_DIR} && cd ${BUILD_DIR}
 # If INSTALL_PREFIX is not empty; install at INSTALL_PREFIX
 [[ -n "${INSTALL_PREFIX:-}" ]] && CMAKE_OPTS+=" -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX}"
 
+# activate tests based on if this is cloned within the global-workflow
+WORKFLOW_BUILD=${WORKFLOW_BUILD:-"OFF"}
+CMAKE_OPTS+=" -DWORKFLOW_TESTS=${WORKFLOW_BUILD}"
+
 # Configure
 echo "Configuring ..."
 set -x

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -73,6 +73,9 @@ endforeach(FILENAME)
 install(FILES ${test_input}
         DESTINATION "test/testinput/")
 
+# create testrun dir
+file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/test/testrun)
+
 # create testout dir
 file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/test/testoutput)
 
@@ -143,6 +146,14 @@ endif()
 add_test(NAME test_gdasapp_convert_ewok_yaml
          COMMAND ${PROJECT_SOURCE_DIR}/test/convert_ewok_yaml.sh ${PROJECT_BINARY_DIR} ${PROJECT_SOURCE_DIR}
          WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/)
+
+# high level tests that require the global-workflow
+if (WORKFLOW_TESTS)
+  # test for creating an experiment directory within the global-workflow
+  add_test(NAME test_gdasapp_setup_cycled_exp
+           COMMAND ${PROJECT_SOURCE_DIR}/test/setup_workflow_exp.sh ${PROJECT_BINARY_DIR} ${PROJECT_SOURCE_DIR}
+           WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/testrun)
+endif()
 
 # soca tests
 if (${BUILD_GDASBUNDLE})

--- a/test/setup_workflow_exp.sh
+++ b/test/setup_workflow_exp.sh
@@ -5,7 +5,7 @@ srcdir=$2
 
 # test experiment variables
 idate=2021032318
-edate=2021034318
+edate=2021032418
 app=ATM # NOTE make this S2SWA soon
 starttype='warm'
 gfscyc='4'

--- a/test/setup_workflow_exp.sh
+++ b/test/setup_workflow_exp.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# ctest to create an experiment directory for global-workflow
+bindir=$1
+srcdir=$2
+
+# test experiment variables
+idate=2021032318
+edate=2021034318
+app=ATM # NOTE make this S2SWA soon
+starttype='warm'
+gfscyc='4'
+resdet='48'
+resens='24'
+nens=0
+pslot='gdas_test'
+configdir=$srcdir/../../parm/config
+comrot=$bindir/test/testrun/ROTDIRS
+expdir=$bindir/test/testrun/experiments
+
+
+# run the script
+cd $srcdir/../../workflow
+
+echo "Running global-workflow experiment generation script"
+./setup_expt.py cycled --idate $idate --edate $edate --app $app --start $starttype --gfs_cyc $gfscyc --resdet $resdet --resens $resens --nens $nens --pslot $pslot --configdir $configdir --comrot $comrot --expdir $expdir
+
+ls $expdir/$pslot

--- a/test/setup_workflow_exp.sh
+++ b/test/setup_workflow_exp.sh
@@ -24,4 +24,4 @@ cd $srcdir/../../workflow
 echo "Running global-workflow experiment generation script"
 ./setup_expt.py cycled --idate $idate --edate $edate --app $app --start $starttype --gfs_cyc $gfscyc --resdet $resdet --resens $resens --nens $nens --pslot $pslot --configdir $configdir --comrot $comrot --expdir $expdir
 
-ls $expdir/$pslot
+exit $?


### PR DESCRIPTION
This PR does the following:

1. Creates a new GitHub Action that will clone first the NCEP global-workflow, and then clone (manually) the GDASApp in `global-workflow/sorc/gdas.cd`. This action then will run ctests that are enabled with the workflow option (see below). The action runs `sudo mkdir -p /work/noaa` to trick global-workflow into thinking it is on Orion.
2. Adds a new option to the build script, and the top level CMakeLists.txt file (`WORKFLOW_TESTS`), to control if tests that need the global workflow should be built or not
3. Adds a new ctest that uses the g-w setup_expt.py script to create an experiment directory and populate it with config.* (e.g. config.base) files

Check here to see some output to confirm that config.base is being created like it would be on Orion: https://github.com/NOAA-EMC/GDASApp/actions/runs/3586750549/jobs/6036321385 (look in the run ctest section)