### PR TITLE
Update observation yamls for atm_jjob ens_run and var_run ctests

### DIFF
--- a/parm/atm/obs/config/amsua_n19.yaml
+++ b/parm/atm/obs/config/amsua_n19.yaml
@@ -10,7 +10,7 @@ obs space:
       obsfile: !ENV ${DATA}/diags/diag_amsua_n19_${CDATE}.nc4
   io pool:
     max pool size: 1
-  simulated variables: [brightness_temperature]
+  simulated variables: [brightnessTemperature]
   channels: &amsua_n19_channels 1-15
 obs operator:
   name: CRTM
@@ -54,7 +54,7 @@ obs bias:
 obs filters:
 - filter: BlackList
   filter variables:
-  - name: brightness_temperature
+  - name: brightnessTemperature
     channels: *amsua_n19_channels
   action:
     name: assign error
@@ -84,7 +84,7 @@ obs filters:
 #  CLW Retrieval Check
 - filter: Bounds Check
   filter variables:
-  - name: brightness_temperature
+  - name: brightnessTemperature
     channels: 1-6, 15
   test variables:
   - name: CLWRetMW@ObsFunction
@@ -98,7 +98,7 @@ obs filters:
 #  CLW Retrieval Check
 - filter: Bounds Check
   filter variables:
-  - name: brightness_temperature
+  - name: brightnessTemperature
     channels: 1-6, 15
   test variables:
   - name: CLWRetMW@ObsFunction
@@ -112,7 +112,7 @@ obs filters:
 #  Hydrometeor Check (cloud/precipitation affected chanels)
 - filter: Bounds Check
   filter variables:
-  - name: brightness_temperature
+  - name: brightnessTemperature
     channels: *amsua_n19_channels
   test variables:
   - name: HydrometeorCheckAMSUA@ObsFunction
@@ -157,7 +157,7 @@ obs filters:
 #  Topography check
 - filter: BlackList
   filter variables:
-  - name: brightness_temperature
+  - name: brightnessTemperature
     channels: *amsua_n19_channels
   action:
     name: inflate error
@@ -170,7 +170,7 @@ obs filters:
 #  Transmittnace Top Check
 - filter: BlackList
   filter variables:
-  - name: brightness_temperature
+  - name: brightnessTemperature
     channels: *amsua_n19_channels
   action:
     name: inflate error
@@ -183,7 +183,7 @@ obs filters:
 #  Surface Jacobian check
 - filter: BlackList
   filter variables:
-  - name: brightness_temperature
+  - name: brightnessTemperature
     channels: *amsua_n19_channels
   action:
     name: inflate error
@@ -198,7 +198,7 @@ obs filters:
 #  Situation dependent Check
 - filter: BlackList
   filter variables:
-  - name: brightness_temperature
+  - name: brightnessTemperature
     channels: *amsua_n19_channels
   action:
     name: inflate error
@@ -256,7 +256,7 @@ obs filters:
 #  Gross check
 - filter: Background Check
   filter variables:
-  - name: brightness_temperature
+  - name: brightnessTemperature
     channels: *amsua_n19_channels
   function absolute threshold:
   - name: ObsErrorBoundMW@ObsFunction
@@ -311,7 +311,7 @@ obs filters:
 #  Inter-channel check
 - filter: Bounds Check
   filter variables:
-  - name: brightness_temperature
+  - name: brightnessTemperature
     channels: *amsua_n19_channels
   test variables:
   - name: InterChannelConsistencyCheck@ObsFunction
@@ -328,7 +328,7 @@ obs filters:
 #  Useflag check
 - filter: Bounds Check
   filter variables:
-  - name: brightness_temperature
+  - name: brightnessTemperature
     channels: *amsua_n19_channels
   test variables:
   - name: ChannelUseflagCheckRad@ObsFunction

--- a/parm/atm/obs/config/amsua_n19.yaml
+++ b/parm/atm/obs/config/amsua_n19.yaml
@@ -59,12 +59,12 @@ obs filters:
   action:
     name: assign error
     error function:
-      name: ObsErrorModelRamp@ObsFunction
+      name: ObsFunction/ObsErrorModelRamp
       channels: *amsua_n19_channels
       options:
         channels: *amsua_n19_channels
         xvar:
-          name: CLWRetSymmetricMW@ObsFunction
+          name: ObsFunction/CLWRetSymmetricMW
           options:
             clwret_ch238: 1
             clwret_ch314: 2
@@ -87,7 +87,7 @@ obs filters:
   - name: brightnessTemperature
     channels: 1-6, 15
   test variables:
-  - name: CLWRetMW@ObsFunction
+  - name: ObsFunction/CLWRetMW
     options:
       clwret_ch238: 1
       clwret_ch314: 2
