### PR TITLE
minor tweaks to autodetect machine and purge/reset modules correctly

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,6 +9,8 @@ set -eu
 
 dir_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
+source $dir_root/ush/detect_machine.sh
+
 # ==============================================================================
 usage() {
   set +x
@@ -16,7 +18,7 @@ usage() {
   echo "Usage: $0 -p <prefix> | -t <target> -h"
   echo
   echo "  -p  installation prefix <prefix>    DEFAULT: <none>"
-  echo "  -t  target to build for <target>    DEFAULT: $(hostname)"
+  echo "  -t  target to build for <target>    DEFAULT: $MACHINE_ID"
   echo "  -c  additional CMake options        DEFAULT: <none>"
   echo "  -v  build with verbose output       DEFAULT: NO"
   echo "  -f  force a clean build             DEFAULT: NO"
@@ -32,7 +34,7 @@ usage() {
 # Defaults:
 INSTALL_PREFIX=""
 CMAKE_OPTS=""
-BUILD_TARGET="$(hostname)"
+BUILD_TARGET="${MACHINE_ID}"
 BUILD_VERBOSE="NO"
 CLONE_JCSDADATA="NO"
 CLEAN_BUILD="NO"
@@ -70,15 +72,12 @@ done
 case ${BUILD_TARGET} in
   hera | orion)
     echo "Building GDASApp on $BUILD_TARGET"
-    set +e
-    source $MODULESHOME/init/sh
-    module purge
+    source $dir_root/ush/module-setup.sh
     module use $dir_root/modulefiles
     module load GDAS/$BUILD_TARGET
     CMAKE_OPTS+=" -DMPIEXEC_EXECUTABLE=$MPIEXEC_EXEC -DMPIEXEC_NUMPROC_FLAG=$MPIEXEC_NPROC -DBUILD_GSIBEC=ON"
     CMAKE_OPTS+=" -DCLONE_JCSDADATA=$CLONE_JCSDADATA"
     module list
-    set -e
     ;;
   $(hostname))
     echo "Building GDASApp on $BUILD_TARGET"

--- a/ush/detect_machine.sh
+++ b/ush/detect_machine.sh
@@ -2,16 +2,6 @@
 
 case $(hostname -f) in
 
-  llogin[1-3]) MACHINE_ID=wcoss_cray ;; ### luna
-  slogin[1-3]) MACHINE_ID=wcoss_cray ;; ### surge
-
-  m7[12]a[1-3].ncep.noaa.gov) MACHINE_ID=wcoss_dell_p3 ;; ### mars
-  v7[12]a[1-3].ncep.noaa.gov) MACHINE_ID=wcoss_dell_p3 ;; ### venus
-  m109a[1-4].ncep.noaa.gov)   MACHINE_ID=wcoss_dell_p3 ;; ### mars3.5
-  m110a[1-4].ncep.noaa.gov)   MACHINE_ID=wcoss_dell_p3 ;; ### mars3.5
-  v109a[1-4].ncep.noaa.gov)   MACHINE_ID=wcoss_dell_p3 ;; ### venus3.5
-  v110a[1-4].ncep.noaa.gov)   MACHINE_ID=wcoss_dell_p3 ;; ### venus3.5
-
   adecflow0[12].acorn.wcoss2.ncep.noaa.gov)  MACHINE_ID=wcoss2 ;; ### acorn
   alogin0[12].acorn.wcoss2.ncep.noaa.gov)    MACHINE_ID=wcoss2 ;; ### acorn
   clogin0[1-9].cactus.wcoss2.ncep.noaa.gov)  MACHINE_ID=wcoss2 ;; ### cactus01-9

