### PR TITLE
Minor updates related soca running in the g-w

### DIFF
--- a/scripts/exgdas_global_marine_analysis_prep.py
+++ b/scripts/exgdas_global_marine_analysis_prep.py
@@ -171,7 +171,7 @@ ufsda.symlink(anl_out, os.path.join(anl_dir, 'Data'), remove=False)
 logging.info(f"---------------- Stage observations")
 
 # setup the archive, local and shared R2D2 databases
-ufsda.r2d2.setup(r2d2_config_yaml='r2d2_config.yaml', shared_root=comin_obs)
+ufsda.r2d2.setup(r2d2_config_yaml=os.path.join(anl_dir, 'r2d2_config.yaml'), shared_root=comin_obs)
 
 # create config dict from runtime env
 envconfig = ufsda.misc_utils.get_env_config(component='notatm')

--- a/test/soca/test_run.sh
+++ b/test/soca/test_run.sh
@@ -32,8 +32,7 @@ test_file  ${DATA}/ocn.bkgerr_stddev.incr.2018-04-15T09:00:00Z.nc
 
 echo "============================= Test that an increment and an analysis were created"
 test_file  ${DATA}/Data/ocn.iter1.incr.2018-04-15T09:00:00Z.nc
-test_file  ${DATA}/Data/ocn.3dvarfgat_pseudo.incr.2018-04-15T09:00:00Z.nc
 test_file  ${DATA}/Data/ocn.3dvarfgat_pseudo.an.2018-04-15T09:00:00Z.nc
 test_file  ${DATA}/Data/ocn.3dvarfgat_pseudo.an.2018-04-15T12:00:00Z.nc
 test_file  ${DATA}/Data/ocn.3dvarfgat_pseudo.an.2018-04-15T15:00:00Z.nc
-test_file  ${DATA}/Data/inc.nc
+test_file  ${COMOUT}/inc.nc


### PR DESCRIPTION
- Cleaned-up the bash function that creates the MOM6 increment from the JEDI/SOCA increment
- dump the MOM6 incremement in `COMOUT`
- added a full path to `r2d2_config.yaml`, for some reason not specifying the full path was causing problems. No clue why, it was fine before and the `CI` never picked up that issue. Adding the full path and moving on to more interesting problems