@@ -101,7 +101,7 @@ obs filters:
   - name: brightnessTemperature
     channels: 1-6, 15
   test variables:
-  - name: CLWRetMW@ObsFunction
+  - name: ObsFunction/CLWRetMW
     options:
       clwret_ch238: 1
       clwret_ch314: 2
@@ -115,7 +115,7 @@ obs filters:
   - name: brightnessTemperature
     channels: *amsua_n19_channels
   test variables:
-  - name: HydrometeorCheckAMSUA@ObsFunction
+  - name: ObsFunction/HydrometeorCheckAMSUA
     channels: *amsua_n19_channels
     options:
       channels: *amsua_n19_channels
@@ -123,18 +123,18 @@ obs filters:
                          0.230, 0.230, 0.250, 0.250, 0.350,
                          0.400, 0.550, 0.800, 3.000, 3.500]
       clwret_function:
-        name: CLWRetMW@ObsFunction
+        name: ObsFunction/CLWRetMW
         options:
           clwret_ch238: 1
           clwret_ch314: 2
           clwret_types: [ObsValue]
       obserr_function:
-        name: ObsErrorModelRamp@ObsFunction
+        name: ObsFunction/ObsErrorModelRamp
         channels: *amsua_n19_channels
         options:
           channels: *amsua_n19_channels
           xvar:
-            name: CLWRetSymmetricMW@ObsFunction
+            name: ObsFunction/CLWRetSymmetricMW
             options:
               clwret_ch238: 1
               clwret_ch314: 2
@@ -162,7 +162,7 @@ obs filters:
   action:
     name: inflate error
     inflation variable:
-      name: ObsErrorFactorTopoRad@ObsFunction
+      name: ObsFunction/ObsErrorFactorTopoRad
       channels: *amsua_n19_channels
       options:
         sensor: amsua_n19
@@ -175,7 +175,7 @@ obs filters:
   action:
     name: inflate error
     inflation variable:
-      name: ObsErrorFactorTransmitTopRad@ObsFunction
+      name: ObsFunction/ObsErrorFactorTransmitTopRad
       channels: *amsua_n19_channels
       options:
         sensor: amsua_n19
@@ -188,7 +188,7 @@ obs filters:
   action:
     name: inflate error
     inflation variable:
-      name: ObsErrorFactorSurfJacobianRad@ObsFunction
+      name: ObsFunction/ObsErrorFactorSurfJacobianRad
       channels: *amsua_n19_channels
       options:
         sensor: amsua_n19
@@ -203,26 +203,26 @@ obs filters:
   action:
     name: inflate error
     inflation variable:
-      name: ObsErrorFactorSituDependMW@ObsFunction
+      name: ObsFunction/ObsErrorFactorSituDependMW
       channels: *amsua_n19_channels
       options:
         sensor: amsua_n19
         channels: *amsua_n19_channels
         clwobs_function:
-          name: CLWRetMW@ObsFunction
+          name: ObsFunction/CLWRetMW
           options:
             clwret_ch238: 1
             clwret_ch314: 2
             clwret_types: [ObsValue]
         clwbkg_function:
-          name: CLWRetMW@ObsFunction
+          name: ObsFunction/CLWRetMW
           options:
             clwret_ch238: 1
             clwret_ch314: 2
             clwret_types: [HofX]
             bias_application: HofX
         scatobs_function:
-          name: SCATRetMW@ObsFunction
+          name: ObsFunction/SCATRetMW
           options:
             scatret_ch238: 1
             scatret_ch314: 2
@@ -230,18 +230,18 @@ obs filters:
             scatret_types: [ObsValue]
             bias_application: HofX
         clwmatchidx_function:
-          name: CLWMatchIndexMW@ObsFunction
+          name: ObsFunction/CLWMatchIndexMW
           channels: *amsua_n19_channels
           options:
             channels: *amsua_n19_channels
             clwobs_function:
-              name: CLWRetMW@ObsFunction
+              name: ObsFunction/CLWRetMW
               options:
                 clwret_ch238: 1
                 clwret_ch314: 2
                 clwret_types: [ObsValue]
             clwbkg_function:
-              name: CLWRetMW@ObsFunction
+              name: ObsFunction/CLWRetMW
               options:
                 clwret_ch238: 1
                 clwret_ch314: 2
@@ -259,33 +259,33 @@ obs filters:
   - name: brightnessTemperature
     channels: *amsua_n19_channels
   function absolute threshold:
-  - name: ObsErrorBoundMW@ObsFunction
+  - name: ObsFunction/ObsErrorBoundMW
     channels: *amsua_n19_channels
     options:
       sensor: amsua_n19
       channels: *amsua_n19_channels
       obserr_bound_latitude:
