### PR TITLE
Re-organization of where the pre-computed bump files are stored

### DIFF
--- a/ush/ufsda/stage.py
+++ b/ush/ufsda/stage.py
@@ -79,7 +79,7 @@ def soca_fix(config):
     """
 
     # link static B bump files
-    bump_archive = os.path.join(config['soca_input_fix_dir'], 'bump')
+    bump_archive = os.path.join(config['soca_input_fix_dir'], 'bkgerr', 'bump')
     bump_scratch = os.path.join(config['stage_dir'], 'bump')
     if os.path.isdir(bump_archive):
         # link archived bump files


### PR DESCRIPTION
Getting ready to run with pre-computed bump files. Our bkg error static dir is now organized as follows:

```
bkgerr
|-- bump
    |-- bump2d_nicas_local_000480-000001.nc
    |-- bump2d_nicas_local_000480-000002.nc
    |-- bump2d_nicas_local_000480-000003.nc
    |-- ...
|-- stddev
    |-- ice.ensstddev.fc.2019-04-01T00:00:00Z.PT0S.nc
    |-- ice.ensstddev.fc.2019-04-11T00:00:00Z.PT0S.nc
    |-- ice.ensstddev.fc.2019-04-21T00:00:00Z.PT0S.nc
    |-- ice.ensstddev.fc.2019-05-01T00:00:00Z.PT0S.nc
    |-- ...
```