### PR TITLE
Add a ctest using letkfoi to assimilate GTS snow depth.

### DIFF
--- a/test/land/CMakeLists.txt
+++ b/test/land/CMakeLists.txt
@@ -22,3 +22,11 @@ set_tests_properties(test_gdasapp_land_apply_jediincr
     PROPERTIES
     ENVIRONMENT "GDASAPP_TESTDATA=$ENV{GDASAPP_TESTDATA}")
 
+# test for running letkfoi to assimilate snow DA
+add_test(NAME test_gdasapp_land_letkfoi_snowda
+         COMMAND ${PROJECT_SOURCE_DIR}/test/land/letkfoi_snowda.sh ${PROJECT_BINARY_DIR} ${PROJECT_SOURCE_DIR}
+         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/land/)
+set_tests_properties(test_gdasapp_land_letkfoi_snowda
+    PROPERTIES
+    ENVIRONMENT "GDASAPP_TESTDATA=$ENV{GDASAPP_TESTDATA}")
+

--- a/test/land/letkfoi_snowda.sh
+++ b/test/land/letkfoi_snowda.sh
@@ -60,7 +60,9 @@ if [[ ${DAtype} == 'letkfoi_snow' ]]; then
     python ${project_source_dir}/ush/land/letkf_create_ens.py $FILEDATE $SNOWDEPTHVAR $B $WORKDIR
 
 fi
-
+############################################
+# Prepare and Run JEDI
+############################################
 mkdir -p Data diags
 ln -s ${project_binary_dir}/fv3-jedi/test/Data/fieldmetadata Data/fieldmetadata
 ln -s ${project_binary_dir}/fv3-jedi/test/Data/fv3files Data/fv3files

--- a/test/land/letkfoi_snowda.sh
+++ b/test/land/letkfoi_snowda.sh
@@ -67,12 +67,11 @@ mkdir -p Data diags
 ln -s ${project_binary_dir}/fv3-jedi/test/Data/fieldmetadata Data/fieldmetadata
 ln -s ${project_binary_dir}/fv3-jedi/test/Data/fv3files Data/fv3files
 ln -s ${project_source_dir}/ush/land/genYAML_output_letkfoi.yaml letkf_land.yaml
-ln -s /scratch2/NCEPDEV/land/data/DA/snow_depth/GTS/data_proc/202103/adpsfc_snow_2021032318.nc4 adpsfc_snow.nc4
-#ln -s ${OBSDIR}/snow_depth/GTS/202103/adpsfc_snow_2021032318.nc4 adpsfc_snow.nc4
+ln -s ${OBSDIR}/snow_depth/GTS/202103/adpsfc_snow_2021032318.nc4 adpsfc_snow.nc4
 ln -s ${OBSDIR} Data/land
 echo 'do_landDA: calling fv3-jedi'
 
-srun '--export=ALL' -n 6 ${EXECDIR}/${JEDI_EXEC} letkf_land.yaml ${WORKDIR}/letkfoi_snowda.log
+srun '--export=ALL' -n 6 ${EXECDIR}/${JEDI_EXEC} letkf_land.yaml
 
 rc=$?
 

--- a/test/land/letkfoi_snowda.sh
+++ b/test/land/letkfoi_snowda.sh
@@ -67,6 +67,7 @@ ln -s ${project_binary_dir}/fv3-jedi/test/Data/fv3files Data/fv3files
 ln -s ${project_source_dir}/ush/land/genYAML_output_letkfoi.yaml letkf_land.yaml
 ln -s /scratch2/NCEPDEV/land/data/DA/snow_depth/GTS/data_proc/202103/adpsfc_snow_2021032318.nc4 adpsfc_snow.nc4
 #ln -s ${OBSDIR}/snow_depth/GTS/202103/adpsfc_snow_2021032318.nc4 adpsfc_snow.nc4
+ln -s ${OBSDIR} Data/land
 echo 'do_landDA: calling fv3-jedi'
 
 srun '--export=ALL' -n 6 ${EXECDIR}/${JEDI_EXEC} letkf_land.yaml ${WORKDIR}/letkfoi_snowda.log