--- a/ush/detect_machine.sh
+++ b/ush/detect_machine.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+case $(hostname -f) in
+
+  llogin[1-3]) MACHINE_ID=wcoss_cray ;; ### luna
+  slogin[1-3]) MACHINE_ID=wcoss_cray ;; ### surge
+
+  m7[12]a[1-3].ncep.noaa.gov) MACHINE_ID=wcoss_dell_p3 ;; ### mars
+  v7[12]a[1-3].ncep.noaa.gov) MACHINE_ID=wcoss_dell_p3 ;; ### venus
+  m109a[1-4].ncep.noaa.gov)   MACHINE_ID=wcoss_dell_p3 ;; ### mars3.5
+  m110a[1-4].ncep.noaa.gov)   MACHINE_ID=wcoss_dell_p3 ;; ### mars3.5
+  v109a[1-4].ncep.noaa.gov)   MACHINE_ID=wcoss_dell_p3 ;; ### venus3.5
+  v110a[1-4].ncep.noaa.gov)   MACHINE_ID=wcoss_dell_p3 ;; ### venus3.5
+
+  adecflow0[12].acorn.wcoss2.ncep.noaa.gov)  MACHINE_ID=wcoss2 ;; ### acorn
+  alogin0[12].acorn.wcoss2.ncep.noaa.gov)    MACHINE_ID=wcoss2 ;; ### acorn
+  clogin0[1-9].cactus.wcoss2.ncep.noaa.gov)  MACHINE_ID=wcoss2 ;; ### cactus01-9
+  clogin10.cactus.wcoss2.ncep.noaa.gov)      MACHINE_ID=wcoss2 ;; ### cactus10
+  dlogin0[1-9].dogwood.wcoss2.ncep.noaa.gov) MACHINE_ID=wcoss2 ;; ### dogwood01-9
+  dlogin10.dogwood.wcoss2.ncep.noaa.gov)     MACHINE_ID=wcoss2 ;; ### dogwood10
+
+  gaea9)               MACHINE_ID=gaea ;; ### gaea9
+  gaea1[0-6])          MACHINE_ID=gaea ;; ### gaea10-16
+  gaea9.ncrc.gov)      MACHINE_ID=gaea ;; ### gaea9
+  gaea1[0-6].ncrc.gov) MACHINE_ID=gaea ;; ### gaea10-16
+
+  hfe0[1-9]) MACHINE_ID=hera ;; ### hera01-9
+  hfe1[0-2]) MACHINE_ID=hera ;; ### hera10-12
+  hecflow01) MACHINE_ID=hera ;; ### heraecflow01
+
+  s4-submit.ssec.wisc.edu) MACHINE_ID=s4 ;; ### s4
+
+  fe[1-8]) MACHINE_ID=jet ;; ### jet01-8
+  tfe[12]) MACHINE_ID=jet ;; ### tjet1-2
+
+  Orion-login-[1-4].HPC.MsState.Edu) MACHINE_ID=orion ;; ### orion1-4
+
+  cheyenne[1-6].cheyenne.ucar.edu)     MACHINE_ID=cheyenne ;; ### cheyenne1-6
+  cheyenne[1-6].ib0.cheyenne.ucar.edu) MACHINE_ID=cheyenne ;; ### cheyenne1-6
+  chadmin[1-6].ib0.cheyenne.ucar.edu)  MACHINE_ID=cheyenne ;; ### cheyenne1-6
+
+  login[1-4].stampede2.tacc.utexas.edu) MACHINE_ID=stampede ;; ### stampede1-4
+
+  login0[1-2].expanse.sdsc.edu) MACHINE_ID=expanse ;; ### expanse1-2
+
+  discover3[1-5].prv.cube) MACHINE_ID=discover ;; ### discover31-35
+esac
+
+# Overwrite auto-detect with MACHINE if set
+MACHINE_ID=${MACHINE:-${MACHINE_ID}}

