### PR TITLE
Remove redundant marine ctests

### DIFF
--- a/parm/soca/obs/obs_list.yaml
+++ b/parm/soca/obs/obs_list.yaml
@@ -1,6 +1,6 @@
 observers:
 - !INC ${OBS_YAML_DIR}/adt_j3.yaml
-- !INC ${OBS_YAML_DIR}/salt_profile_fnmoc.yaml
+#- !INC ${OBS_YAML_DIR}/salt_profile_fnmoc.yaml
 - !INC ${OBS_YAML_DIR}/sss_smap.yaml
 - !INC ${OBS_YAML_DIR}/sst_noaa19_l3u.yaml
 - !INC ${OBS_YAML_DIR}/icec_emc.yaml

--- a/test/soca/CMakeLists.txt
+++ b/test/soca/CMakeLists.txt
@@ -88,37 +88,6 @@ add_test(NAME test_gdasapp_soca_ana_prep
       PROPERTIES
       ENVIRONMENT "PYTHONPATH=${PROJECT_BINARY_DIR}/ush:$ENV{PYTHONPATH}")
 
-# Test exgdas_global_marine_analysis_bmat.sh
-# -----------------------------------------
-add_test(NAME test_gdasapp_soca_ana_bmat
-         COMMAND ${PROJECT_SOURCE_DIR}/test/soca/test_bmat.sh ${PROJECT_BINARY_DIR} ${PROJECT_SOURCE_DIR}
-         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/soca/3dvar/ocnanal_12)
-set_tests_properties(test_gdasapp_soca_ana_bmat
-      PROPERTIES
-          DEPENDS "test_gdasapp_soca_ana_prep"
-        )
-
-
-# Test exgdas_global_marine_analysis_run.sh
-# -----------------------------------------
-add_test(NAME test_gdasapp_soca_ana_run
-         COMMAND ${PROJECT_SOURCE_DIR}/test/soca/test_run.sh ${PROJECT_BINARY_DIR} ${PROJECT_SOURCE_DIR}
-         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/soca/3dvar/ocnanal_12)
-set_tests_properties(test_gdasapp_soca_ana_run
-      PROPERTIES
-          DEPENDS "test_gdasapp_soca_ana_prep"
-        )
-
-# Test exgdas_global_marine_analysis_bmat_vrfy.sh
-# -----------------------------------------------
-add_test(NAME test_gdasapp_soca_ana_bmat_vrfy
-         COMMAND ${PROJECT_SOURCE_DIR}/test/soca/test_bmat_vrfy.sh ${PROJECT_BINARY_DIR} ${PROJECT_SOURCE_DIR}
-         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/soca/3dvar/ocnanal_12)
-set_tests_properties(test_gdasapp_soca_ana_bmat_vrfy
-      PROPERTIES
-          DEPENDS "test_gdasapp_soca_ana_run"
-        )
-
 # Test exgdas scripts from the global-worflow
 if (WORKFLOW_TESTS)
   add_subdirectory(gw)

--- a/test/soca/gw/CMakeLists.txt
+++ b/test/soca/gw/CMakeLists.txt
@@ -40,6 +40,6 @@ foreach(jjob ${jjob_list})
          ${setup}
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/soca/gw/testrun)
 
-  set(setup "--skip") # Only run the seup of the first test, if not, it will hang
+  set(setup "--skip") # Only run the setup of the first test, if not, it will hang
                       # waiting for standard input from setup_expt.py
 endforeach()


### PR DESCRIPTION
Fixes the current `soca` related failures.

But also:
- fixes #306