### PR TITLE
Bugfix for iodaconv path issues

### DIFF
--- a/test/land/test_imsproc.sh
+++ b/test/land/test_imsproc.sh
@@ -53,7 +53,7 @@ done
 ulimit -Ss unlimited
 ${EXECDIR}/calcfIMS.exe
 
-export PYTHONPATH=$PYTHONPATH:${project_source_dir}/build/lib/python${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}/pyioda/
+export PYTHONPATH=$PYTHONPATH:${project_source_dir}/iodaconv/src/:${project_source_dir}/build/lib/python${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}/pyioda/
 IMS_IODA=${EXECDIR}/imsfv3_scf2ioda.py
 
 echo 'do_landDA: calling ioda converter'


### PR DESCRIPTION
This PR closes #377 in that it solves the issue for the ims_snowcover test (others may need this later).

The JCSDA changed ioda-converters recently where it installs with `pip install` but it was done in a way in which all of the `ioda-converters/src` directories became python packages. This is inconsistent with the way the ioda-bundle installs the python scripts. So instead of `build/lib/pyiodaconv`, some scripts now need `iodaconv/src` on their `$PYTHONPATH`. This should probably be eventually resolved with JCSDA core staff, but this fix gets the test passing again.