--- a/ush/module-setup.sh
+++ b/ush/module-setup.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+set -eu
+
+if [[ $MACHINE_ID = jet* ]] ; then
+    # We are on NOAA Jet
+    if ( ! eval module help > /dev/null 2>&1 ) ; then
+        source /apps/lmod/lmod/init/bash
+    fi
+    module purge
+
+elif [[ $MACHINE_ID = hera* ]] ; then
+    # We are on NOAA Hera
+    if ( ! eval module help > /dev/null 2>&1 ) ; then
+        source /apps/lmod/lmod/init/bash
+    fi
+    module purge
+
+elif [[ $MACHINE_ID = orion* ]] ; then
+    # We are on Orion
+    if ( ! eval module help > /dev/null 2>&1 ) ; then
+        source /apps/lmod/init/bash
+    fi
+    module purge
+
+elif [[ $MACHINE_ID = s4* ]] ; then
+    # We are on SSEC Wisconsin S4
+    if ( ! eval module help > /dev/null 2>&1 ) ; then
+        source /usr/share/lmod/lmod/init/bash
+    fi
+    module purge
+
+elif [[ $MACHINE_ID = wcoss_cray ]] ; then
+    # We are on NOAA Luna or Surge
+    if ( ! eval module help > /dev/null 2>&1 ) ; then
+        source /opt/modules/default/init/bash
+    fi
+    module purge
+    # Workaround until module issues are fixed:
+    unset _LMFILES_
+    unset LOADEDMODULES
+    module use /opt/modulefiles
+    module use /opt/cray/ari/modulefiles
+    module use /opt/cray/craype/default/alt-modulefiles
+    module use /opt/cray/alt-modulefiles
+    module use /gpfs/hps/nco/ops/nwprod/modulefiles
+    module use /gpfs/hps/nco/ops/nwprod/lib/modulefiles
+    module use /usrx/local/prod/modulefiles
+
+elif [[ $MACHINE_ID = wcoss_dell_p3 ]] ; then
+    # We are on NOAA Mars or Venus
+    if ( ! eval module help > /dev/null 2>&1 ) ; then
+        source /usrx/local/prod/lmod/lmod/init/bash
+    fi
+    module purge
+
+elif [[ $MACHINE_ID = wcoss2 ]]; then
+    # We are on WCOSS2
+    module reset
+
+elif [[ $MACHINE_ID = cheyenne* ]] ; then
+    # We are on NCAR Cheyenne
+    if ( ! eval module help > /dev/null 2>&1 ) ; then
+        source /glade/u/apps/ch/modulefiles/default/localinit/localinit.sh
+    fi
+    module purge
+
+elif [[ $MACHINE_ID = stampede* ]] ; then
+    # We are on TACC Stampede
+    if ( ! eval module help > /dev/null 2>&1 ) ; then
+        source /opt/apps/lmod/lmod/init/bash
+    fi
+    module purge
+
+elif [[ $MACHINE_ID = gaea* ]] ; then
+    # We are on GAEA.
+    if ( ! eval module help > /dev/null 2>&1 ) ; then
+        # We cannot simply load the module command.  The GAEA
+        # /etc/profile modifies a number of module-related variables
+        # before loading the module command.  Without those variables,
+        # the module command fails.  Hence we actually have to source
+        # /etc/profile here.
+        source /etc/profile
+        __ms_source_etc_profile=yes
+    else
+        __ms_source_etc_profile=no
+    fi
+    module purge
+    # clean up after purge
+    unset _LMFILES_
+    unset _LMFILES_000
+    unset _LMFILES_001
+    unset LOADEDMODULES
+    module load modules
+    if [[ -d /opt/cray/ari/modulefiles ]] ; then
+        module use -a /opt/cray/ari/modulefiles
+    fi
+    if [[ -d /opt/cray/pe/ari/modulefiles ]] ; then
+        module use -a /opt/cray/pe/ari/modulefiles
+    fi
+    if [[ -d /opt/cray/pe/craype/default/modulefiles ]] ; then
+        module use -a /opt/cray/pe/craype/default/modulefiles
+    fi
+    if [[ -s /etc/opt/cray/pe/admin-pe/site-config ]] ; then
+        source /etc/opt/cray/pe/admin-pe/site-config
+    fi
+    if [[ "$__ms_source_etc_profile" == yes ]] ; then
+        source /etc/profile
+        unset __ms_source_etc_profile
+    fi
+
+elif [[ $MACHINE_ID = expanse* ]]; then
+    # We are on SDSC Expanse
+    if ( ! eval module help > /dev/null 2>&1 ) ; then
+        source /etc/profile.d/modules.sh
+    fi
+    module purge
+    module load slurm/expanse/20.02.3
+
+elif [[ $MACHINE_ID = discover* ]]; then
+    # We are on NCCS discover
+    export SPACK_ROOT=/discover/nobackup/mapotts1/spack
+    export PATH=$PATH:$SPACK_ROOT/bin
+    . $SPACK_ROOT/share/spack/setup-env.sh
+
+else
+    echo WARNING: UNKNOWN PLATFORM 1>&2
+fi

--- a/ush/module-setup.sh
+++ b/ush/module-setup.sh
@@ -29,30 +29,6 @@ elif [[ $MACHINE_ID = s4* ]] ; then
     fi
     module purge
 
-elif [[ $MACHINE_ID = wcoss_cray ]] ; then
-    # We are on NOAA Luna or Surge
-    if ( ! eval module help > /dev/null 2>&1 ) ; then
-        source /opt/modules/default/init/bash
-    fi
-    module purge
-    # Workaround until module issues are fixed:
-    unset _LMFILES_
-    unset LOADEDMODULES
-    module use /opt/modulefiles
-    module use /opt/cray/ari/modulefiles
-    module use /opt/cray/craype/default/alt-modulefiles
-    module use /opt/cray/alt-modulefiles
-    module use /gpfs/hps/nco/ops/nwprod/modulefiles
-    module use /gpfs/hps/nco/ops/nwprod/lib/modulefiles
-    module use /usrx/local/prod/modulefiles
-
-elif [[ $MACHINE_ID = wcoss_dell_p3 ]] ; then
-    # We are on NOAA Mars or Venus
-    if ( ! eval module help > /dev/null 2>&1 ) ; then
-        source /usrx/local/prod/lmod/lmod/init/bash
-    fi
-    module purge
-
 elif [[ $MACHINE_ID = wcoss2 ]]; then
     # We are on WCOSS2
     module reset


### PR DESCRIPTION
This PR has minor updates to `build.sh` to bring it up to being consistent with other GFS components such as the ufs-weather-model, GSI, etc.

Specifically,
- auto detects the machine the build is for
- purges/resets the modules based on the machine