--- a/test/land/letkfoi_snowda.sh
+++ b/test/land/letkfoi_snowda.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+set -e
+################################################
+YY=2021
+MM=03
+DD=23
+HH=18
+FILEDATE=$YY$MM$DD.${HH}0000
+RES=48
+
+project_binary_dir=$1
+project_source_dir=$2
+
+GYMD=$(date +%Y%m%d -d "$YY$MM$DD $HH - 6 hours")
+GHR=$(date +%H -d "$YY$MM$DD $HH - 6 hours")
+
+EXECDIR=$project_source_dir/build/bin
+WORKDIR=$project_binary_dir/test/land/letkfoi_snowda
+RSTDIR=$GDASAPP_TESTDATA/lowres/gdas.$GYMD/$GHR/atmos/RESTART
+export OBSDIR=$GDASAPP_TESTDATA/land
+
+GFSv17=${GFSv17:-"NO"}
+DAtype=letkfoi_snow
+
+if [ $GFSv17 == "YES" ]; then
+    SNOWDEPTHVAR="snodl"
+else
+    SNOWDEPTHVAR="snwdph"
+fi
+
+if [[ -e $WORKDIR ]]; then
+  rm -rf $WORKDIR
+fi
+mkdir -p $WORKDIR
+cd $WORKDIR
+
+if [[ ${DAtype} == 'letkfoi_snow' ]]; then
+
+    B=30  # background error std for LETKFOI
+
+    JEDI_EXEC="fv3jedi_letkf.x"
+
+    # FOR LETKFOI, CREATE THE PSEUDO-ENSEMBLE
+    for ens in 001 002
+    do
+        if [ -e $WORKDIR/mem${ens} ]; then
+                rm -rf $WORKDIR/mem${ens}
+        fi
+        mkdir -p $WORKDIR/mem${ens}
+        for tile in 1 2 3 4 5 6
+        do
+            cp ${RSTDIR}/${FILEDATE}.sfc_data.tile${tile}.nc  ${WORKDIR}/mem${ens}/${FILEDATE}.sfc_data.tile${tile}.nc
+        done
+        cp ${RSTDIR}/${FILEDATE}.coupler.res ${WORKDIR}/mem${ens}/${FILEDATE}.coupler.res
+    done
+
+
+    echo 'do_landDA: calling create ensemble'
+
+    python ${project_source_dir}/ush/land/letkf_create_ens.py $FILEDATE $SNOWDEPTHVAR $B $WORKDIR
+
+fi
+
+mkdir -p Data diags
+ln -s ${project_binary_dir}/fv3-jedi/test/Data/fieldmetadata Data/fieldmetadata
+ln -s ${project_binary_dir}/fv3-jedi/test/Data/fv3files Data/fv3files
+ln -s ${project_source_dir}/ush/land/genYAML_output_letkfoi.yaml letkf_land.yaml
+ln -s /scratch2/NCEPDEV/land/data/DA/snow_depth/GTS/data_proc/202103/adpsfc_snow_2021032318.nc4 adpsfc_snow.nc4
+#ln -s ${OBSDIR}/snow_depth/GTS/202103/adpsfc_snow_2021032318.nc4 adpsfc_snow.nc4
+echo 'do_landDA: calling fv3-jedi'
+
+srun '--export=ALL' -n 6 ${EXECDIR}/${JEDI_EXEC} letkf_land.yaml ${WORKDIR}/letkfoi_snowda.log
+
+rc=$?
+
+exit $rc
+

