### PR TITLE
add soca bmat script plus ctest

### DIFF
--- a/scripts/exgdas_global_marine_analysis_bmat.sh
+++ b/scripts/exgdas_global_marine_analysis_bmat.sh
@@ -2,12 +2,17 @@
 ################################################################################
 ####  UNIX Script Documentation Block
 #                      .                                             .
-# Script name:         exgdas_global_marine_analysis_run.sh
-# Script description:  Runs the global marine analysis with SOCA
+# Script name:         exgdas_global_marine_analysis_bmat.sh
+# Script description:  Performs calculations in preparation for the global 
+#                      marine analysis with SOCA
 #
-# Author: Guillaume Vernieres        Org: NCEP/EMC     Date: 2022-04-24
+# Author: Andrew Eichamnn   Org: NCEP/EMC     Date: 2023-01-12
 #
-# Abstract: This script makes a global model ocean sea-ice analysis using SOCA
+# Abstract: This script does the follwing in preparation for creating the 
+#           global model ocean sea-ice analysis using SOCA:
+#           - generates the DA grid
+#           - computes diagonal of B based on the background
+#           - creates the bump correlation operators
 #
 # $Id$
 #

--- a/scripts/exgdas_global_marine_analysis_bmat.sh
+++ b/scripts/exgdas_global_marine_analysis_bmat.sh
@@ -30,42 +30,6 @@ pwd=$(pwd)
 #  Utilities
 export NLN=${NLN:-"/bin/ln -sf"}
 
