### PR TITLE
Add cron scripts to run tests within NCEP global-workflow

### DIFF
--- a/ci/gw_driver.sh
+++ b/ci/gw_driver.sh
@@ -1,0 +1,104 @@
+#!/bin/bash --login
+
+my_dir="$( cd "$( dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd )"
+
+# ==============================================================================
+usage() {
+  set +x
+  echo
+  echo "Usage: $0 -t <target> -h"
+  echo
+  echo "  -t  target/machine script is running on    DEFAULT: $(hostname)"
+  echo "  -h  display this message and quit"
+  echo
+  exit 1
+}
+
+# ==============================================================================
+# First, set up runtime environment
+
+export TARGET="$(hostname)"
+
+while getopts "t:h" opt; do
+  case $opt in
+    t)
+      TARGET=$OPTARG
+      ;;
+    h|\?|:)
+      usage
+      ;;
+  esac
+done
+
+case ${TARGET} in
+  hera | orion)
+    echo "Running automated testing with workflow on $TARGET"
+    source $MODULESHOME/init/sh
+    source $my_dir/${TARGET}.sh
+    module purge
+    module use $GDAS_MODULE_USE
+    module load GDAS/$TARGET
+    module list
+    ;;
+  *)
+    echo "Unsupported platform. Exiting with error."
+    exit 1
+    ;;
+esac
+
+# ==============================================================================
+# pull on the repo and get list of open PRs
+cd $GDAS_CI_ROOT/repo
+CI_LABEL="${GDAS_CI_HOST}-GW-RT"
+gh pr list --label "$CI_LABEL" --state "open" | awk '{print $1;}' > $GDAS_CI_ROOT/open_pr_list_gw
+open_pr_list=$(cat $GDAS_CI_ROOT/open_pr_list_gw)
+
+# ==============================================================================
+# clone, checkout, build, test, etc.
+repo_url="https://github.com/NOAA-EMC/GDASApp.git"
+workflow_url="https://github.com/NOAA-EMC/global-workflow.git"
+# loop through all open PRs
+for pr in $open_pr_list; do
+  gh pr edit $pr --remove-label $CI_LABEL --add-label ${CI_LABEL}-Running
+  echo "Processing Pull Request #${pr}"
+  mkdir -p $GDAS_CI_ROOT/workflow/PR/$pr
+  cd $GDAS_CI_ROOT/workflow/PR/$pr
+
+  # clone global workflow develop branch
+  git clone $workflow_url
+
+  # run checkout script for all other components
+  cd $GDAS_CI_ROOT/workflow/PR/$pr/global-workflow/sorc
+  ./checkout.sh -u
+
+  # checkout pull request
+  cd gdas.cd
+  git checkout develop
+  git pull
+  gh pr checkout $pr
+
+  # get commit hash
+  commit=$(git log --pretty=format:'%h' -n 1)
+  if [ -f "$GDAS_CI_ROOT/workflow/PR/$pr/commit" ]; then
+    oldcommit=$(cat $GDAS_CI_ROOT/workflow/PR/$pr/commit)
+    if [ $oldcommit == $commit ]; then
+      # do no more for this PR, as the commit has already been tested
+      continue
+    fi
+  fi
+  echo "$commit" > $GDAS_CI_ROOT/workflow/PR/$pr/commit
+
+  $my_dir/run_gw_ci.sh -d $GDAS_CI_ROOT/workflow/PR/$pr/global-workflow -o $GDAS_CI_ROOT/workflow/PR/$pr/output_${commit}
+  ci_status=$?
+  gh pr comment $pr --body-file $GDAS_CI_ROOT/workflow/PR/$pr/output_${commit}
+  if [ $ci_status -eq 0 ]; then
+    gh pr edit $pr --remove-label ${CI_LABEL}-Running --add-label ${CI_LABEL}-Passed
+  else
+    gh pr edit $pr --remove-label ${CI_LABEL}-Running --add-label ${CI_LABEL}-Failed
+  fi
+done
+
+# ==============================================================================
+# scrub working directory for older files
+find $GDAS_CI_ROOT/workflow/PR/* -maxdepth 1 -mtime +3 -exec rm -rf {} \;
+

--- a/ci/run_gw_ci.sh
+++ b/ci/run_gw_ci.sh
@@ -58,7 +58,7 @@ fi
 # ==============================================================================
 # run ctests
 cd $repodir/sorc/gdas.cd/build
-module use $GDAS_MODULE_USE
+module use $repodir/sorc/gdas.cd/modulefiles
 module load GDAS/$TARGET
 echo "---------------------------------------------------" >> $outfile
 rm -rf log.ctest

--- a/ci/run_gw_ci.sh
+++ b/ci/run_gw_ci.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+#set -eu
+
+# ==============================================================================
+usage() {
+  set +x
+  echo
+  echo "Usage: $0 -d <directory> -o <output> -h"
+  echo
+  echo "  -d  Run build and ctest for clone in <directory>"
+  echo "  -o  Path to output message detailing results of CI tests"
+  echo "  -h  display this message and quit"
+  echo
+  exit 1
+}
+
+# ==============================================================================
+while getopts "d:o:h" opt; do
+  case $opt in
+    d)
+      repodir=$OPTARG
+      ;;
+    o)
+      outfile=$OPTARG
+      ;;
+    h|\?|:)
+      usage
+      ;;
+  esac
+done
+
+# ==============================================================================
+# start output file
+echo "Automated Global-Workflow GDASApp Testing Results:" > $outfile
+echo "Machine: ${TARGET}" >> $outfile
+echo '```' >> $outfile
+echo "Start: $(date) on $(hostname)" >> $outfile
+echo "---------------------------------------------------" >> $outfile
+# ==============================================================================
+# run build and link as part of the workflow
+export WORKFLOW_BUILD="ON"
+cd $repodir/sorc
+module purge
+rm -rf log.build
+./build_all.sh &>> log.build
+build_status=$?
+if [ $build_status -eq 0 ]; then
+  echo "Build:                                 *SUCCESS*" >> $outfile
+  echo "Build: Completed at $(date)" >> $outfile
+else
+  echo "Build:                                  *FAILED*" >> $outfile
+  echo "Build: Failed at $(date)" >> $outfile
+  echo "Build: see output at $repodir/sorc/log.build" >> $outfile
+  echo '```' >> $outfile
+  exit $build_status
+fi
+./link_workflow.sh
+# ==============================================================================
+# run ctests
+cd $repodir/sorc/gdas.cd/build
+module use $GDAS_MODULE_USE
+module load GDAS/$TARGET
+echo "---------------------------------------------------" >> $outfile
+rm -rf log.ctest
+ctest -R gdasapp --output-on-failure &>> log.ctest
+ctest_status=$?
+npassed=$(cat log.ctest | grep "tests passed")
+if [ $ctest_status -eq 0 ]; then
+  echo "Tests:                                 *SUCCESS*" >> $outfile
+  echo "Tests: Completed at $(date)" >> $outfile
+  echo "Tests: $npassed" >> $outfile
+else
+  echo "Tests:                                  *Failed*" >> $outfile
+  echo "Tests: Failed at $(date)" >> $outfile
+  echo "Tests: $npassed" >> $outfile
+  cat log.ctest | grep "(Failed)" >> $outfile
+  echo "Tests: see output at $repodir/sorc/gdas.cd/build/log.ctest" >> $outfile
+fi
+echo '```' >> $outfile
+exit $ctest_status
+


### PR DESCRIPTION
These scripts add a capability to (as part of a cron) do the following:

1. Get a list of GDASApp PRs with the label `$(machine)-GW-RT`
2. Clone NCEP's global-workflow develop branch
3. Checkout all of the global-workflow and the PR commit hash for GDASApp (in `sorc/gdas.cd`)
4. Build the workflow components and link files
5. Run GDASApp ctests (some of which now can depend on workflow configuration/scripts)

Note: this cron will not be enabled on Hera or Orion until this PR is merged to develop