-        name: ObsErrorFactorLatRad@ObsFunction
+        name: ObsFunction/ObsErrorFactorLatRad
         options:
           latitude_parameters: [25.0, 0.25, 0.04, 3.0]
       obserr_bound_transmittop:
-        name: ObsErrorFactorTransmitTopRad@ObsFunction
+        name: ObsFunction/ObsErrorFactorTransmitTopRad
         channels: *amsua_n19_channels
         options:
           channels: *amsua_n19_channels
       obserr_bound_topo:
-        name: ObsErrorFactorTopoRad@ObsFunction
+        name: ObsFunction/ObsErrorFactorTopoRad
         channels: *amsua_n19_channels
         options:
           channels: *amsua_n19_channels
           sensor: amsua_n19
       obserr_function:
-        name: ObsErrorModelRamp@ObsFunction
+        name: ObsFunction/ObsErrorModelRamp
         channels: *amsua_n19_channels
         options:
           channels: *amsua_n19_channels
           xvar:
-            name: CLWRetSymmetricMW@ObsFunction
+            name: ObsFunction/CLWRetSymmetricMW
             options:
               clwret_ch238: 1
               clwret_ch314: 2
@@ -314,7 +314,7 @@ obs filters:
   - name: brightnessTemperature
     channels: *amsua_n19_channels
   test variables:
-  - name: InterChannelConsistencyCheck@ObsFunction
+  - name: ObsFunction/InterChannelConsistencyCheck
     channels: *amsua_n19_channels
     options:
       channels: *amsua_n19_channels
@@ -331,7 +331,7 @@ obs filters:
   - name: brightnessTemperature
     channels: *amsua_n19_channels
   test variables:
-  - name: ChannelUseflagCheckRad@ObsFunction
+  - name: ObsFunction/ChannelUseflagCheckRad
     channels: *amsua_n19_channels
     options:
       sensor: amaua_n19

--- a/parm/atm/obs/config/lgetkf_amsua_n19.yaml
+++ b/parm/atm/obs/config/lgetkf_amsua_n19.yaml
@@ -44,31 +44,31 @@ obs filters:
     channels: 4-6,9-14
   where:
   - variable:
-      name: sensorScanPosition@MetaData
+      name: MetaData/sensorScanPosition
     minvalue: 4
     maxvalue: 27
   - variable:
-      name: brightnessTemperature_1@ObsValue
+      name: ObsValue/brightnessTemperature_1
     minvalue: 50.0
     maxvalue: 550.0
   - variable:
-      name: brightnessTemperature_2@ObsValue
+      name: ObsValue/brightnessTemperature_2
     minvalue: 50.0
     maxvalue: 550.0
   - variable:
-      name: brightnessTemperature_3@ObsValue
+      name: ObsValue/brightnessTemperature_3
     minvalue: 50.0
     maxvalue: 550.0
   - variable:
-      name: brightnessTemperature_4@ObsValue
+      name: ObsValue/brightnessTemperature_4
     minvalue: 50.0
     maxvalue: 550.0
   - variable:
-      name: brightnessTemperature_6@ObsValue
+      name: ObsValue/brightnessTemperature_6
     minvalue: 50.0
     maxvalue: 550.0
   - variable:
-      name: brightnessTemperature_15@ObsValue
+      name: ObsValue/brightnessTemperature_15
     minvalue: 50.0
     maxvalue: 550.0
 obs localizations:

--- a/parm/atm/obs/config/lgetkf_amsua_n19.yaml
+++ b/parm/atm/obs/config/lgetkf_amsua_n19.yaml
@@ -13,7 +13,7 @@ obs space:
       obsfile: !ENV ./diags/diag_amsua_n19_${CDATE}.nc4
   io pool:
     max pool size: 1
-  simulated variables: [brightness_temperature]
+  simulated variables: [brightnessTemperature]
   channels: 4-6,9-14
 obs operator:
   name: CRTM
@@ -29,46 +29,46 @@ obs error:
 obs filters:
 - filter: Bounds Check
   filter variables:
-  - name: brightness_temperature
+  - name: brightnessTemperature
     channels: 4-6,9-14
   minvalue: 100.0
   maxvalue: 500.0
 - filter: Background Check
   filter variables:
-  - name: brightness_temperature
+  - name: brightnessTemperature
     channels: 4-6,9-14
   threshold: 3.0
 - filter: Domain Check
   filter variables:
-  - name: brightness_temperature
+  - name: brightnessTemperature
     channels: 4-6,9-14
   where:
   - variable:
-      name: scan_position@MetaData
+      name: sensorScanPosition@MetaData
     minvalue: 4
     maxvalue: 27
   - variable:
-      name: brightness_temperature_1@ObsValue
+      name: brightnessTemperature_1@ObsValue
     minvalue: 50.0
     maxvalue: 550.0
   - variable:
