### PR TITLE
changing acount for jjob soca test

### DIFF
--- a/test/soca/gw/run_jjobs.yaml.test
+++ b/test/soca/gw/run_jjobs.yaml.test
@@ -43,7 +43,7 @@ setup_expt config:
     NICAS_GRID_SIZE: 150
 
 job options:
-  account: marine-cpu
+  account: da-cpu
   qos: debug
   output: @JJOB@.out
   nodes: 1


### PR DESCRIPTION
All this does is change the account name used for job accounting to da-cpu. Works for me on Hera

File changed:
test/soca/gw/run_jjobs.yaml.test

