### PR TITLE
removed pythonpath construction from script

### DIFF
--- a/scripts/exgdas_global_marine_analysis_prep.py
+++ b/scripts/exgdas_global_marine_analysis_prep.py
@@ -43,8 +43,6 @@ logging.basicConfig(format='%(asctime)s:%(levelname)s:%(message)s', level=loggin
 my_dir = os.path.dirname(__file__)
 my_home = os.path.dirname(os.path.dirname(my_dir))
 gdas_home = os.path.join(os.getenv('HOMEgfs'), 'sorc', 'gdas.cd')
-sys.path.append(os.path.join(os.getenv('HOMEgfs', my_home), 'ush'))
-sys.path.append(os.path.join(gdas_home, 'ush'))
 
 # import UFSDA utilities
 import ufsda


### PR DESCRIPTION
Effectively outsourced construction of what gets imported as the env variable PYTHONPATH to the environment. No changes were required in `CMakeLists.txt` because the necessary path construction was already there. So it's just removal of the additions to `sys.path` in `scripts/exgdas_global_marine_analysis_prep.py`.

Addresses issues https://github.com/NOAA-EMC/GDASApp/issues/242 and https://github.com/NOAA-EMC/GDASApp/pull/234 . Should break ctest `test_gdasapp_soca_JGDAS_GLOBAL_OCEAN_ANALYSIS_PREP` and dependencies until https://github.com/NOAA-EMC/global-workflow/pull/1292 is merged.