-      name: brightness_temperature_2@ObsValue
+      name: brightnessTemperature_2@ObsValue
     minvalue: 50.0
     maxvalue: 550.0
   - variable:
-      name: brightness_temperature_3@ObsValue
+      name: brightnessTemperature_3@ObsValue
     minvalue: 50.0
     maxvalue: 550.0
   - variable:
-      name: brightness_temperature_4@ObsValue
+      name: brightnessTemperature_4@ObsValue
     minvalue: 50.0
     maxvalue: 550.0
   - variable:
-      name: brightness_temperature_6@ObsValue
+      name: brightnessTemperature_6@ObsValue
     minvalue: 50.0
     maxvalue: 550.0
   - variable:
-      name: brightness_temperature_15@ObsValue
+      name: brightnessTemperature_15@ObsValue
     minvalue: 50.0
     maxvalue: 550.0
 obs localizations:

--- a/parm/atm/obs/config/lgetkf_amsua_n19.yaml
+++ b/parm/atm/obs/config/lgetkf_amsua_n19.yaml
@@ -14,12 +14,12 @@ obs space:
   io pool:
     max pool size: 1
   simulated variables: [brightnessTemperature]
-  channels: 4-6,9-14
+  channels: &amsua_n19_channels 4-6,9-14
 obs operator:
   name: CRTM
   Absorbers: [H2O,O3]
-#   Clouds: [Water, Ice]
-#   Cloud_Fraction: 1.0
+  Clouds: [Water, Ice]
+  Cloud_Fraction: 1.0
   obs options:
     Sensor_ID: amsua_n19
     EndianType: little_endian
@@ -30,47 +30,19 @@ obs filters:
 - filter: Bounds Check
   filter variables:
   - name: brightnessTemperature
-    channels: 4-6,9-14
+    channels: *amsua_n19_channels
   minvalue: 100.0
   maxvalue: 500.0
+  action:
+    name: reject
+#  Gross check
 - filter: Background Check
   filter variables:
   - name: brightnessTemperature
-    channels: 4-6,9-14
+    channels: *amsua_n19_channels
   threshold: 3.0
-- filter: Domain Check
-  filter variables:
-  - name: brightnessTemperature
-    channels: 4-6,9-14
-  where:
-  - variable:
-      name: MetaData/sensorScanPosition
-    minvalue: 4
-    maxvalue: 27
-  - variable:
-      name: ObsValue/brightnessTemperature_1
-    minvalue: 50.0
-    maxvalue: 550.0
-  - variable:
-      name: ObsValue/brightnessTemperature_2
-    minvalue: 50.0
-    maxvalue: 550.0
-  - variable:
-      name: ObsValue/brightnessTemperature_3
-    minvalue: 50.0
-    maxvalue: 550.0
-  - variable:
-      name: ObsValue/brightnessTemperature_4
-    minvalue: 50.0
-    maxvalue: 550.0
-  - variable:
-      name: ObsValue/brightnessTemperature_6
-    minvalue: 50.0
-    maxvalue: 550.0
-  - variable:
-      name: ObsValue/brightnessTemperature_15
-    minvalue: 50.0
-    maxvalue: 550.0
+  action:
+    name: reject
 obs localizations:
 - localization method: Horizontal Gaspari-Cohn
   lengthscale: 1250e3

--- a/parm/atm/obs/config/lgetkf_sondes.yaml
+++ b/parm/atm/obs/config/lgetkf_sondes.yaml
@@ -13,7 +13,7 @@ obs space:
       obsfile: !ENV ./diags/diag_sondes_lgetkf_${CDATE}.nc4
   io pool:
     max pool size: 1
-  simulated variables: [eastward_wind, northward_wind, air_temperature]
+  simulated variables: [windEastward, windNorthward, airTemperature]
 obs operator:
   name: VertInterp
 obs error:
@@ -23,9 +23,9 @@ obs filters:
   maxvalue: 3
 - filter: Background Check
   filter variables:
-  - name: eastward_wind
-  - name: northward_wind
-  - name: air_temperature
+  - name: windEastward
+  - name: windNorthward
+  - name: airTemperature
   threshold: 2.0
 obs localizations:
 - localization method: Horizontal Gaspari-Cohn


### PR DESCRIPTION
`test_gdasapp_atm_jjob_var_run` and `test_gdasapp_atm_jjob_ens_run` fail in `develop` at 99f924e.   Two actions need to be taken to restore these tests to the `Passed` state:
1. update observation yamls used by these ctests to the new IODA format
2. update the observation dump files used by these ctests to the new IODA format

This PR addresses item 1.   The dump files used by these ctests reside in shared R2D2 databases on Hera and Orion.

Fixes #332