--- a/ush/land/genYAML_output_letkfoi.yaml
+++ b/ush/land/genYAML_output_letkfoi.yaml
@@ -1,0 +1,161 @@
+background:
+  datetime: '2021-03-23T18:00:00Z'
+  members from template:
+    nmembers: '2'
+    pattern: '%mem%'
+    template:
+      datapath: mem%mem%
+      datetime: '2021-03-23T18:00:00Z'
+      filename_cplr: 20210323.180000.coupler.res
+      filename_sfcd: 20210323.180000.sfc_data.nc
+      filetype: fms restart
+      state variables:
+      - snwdph
+      - vtype
+      - slmsk
+    zero padding: '3'
+driver:
+  save posterior ensemble: 'false'
+  save posterior mean: 'false'
+  save posterior mean increment: 'true'
+geometry:
+  akbk: Data/fv3files/akbk127.nc4
+  field metadata override: Data/fieldmetadata/gfs-land.yaml
+  fms initialization:
+    field table filename: Data/fv3files/field_table
+    namelist filename: Data/fv3files/fmsmpp.nml
+  io_layout:
+  - '1'
+  - '1'
+  layout:
+  - '1'
+  - '1'
+  npx: '49'
+  npy: '49'
+  npz: '127'
+  ntiles: '6'
+  time invariant fields:
+    state fields:
+      datapath: /scratch1/NCEPDEV/da/Cory.R.Martin/CI/GDASApp/data/land/C48
+      datetime: '2021-03-23T15:00:00Z'
+      filename_orog: C48_oro_data
+      filetype: fms restart
+      skip coupler file: true
+      state variables: [orog_filt]
+local ensemble DA:
+  inflation:
+    mult: '1.0'
+    rtpp: '0.0'
+    rtps: '0.0'
+  solver: LETKF
+observations:
+  observers:
+  - obs error:
+      covariance model: diagonal
+    obs filters:
+    - action:
+        name: reject
+      filter: Bounds Check
+      filter variables:
+      - name: totalSnowDepth
+      maxvalue: '2000.0'
+      minvalue: '0.0'
+    - filter: Domain Check
+      where:
+      - minvalue: '-999.0'
+        variable:
+          name: height@MetaData
+    - filter: Domain Check
+      where:
+      - maxvalue: '1.5'
+        minvalue: '0.5'
+        variable:
+          name: slmsk@GeoVaLs
+    - filter: RejectList
+      where:
+      - maxvalue: '15.5'
+        minvalue: '14.5'
+        variable:
+          name: vtype@GeoVaLs
+    - filter: BlackList
+      where:
+      - is_in:
+        - '71120'
+        - '71397'
+        - '71621'
+        - '71727'
+        - '71816'
+        size where true: '5'
+        variable:
+          name: station_id@MetaData
+    - action:
+        name: reject
+      filter: Background Check
+      filter variables:
+      - name: totalSnowDepth
+      threshold: '6.25'
+    - filter: Met Office Buddy Check
+      filter variables:
+      - background_error_group: BkgError
+        damping_factor_1: '1.0'
+        damping_factor_2: '1.0'
+        horizontal_correlation_scale:
+          '-90': '150'
+          '90': '150'
+        max_num_buddies_from_single_band: '10'
+        max_num_buddies_with_same_station_id: '5'
+        max_total_num_buddies: '15'
+        name: totalSnowDepth
+        num_zonal_bands: '24'
+        rejection_threshold: '0.5'
+        search_radius: '150'
+        sort_by_pressure: 'false'
+        station_id_variable:
+          name: station_id@MetaData
+        temporal_correlation_scale: PT6H
+        traced_boxes:
+          max_latitude: '90'
+          max_longitude: '180'
+          min_latitude: '-90'
+          min_longitude: '-180'
+        use_legacy_buddy_collector: 'false'
+    - assignments:
+      - name: totalSnowDepth@GrossErrorProbability
+        type: float
+        value: '0.02'
+      - name: totalSnowDepth_background_error@BkgError
+        type: float
+        value: '30.0'
+      filter: Variable Assignment
+    obs localizations:
+    - lengthscale: 250e3
+      localization method: Horizontal SOAR
+      max nobs: '50'
+      soar horizontal decay: '0.000021'
+    - localization method: Vertical Brasnett
+      vertical lengthscale: '700'
+    obs operator:
+      components:
+      - name: Identity
+      - name: BackgroundErrorIdentity
+      name: Composite
+    obs space:
+      distribution:
+        halo size: 250e3
+        name: Halo
+      name: adpsfc_snow
+      obsdatain:
+        engine:
+          obsfile: adpsfc_snow.nc4
+          type: H5File
+      obsdataout:
+        engine:
+          obsfile: diags/diag_adpsfc_snow.nc4
+          type: H5File
+      simulated variables:
+      - totalSnowDepth
+output increment:
+  filename_sfcd: xainc.sfc_data.nc
+  filetype: fms restart
+window begin: '2021-03-23T15:00:00Z'
+window length: PT6H

--- a/ush/land/genYAML_output_letkfoi.yaml
+++ b/ush/land/genYAML_output_letkfoi.yaml
@@ -36,7 +36,7 @@ geometry:
   ntiles: '6'
   time invariant fields:
     state fields:
-      datapath: /scratch1/NCEPDEV/da/Cory.R.Martin/CI/GDASApp/data/land/C48
+      datapath: Data/land/C48
       datetime: '2021-03-23T15:00:00Z'
       filename_orog: C48_oro_data
       filetype: fms restart


### PR DESCRIPTION
Add a ctest by using JEDI letkfoi to assimilate the GTS snow depth (Issue #241). 
To avoid staging too much data (two ensemble members), we use the previous ctest (`test_gdasapp_land_create_ens`) to generate two required ensemble members for use in this ctest. 

One obs data is required for this test as: 

COPY the data: 
`/scratch2/NCEPDEV/land/data/DA/snow_depth/GTS/data_proc/202103/adpsfc_snow_2021032318.nc4`
TO the directory at:
`/scratch1/NCEPDEV/da/Cory.R.Martin/CI/GDASApp/data/land/snow_depth/GTS/202103/`

