### PR TITLE
Do not cache ecbuild

### DIFF
--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -29,15 +29,7 @@ jobs:
       with:
         path: GDASApp
 
-    - name: Cache ecBuild
-      id: cache-ecbuild
-      uses: actions/cache@v2
-      with:
-        path: ecbuild
-        key: ${{ runner.os }}-ecbuild
-
     - name: Install ecBuild
-      if: steps.cache-ecbuild.outputs.cache-hit != 'true'
       run: |
         git clone https://github.com/ecmwf/ecbuild.git ecbuild
         cd ecbuild

--- a/.github/workflows/unittests_g-w.yaml
+++ b/.github/workflows/unittests_g-w.yaml
@@ -37,15 +37,7 @@ jobs:
       with:
         path: global-workflow/sorc/gdas.cd
 
-    - name: Cache ecBuild
-      id: cache-ecbuild
-      uses: actions/cache@v2
-      with:
-        path: ecbuild
-        key: ${{ runner.os }}-ecbuild
-
     - name: Install ecBuild
-      if: steps.cache-ecbuild.outputs.cache-hit != 'true'
       run: |
         git clone https://github.com/ecmwf/ecbuild.git ecbuild
         cd ecbuild


### PR DESCRIPTION
Like the title says. Caching ecbuild in GitHub Actions is doing more harm than good, and a clone/install only takes a few seconds anyways