### PR TITLE
remove non-run items from soca run

### DIFF
--- a/scripts/exgdas_global_marine_analysis_run.sh
+++ b/scripts/exgdas_global_marine_analysis_run.sh
@@ -67,87 +67,11 @@ function socaincr2mom6 {
   rm -r $scratch
 }
 
-function bump_vars()
-{
-    tmp=$(ls -d ${1}_* )
-    lov=()
-    for v in $tmp; do
-        lov[${#lov[@]}]=${v#*_}
-    done
-    echo "$lov"
-}
-
-function concatenate_bump()
-{
-    bumpdim=$1
-    # Concatenate the bump files
-    vars=$(bump_vars $bumpdim)
-    n=$(wc -w <<< "$vars")
-    echo "concatenating $n variables: $vars"
-    lof=$(ls ${bumpdim}_${vars[0]})
-    echo $lof
-    for f in $lof; do
-        bumpbase=${f#*_}
-        output=bump/${bumpdim}_$bumpbase
-        lob=$(ls ${bumpdim}_*/*$bumpbase)
-        for b in $lob; do
-            ncks -A $b $output
-        done
-    done
-}
-
 function clean_yaml()
 {
     mv $1 tmp_yaml;
     sed -e "s/'//g" tmp_yaml > $1
 }
-
-################################################################################
-# generate soca geometry
-# TODO (Guillaume): Should not use all pe's for the grid generation
-# TODO (Guillaume): Does not need to be generated at every cycles, store in static dir?
-$APRUN_OCNANAL $JEDI_BIN/soca_gridgen.x gridgen.yaml > gridgen.out 2>&1
-export err=$?; err_chk
-if [ $err -gt 0  ]; then
-    exit $err
-fi
-
-################################################################################
-# Generate the parametric diag of B
-$APRUN_OCNANAL $JEDI_BIN/soca_convertincrement.x parametric_stddev_b.yaml > parametric_stddev_b.out 2>&1
-export err=$?; err_chk
-if [ $err -gt 0  ]; then
-    exit $err
-fi
-################################################################################
-# Set decorrelation scales for bump C
-$APRUN_OCNANAL $JEDI_BIN/soca_setcorscales.x soca_setcorscales.yaml > soca_setcorscales.out 2>&1
-export err=$?; err_chk
-if [ $err -gt 0  ]; then
-    exit $err
-fi
-
-# TODO (G, C, R, ...): problem with ' character when reading yaml, removing from file for now
-# 2D C from bump
-yaml_bump2d=soca_bump2d.yaml
-clean_yaml $yaml_bump2d
-$APRUN_OCNANAL $JEDI_BIN/soca_error_covariance_training.x $yaml_bump2d 2>$yaml_bump2d.err
-export err=$?; err_chk
-if [ $err -gt 0  ]; then
-    exit $err
-fi
-
-# 3D C from bump
-yaml_list=`ls soca_bump3d_*.yaml`
-for yaml in $yaml_list; do
-    clean_yaml $yaml
-    $APRUN_OCNANAL $JEDI_BIN/soca_error_covariance_training.x $yaml 2>$yaml.err
-    export err=$?; err_chk
-    if [ $err -gt 0  ]; then
-        exit $err
-    fi
-done
-concatenate_bump 'bump3d'
 
 ################################################################################
 # run 3DVAR FGAT


### PR DESCRIPTION
Everything superfluous with the bmat stage should have been removed from run script. Tested with global-workflow suite on Hera.

File changed:
scripts/exgdas_global_marine_analysis_run.sh

- fixes #288 
