### PR TITLE
Add global-workflow utils to GitHub Actions

### DIFF
--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -33,7 +33,7 @@ jobs:
 
     - name: Install workflow utils
       run: |
-        cd global-workflow/ush/python
+        cd global-workflow/ush/python/pygw
         pip install .
 
     - name: Checkout

--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -24,6 +24,18 @@ jobs:
         cd solo && pip install . && cd ..
         cd r2d2 && pip install . && cd ..
 
+    - name: Checkout workflow
+      uses: actions/checkout@v3
+      with:
+        repository: NOAA-EMC/global-workflow
+        ref: develop
+        path: global-workflow
+
+    - name: Install workflow utils
+      run: |
+        cd global-workflow/ush/python
+        pip install .
+
     - name: Checkout
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/unittests_g-w.yaml
+++ b/.github/workflows/unittests_g-w.yaml
@@ -32,6 +32,11 @@ jobs:
         ref: develop
         path: global-workflow
 
+    - name: Install workflow utils
+      run: |
+        cd global-workflow/ush/python
+        pip install .
+
     - name: Checkout GDASApp
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/unittests_g-w.yaml
+++ b/.github/workflows/unittests_g-w.yaml
@@ -34,7 +34,7 @@ jobs:
 
     - name: Install workflow utils
       run: |
-        cd global-workflow/ush/python
+        cd global-workflow/ush/python/pygw
         pip install .
 
     - name: Checkout GDASApp


### PR DESCRIPTION
This PR adds global-workflow's pygw tools (https://github.com/NOAA-EMC/global-workflow/tree/dev/gdasapp/ush/python/pygw) to the GitHub Actions CI environment. This is the first step towards consolidating efforts (including YAML parsing and other things like stage, link, cp) in one place.