-function socaincr2mom6 {
-# Function to process the JEDI/SOCA increment file
-# and create a MOM6 increment file with the correct
-# variable names and dimensions
-
-  incr=$1
-  bkg=$2
-  grid=$3
-  incr_out=$4
-
-  # Create a temporary directory
-  scratch=scratch_socaincr2mom6
-  mkdir -p $scratch
-  cd $scratch
-
-  # Rename zaxis_1 to Layer in the increment file
-  ncrename -d zaxis_1,Layer $incr
-
-  # Extract h from the background file and rename axes to be consistent
-  ncks -A -C -v h $bkg h.nc
-  ncrename -d time,Time -d zl,Layer -d xh,xaxis_1 -d yh,yaxis_1 h.nc
-
-  # Replace h in the increment file with h from the background file
-  ncks -A -C -v h h.nc $incr
-
-  # Add longitude and latitude from the grid file to the increment file
-  ncks -A -C -v lon $grid $incr
-  ncks -A -C -v lat $grid $incr
-
-  # Move the final increment file to the desired output location
-  mv $incr $incr_out
-
-  # Clean up the temporary directory
-  cd ..
-  rm -r $scratch
-}
 
 function bump_vars()
 {

--- a/scripts/exgdas_global_marine_analysis_bmat.sh
+++ b/scripts/exgdas_global_marine_analysis_bmat.sh
@@ -129,7 +129,7 @@ fi
 
 # TODO (G, C, R, ...): problem with ' character when reading yaml, removing from file for now
 # 2D C from bump
-yaml_bump2d=soca_bump_C_2d.yaml
+yaml_bump2d=soca_bump2d.yaml
 clean_yaml $yaml_bump2d
 $APRUN_OCNANAL $JEDI_BIN/soca_error_covariance_training.x $yaml_bump2d 2>$yaml_bump2d.err
 export err=$?; err_chk
@@ -138,7 +138,7 @@ if [ $err -gt 0  ]; then
 fi
 
 # 3D C from bump
-yaml_list=`ls soca_bump3d_C*.yaml`
+yaml_list=`ls soca_bump3d_*.yaml`
 for yaml in $yaml_list; do
     clean_yaml $yaml
     $APRUN_OCNANAL $JEDI_BIN/soca_error_covariance_training.x $yaml 2>$yaml.err

--- a/scripts/exgdas_global_marine_analysis_bmat.sh
+++ b/scripts/exgdas_global_marine_analysis_bmat.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+################################################################################
+####  UNIX Script Documentation Block
+#                      .                                             .
+# Script name:         exgdas_global_marine_analysis_run.sh
+# Script description:  Runs the global marine analysis with SOCA
+#
+# Author: Guillaume Vernieres        Org: NCEP/EMC     Date: 2022-04-24
+#
+# Abstract: This script makes a global model ocean sea-ice analysis using SOCA
+#
+# $Id$
+#
+# Attributes:
+#   Language: POSIX shell
+#   Machine: Orion
+#
+################################################################################
+
+#  Set environment.
+export VERBOSE=${VERBOSE:-"YES"}
+if [ $VERBOSE = "YES" ]; then
+   echo $(date) EXECUTING $0 $* >&2
+   set -x
+fi
+
+#  Directories
+pwd=$(pwd)
+
+#  Utilities
+export NLN=${NLN:-"/bin/ln -sf"}
+
+function socaincr2mom6 {
+# Function to process the JEDI/SOCA increment file
+# and create a MOM6 increment file with the correct
+# variable names and dimensions
+
+  incr=$1
+  bkg=$2
+  grid=$3
+  incr_out=$4
+
+  # Create a temporary directory
+  scratch=scratch_socaincr2mom6
+  mkdir -p $scratch
+  cd $scratch
+
+  # Rename zaxis_1 to Layer in the increment file
+  ncrename -d zaxis_1,Layer $incr
+
+  # Extract h from the background file and rename axes to be consistent
+  ncks -A -C -v h $bkg h.nc
+  ncrename -d time,Time -d zl,Layer -d xh,xaxis_1 -d yh,yaxis_1 h.nc
+
+  # Replace h in the increment file with h from the background file
+  ncks -A -C -v h h.nc $incr
+
+  # Add longitude and latitude from the grid file to the increment file
+  ncks -A -C -v lon $grid $incr
+  ncks -A -C -v lat $grid $incr
+
+  # Move the final increment file to the desired output location
+  mv $incr $incr_out
+
+  # Clean up the temporary directory
+  cd ..
+  rm -r $scratch
+}
+
+function bump_vars()
+{
+    tmp=$(ls -d ${1}_* )
+    lov=()
+    for v in $tmp; do
+        lov[${#lov[@]}]=${v#*_}
+    done
+    echo "$lov"
+}
+
+function concatenate_bump()
+{
+    bumpdim=$1
+    # Concatenate the bump files
+    vars=$(bump_vars $bumpdim)
+    n=$(wc -w <<< "$vars")
+    echo "concatenating $n variables: $vars"
+    lof=$(ls ${bumpdim}_${vars[0]})
+    echo $lof
+    for f in $lof; do
+        bumpbase=${f#*_}
+        output=bump/${bumpdim}_$bumpbase
+        lob=$(ls ${bumpdim}_*/*$bumpbase)
+        for b in $lob; do
+            ncks -A $b $output
+        done
+    done
+}
+
+function clean_yaml()
+{
+    mv $1 tmp_yaml;
+    sed -e "s/'//g" tmp_yaml > $1
+}
+
+################################################################################
+# generate soca geometry
+# TODO (Guillaume): Should not use all pe's for the grid generation
+# TODO (Guillaume): Does not need to be generated at every cycles, store in static dir?
+$APRUN_OCNANAL $JEDI_BIN/soca_gridgen.x gridgen.yaml > gridgen.out 2>&1
+export err=$?; err_chk
+if [ $err -gt 0  ]; then
+    exit $err
+fi
+
+################################################################################
+# Generate the parametric diag of B
+$APRUN_OCNANAL $JEDI_BIN/soca_convertincrement.x parametric_stddev_b.yaml > parametric_stddev_b.out 2>&1
+export err=$?; err_chk
+if [ $err -gt 0  ]; then
+    exit $err
+fi
+################################################################################
+# Set decorrelation scales for bump C
+$APRUN_OCNANAL $JEDI_BIN/soca_setcorscales.x soca_setcorscales.yaml > soca_setcorscales.out 2>&1
+export err=$?; err_chk
+if [ $err -gt 0  ]; then
+    exit $err
+fi
+
+# TODO (G, C, R, ...): problem with ' character when reading yaml, removing from file for now
+# 2D C from bump
+yaml_bump2d=soca_bump_C_2d.yaml
+clean_yaml $yaml_bump2d
+$APRUN_OCNANAL $JEDI_BIN/soca_error_covariance_training.x $yaml_bump2d 2>$yaml_bump2d.err
+export err=$?; err_chk
+if [ $err -gt 0  ]; then
+    exit $err
+fi
+
+# 3D C from bump
+yaml_list=`ls soca_bump3d_C*.yaml`
+for yaml in $yaml_list; do
+    clean_yaml $yaml
+    $APRUN_OCNANAL $JEDI_BIN/soca_error_covariance_training.x $yaml 2>$yaml.err
+    export err=$?; err_chk
+    if [ $err -gt 0  ]; then
+        exit $err
+    fi
+done
+concatenate_bump 'bump3d'
+
+################################################################################
+set +x
+if [ $VERBOSE = "YES" ]; then
+   echo $(date) EXITING $0 with return code $err >&2
+fi
+exit $err
+
+################################################################################

--- a/test/soca/CMakeLists.txt
+++ b/test/soca/CMakeLists.txt
@@ -88,6 +88,16 @@ add_test(NAME test_gdasapp_soca_ana_prep
       PROPERTIES
       ENVIRONMENT "PYTHONPATH=${PROJECT_BINARY_DIR}/ush:$ENV{PYTHONPATH}")
 
+# Test exgdas_global_marine_analysis_bmat.sh
+# -----------------------------------------
+add_test(NAME test_gdasapp_soca_ana_bmat
+         COMMAND ${PROJECT_SOURCE_DIR}/test/soca/test_bmat.sh ${PROJECT_BINARY_DIR} ${PROJECT_SOURCE_DIR}
+         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/soca/3dvar/ocnanal_12)
+set_tests_properties(test_gdasapp_soca_ana_bmat
+      PROPERTIES
+          DEPENDS "test_gdasapp_soca_ana_prep"
+        )
+
 
 # Test exgdas_global_marine_analysis_run.sh
 # -----------------------------------------

--- a/test/soca/test_bmat.sh
+++ b/test/soca/test_bmat.sh
@@ -24,4 +24,5 @@ test_file  ${DATA}/soca_gridspec.nc
 
 echo "============================= Test that the parametric diag of B was generated"
 test_file  ${DATA}/ocn.bkgerr_stddev.incr.2018-04-15T09:00:00Z.nc
-test_file  ${DATA}/bump/bump[23]d_nicas_local_000002-00000[12].nc
+test_file  ${DATA}/bump/bump2d_nicas_local_000002-000001.nc
+test_file  ${DATA}/bump/bump3d_nicas_local_000002-000001.nc

--- a/test/soca/test_bmat.sh
+++ b/test/soca/test_bmat.sh
@@ -10,12 +10,7 @@ source ${project_source_dir}/test/soca/test_utils.sh
 echo "============================= Test that the grid has been generated"
 rm -f  ${DATA}/soca_gridspec.nc
 rm -f  ${DATA}/ocn.bkgerr_stddev.incr.2018-04-15T09:00:00Z.nc
-rm -f  ${DATA}/Data/ocn.iter1.incr.2018-04-15T09:00:00Z.nc
-rm -f  ${DATA}/Data/ocn.3dvarfgat_pseudo.incr.2018-04-15T09:00:00Z.nc
-rm -f  ${DATA}/Data/ocn.3dvarfgat_pseudo.an.2018-04-15T09:00:00Z.nc
-rm -f  ${DATA}/Data/ocn.3dvarfgat_pseudo.an.2018-04-15T12:00:00Z.nc
-rm -f  ${DATA}/Data/ocn.3dvarfgat_pseudo.an.2018-04-15T15:00:00Z.nc
-rm -f  ${DATA}/Data/inc.nc
+rm -f  ${DATA}/bump/bump[23]d_nicas_local_000002-00000[12].nc
 
 # Export runtime env. variables
 source ${project_source_dir}/test/soca/runtime_vars.sh $project_binary_dir $project_source_dir
@@ -29,4 +24,4 @@ test_file  ${DATA}/soca_gridspec.nc
 
 echo "============================= Test that the parametric diag of B was generated"
 test_file  ${DATA}/ocn.bkgerr_stddev.incr.2018-04-15T09:00:00Z.nc
-
+test_file  ${DATA}/bump/bump[23]d_nicas_local_000002-00000[12].nc

--- a/test/soca/test_bmat.sh
+++ b/test/soca/test_bmat.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -e
+
+project_binary_dir=$1
+project_source_dir=$2
+
+source ${project_source_dir}/test/soca/test_utils.sh
+
+# Clean test files created during a previous test
+echo "============================= Test that the grid has been generated"
+rm -f  ${DATA}/soca_gridspec.nc
+rm -f  ${DATA}/ocn.bkgerr_stddev.incr.2018-04-15T09:00:00Z.nc
+rm -f  ${DATA}/Data/ocn.iter1.incr.2018-04-15T09:00:00Z.nc
+rm -f  ${DATA}/Data/ocn.3dvarfgat_pseudo.incr.2018-04-15T09:00:00Z.nc
+rm -f  ${DATA}/Data/ocn.3dvarfgat_pseudo.an.2018-04-15T09:00:00Z.nc
+rm -f  ${DATA}/Data/ocn.3dvarfgat_pseudo.an.2018-04-15T12:00:00Z.nc
+rm -f  ${DATA}/Data/ocn.3dvarfgat_pseudo.an.2018-04-15T15:00:00Z.nc
+rm -f  ${DATA}/Data/inc.nc
+
+# Export runtime env. variables
+source ${project_source_dir}/test/soca/runtime_vars.sh $project_binary_dir $project_source_dir
+
+# Run step
+echo "============================= Testing exgdas_global_marine_analysis_bmat.sh for clean exit"
+${project_source_dir}/scripts/exgdas_global_marine_analysis_bmat.sh > exgdas_global_marine_analysis_bmat.log
+
+echo "============================= Test that the grid has been generated"
+test_file  ${DATA}/soca_gridspec.nc
+
+echo "============================= Test that the parametric diag of B was generated"
+test_file  ${DATA}/ocn.bkgerr_stddev.incr.2018-04-15T09:00:00Z.nc
+
+echo "============================= Test that an increment and an analysis were created"
+test_file  ${DATA}/Data/ocn.iter1.incr.2018-04-15T09:00:00Z.nc
+test_file  ${DATA}/Data/ocn.3dvarfgat_pseudo.an.2018-04-15T09:00:00Z.nc
+test_file  ${DATA}/Data/ocn.3dvarfgat_pseudo.an.2018-04-15T12:00:00Z.nc
+test_file  ${DATA}/Data/ocn.3dvarfgat_pseudo.an.2018-04-15T15:00:00Z.nc
+test_file  ${COMOUT}/inc.nc

--- a/test/soca/test_bmat.sh
+++ b/test/soca/test_bmat.sh
@@ -30,9 +30,3 @@ test_file  ${DATA}/soca_gridspec.nc
 echo "============================= Test that the parametric diag of B was generated"
 test_file  ${DATA}/ocn.bkgerr_stddev.incr.2018-04-15T09:00:00Z.nc
 
-echo "============================= Test that an increment and an analysis were created"
-test_file  ${DATA}/Data/ocn.iter1.incr.2018-04-15T09:00:00Z.nc
-test_file  ${DATA}/Data/ocn.3dvarfgat_pseudo.an.2018-04-15T09:00:00Z.nc
-test_file  ${DATA}/Data/ocn.3dvarfgat_pseudo.an.2018-04-15T12:00:00Z.nc
-test_file  ${DATA}/Data/ocn.3dvarfgat_pseudo.an.2018-04-15T15:00:00Z.nc
-test_file  ${COMOUT}/inc.nc


### PR DESCRIPTION
Adds soca script bmat, which runs everything in the soca run script except soca_var.x, in anticipation of splitting the run script. Partially addresses https://github.com/NOAA-EMC/GDASApp/issues/263

File changed:
test/soca/CMakeLists.txt

Files added:
scripts/exgdas_global_marine_analysis_bmat.sh
test/soca/test_bmat.sh