### PR TITLE
Add 3denvar option to run_jedi_exe.py

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ if(BUILD_GDASBUNDLE)
 # Build GSI-B
   option(BUILD_GSIBEC "Build GSI-B" OFF)
   if(BUILD_GSIBEC)
-    ecbuild_bundle( PROJECT gsibec GIT "https://github.com/GEOS-ESM/GSIbec.git" BRANCH develop )
+    ecbuild_bundle( PROJECT gsibec GIT "https://github.com/GEOS-ESM/GSIbec.git" TAG 1.0.7 )
   endif()
 
 # Core JEDI repositories

--- a/parm/atm/berror/hybvar_gsibec.yaml
+++ b/parm/atm/berror/hybvar_gsibec.yaml
@@ -1,0 +1,67 @@
+covariance model: hybrid
+components:
+- covariance:
+    covariance model: SABER
+    saber central block:
+      saber block name: gsi covariance
+      input variables: &control_vars [eastward_wind,northward_wind,air_temperature,surface_pressure,
+                                      specific_humidity,cloud_liquid_ice,cloud_liquid_water,
+                                      mole_fraction_of_ozone_in_air]
+      output variables: *control_vars
+      gsi akbk: !ENV &akbk ${DATA}/fv3jedi/akbk.nc4
+      gsi error covariance file: !ENV &gsiberr ${DATA}/berror/gsi-coeffs-gfs-global.nc4
+#     gsi error covariance file: !ENV &gsiberr ${DATA}/berror/global_berror.f77
+      gsi berror namelist file: !ENV &gsibnml ${DATA}/berror/gfs_gsi_global.nml
+      processor layout x direction: &layout_gsib_x 3
+      processor layout y direction: &layout_gsib_y 2
+      debugging mode: false
+    saber outer blocks:
+    - saber block name: gsi interpolation to model grid
+      input variables: *control_vars
+      output variables: *control_vars
+      gsi akbk: *akbk
+      gsi error covariance file: *gsiberr
+      gsi berror namelist file: *gsibnml
+      processor layout x direction: *layout_gsib_x
+      processor layout y direction: *layout_gsib_y
+      debugging mode: false
+    linear variable change:
+      linear variable change name: Control2Analysis
+      input variables: *control_vars
+      output variables: &3dvars_anal [ua,va,t,ps,sphum,ice_wat,liq_wat,o3mr]
+  weight:
+    value: 0.125
+- covariance:
+    covariance model: ensemble
+    members from template:
+      template:
+        datetime: '{{BKG_ISOTIME}}'
+        filetype: fms restart
+        state variables: *3dvars_anal
+        datapath: ens/mem%mem%
+        filename_core: '{{BKG_YYYYmmddHHMMSS}}.fv_core.res.nc'
+        filename_trcr: '{{BKG_YYYYmmddHHMMSS}}.fv_tracer.res.nc'
+        filename_sfcd: '{{BKG_YYYYmmddHHMMSS}}.sfc_data.nc'
+        filename_sfcw: '{{BKG_YYYYmmddHHMMSS}}.fv_srf_wnd.res.nc'
+        filename_cplr: '{{BKG_YYYYmmddHHMMSS}}.coupler.res'
+      pattern: '%mem%'
+      nmembers: !ENV ${NMEM_ENKF}
+      zero padding: 3
+#    localization:
+#      localization method: SABER
+#      saber block:
+#      - saber block name: BUMP_NICAS
+#        input variables: *control_vars
+#        output variables: *control_vars
+#        active variables: *active_vars
+#        bump:
+#          datadir: *staticb_dir
+#          verbosity: main
+#          strategy: specific_univariate
+#          method: loc
+#          load_nicas_local: true
+#          grids:
+#          - prefix: nicas/nicas_3D_gfs
+#            variables: [stream_function,velocity_potential,air_temperature,relative_humidity,cloud_liquid_water,ozone_mass_mixing_ratio]
+  weight:
+    value: 0.875

--- a/parm/atm/lgetkf/lgetkf.yaml
+++ b/parm/atm/lgetkf/lgetkf.yaml
@@ -22,7 +22,7 @@ background:
        state variables: [ua,va,t,DZ,delp,ps,sphum,ice_wat,liq_wat,o3mr,phis,
                         slmsk,sheleg,tsea,vtype,stype,vfrac,stc,smc,snwdph,
                         u_srf,v_srf,f10m]
-       datapath: bkg/mem%mem%/RESTART
+       datapath: bkg/mem%mem%
        filename_core: '{{BKG_YYYYmmddHHMMSS}}.fv_core.res.nc'
        filename_trcr: '{{BKG_YYYYmmddHHMMSS}}.fv_tracer.res.nc'
        filename_sfcd: '{{BKG_YYYYmmddHHMMSS}}.sfc_data.nc'

--- a/parm/atm/obs/config/sondes.yaml
+++ b/parm/atm/obs/config/sondes.yaml
@@ -26,7 +26,7 @@ obs operator:
      - name: specificHumidity
    - name: SfcPCorrected
      da_psfc_scheme: GSI
-     geovar_sfc_geomz: surface_geometric_height
+     geovar_sfc_geomz: surface_geopotential_height
      geovar_geomz: geopotential_height
      variables: 
      - name: stationPressure
@@ -92,7 +92,7 @@ obs filters:
           error_min: 100.0         # 1 mb
           error_max: 300.0         # 3 mb
           geovar_geomz: geopotential_height
-          geovar_sfc_geomz: surface_geometric_height 
+          geovar_sfc_geomz: surface_geopotential_height 
   #
   # Gross error check with (O - B) / ObsError greater than threshold
   - filter: Background Check

--- a/test/atm/CMakeLists.txt
+++ b/test/atm/CMakeLists.txt
@@ -35,6 +35,11 @@ if (BUILD_GDASBUNDLE)
            COMMAND ${PROJECT_SOURCE_DIR}/test/atm/run_jedi_exe_3dvar.sh ${PROJECT_BINARY_DIR} ${PROJECT_SOURCE_DIR}
            WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/)
 
+  # test for ush/run_jedi_exe.py 3denvar
+  add_test(NAME test_gdasapp_run_jedi_exe_3denvar
+           COMMAND ${PROJECT_SOURCE_DIR}/test/atm/run_jedi_exe_3denvar.sh ${PROJECT_BINARY_DIR} ${PROJECT_SOURCE_DIR}
+           WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/)
+
   # test for ush/run_jedi_exe.py letkf
   add_test(NAME test_gdasapp_run_jedi_exe_letkf
            COMMAND ${PROJECT_SOURCE_DIR}/test/atm/run_jedi_exe_letkf.sh ${PROJECT_BINARY_DIR} ${PROJECT_SOURCE_DIR}

--- a/test/atm/run_jedi_exe_3denvar.sh
+++ b/test/atm/run_jedi_exe_3denvar.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+set -x
+
+bindir=$1
+srcdir=$2
+
+# Identify machine
+if [[ -d /scratch1 ]] ; then
+    machine="hera"
+elif [[ -d /work ]] ; then
+    machine="orion"
+else
+    echo "UNSUPPORTED MACHINE.  ABORT"
+    exit 99
+fi
+
+# Load modules
+set +x
+module use ${srcdir}/modulefiles
+module load GDAS/${machine}
+set -x
+module list
+
+# Set machine dependent variables
+if [ "$machine" = "hera" ] ; then
+    partition="hera"
+    gdasfix="/scratch1/NCEPDEV/da/Cory.R.Martin/GDASApp/fix"
+elif [ "$machine" = "orion" ]; then
+    partition="debug"
+    gdasfix="/work2/noaa/da/cmartin/GDASApp/fix"
+fi
+
+# Create test run directory
+mkdir -p ${bindir}/test/atm/global-workflow/testrun/gdas_single_test_3denvar
+cd ${bindir}/test/atm/global-workflow/testrun/gdas_single_test_3denvar
+
+# Create input yaml
+cat > ./3denvar_example.yaml << EOF
+working directory: ./
+GDASApp home: ${srcdir}
+GDASApp mode: variational
+template: ${srcdir}/parm/atm/variational/3dvar_dripcg.yaml
+config:
+  berror_yaml: ${srcdir}/parm/atm/berror/hybvar_gsibec.yaml
+  obs_dir: obs
+  diag_dir: diags
+  crtm_coeff_dir: crtm
+  bias_in_dir: obs
+  bias_out_dir: bc
+  obs_yaml_dir: ${srcdir}/parm/atm/obs/config
+  executable: ${bindir}/bin/fv3jedi_var.x
+  obs_list: ${srcdir}/parm/atm/obs/lists/gdas_prototype_3d.yaml
+  gdas_fix_root: ${gdasfix}
+  atm: true
+  layout_x: 1
+  layout_y: 1
+  atm_window_length: PT6H
+  valid_time: 2021-12-21T06:00:00Z
+  dump: gdas
+  case: C96
+  case_anl: C48
+  case_enkf: C48
+  staticb_type: gsibec
+  dohybvar: true
+  levs: 128
+  nmem: 10
+  comin_ges: /scratch1/NCEPDEV/da/Russ.Treadon/GDASApp/cases
+  interp_method: barycentric
+job options:
+  machine: ${machine}
+  account: da-cpu
+  queue: debug
+  partition: ${partition}
+  walltime: '30:00'
+  ntasks: 6
+  modulepath: ${srcdir}/modulefiles
+EOF
+
+# Execute run_jedi_exe.py
+if [ -e stdout.txt ]; then
+    rm -f stdout.txt
+fi
+${srcdir}/ush/run_jedi_exe.py -c ./3denvar_example.yaml > stdout.txt 2>&1
+rc=$?
+if [ $rc -ne 0 ]; then
+    exit $rc
+fi
+
+# Wait and ensure buffers flushed to disk
+sleep 5
+sync stdout.txt
+
+# Check for job submission error
+error=$(grep "sbatch: error" stdout.txt | wc -l)
+if [ $error -ne 0 ]; then
+    rc=$error
+    exit $rc
+fi
+
+# Cancel submitted job
+jobid=$(grep "Submitted" stdout.txt | awk -F' ' '{print $4}')
+scancel $jobid
+rc=$?
+if [ $rc -ne 0 ]; then
+    exit $rc
+fi
+
+# Check for valid yaml files
+ylist="3denvar_example.yaml gdas_variational.yaml"
+for yfile in $ylist; do
+    python3 -c 'import yaml, sys; yaml.safe_load(sys.stdin)' < $yfile
+    rc=$?
+    if [ $rc -ne 0 ]; then
+	exit $rc
+    fi
+done
+
+exit $rc

--- a/test/atm/run_jedi_exe_3denvar.sh
+++ b/test/atm/run_jedi_exe_3denvar.sh
@@ -25,11 +25,9 @@ module list
 if [ "$machine" = "hera" ] ; then
     partition="hera"
     gdasfix="/scratch1/NCEPDEV/da/Cory.R.Martin/GDASApp/fix"
-    cominges="/scratch1/NCEPDEV/da/Russ.Treadon/GDASApp/cases"
 elif [ "$machine" = "orion" ]; then
     partition="debug"
     gdasfix="/work2/noaa/da/cmartin/GDASApp/fix"
-    cominges="/work2/noaa/da/rtreadon/GDASApp/cases"
 fi
 
 # Create test run directory
@@ -66,7 +64,6 @@ config:
   dohybvar: true
   levs: 128
   nmem: 10
-  comin_ges: ${cominges}
   interp_method: barycentric
 job options:
   machine: ${machine}

--- a/test/atm/run_jedi_exe_3denvar.sh
+++ b/test/atm/run_jedi_exe_3denvar.sh
@@ -25,9 +25,11 @@ module list
 if [ "$machine" = "hera" ] ; then
     partition="hera"
     gdasfix="/scratch1/NCEPDEV/da/Cory.R.Martin/GDASApp/fix"
+    cominges="/scratch1/NCEPDEV/da/Russ.Treadon/GDASApp/cases"
 elif [ "$machine" = "orion" ]; then
     partition="debug"
     gdasfix="/work2/noaa/da/cmartin/GDASApp/fix"
+    cominges="/work2/noaa/da/rtreadon/GDASApp/cases"
 fi
 
 # Create test run directory
@@ -64,7 +66,7 @@ config:
   dohybvar: true
   levs: 128
   nmem: 10
-  comin_ges: /scratch1/NCEPDEV/da/Russ.Treadon/GDASApp/cases
+  comin_ges: ${cominges}
   interp_method: barycentric
 job options:
   machine: ${machine}

--- a/test/atm/run_jedi_exe_letkf.sh
+++ b/test/atm/run_jedi_exe_letkf.sh
@@ -23,11 +23,9 @@ module list
 
 # Set machine dependent variables
 if [ "$machine" = "hera" ] ; then
-    cominges="/scratch1/NCEPDEV/da/Russ.Treadon/GDASApp/cases"
     partition="hera"
     gdasfix="/scratch1/NCEPDEV/da/Cory.R.Martin/GDASApp/fix"
 elif [ "$machine" = "orion" ]; then
-    cominges="/work2/noaa/da/rtreadon/GDASApp/cases"
     partition="debug"
     gdasfix="/work2/noaa/da/cmartin/GDASApp/fix"
 fi
@@ -64,7 +62,6 @@ config:
   dohybvar: no
   levs: 128
   nmem: 5
-  comin_ges: ${cominges}
   interp_method: barycentric
 job options:
   machine: ${machine}

--- a/test/genYAML_prep.sh
+++ b/test/genYAML_prep.sh
@@ -19,6 +19,6 @@ config:
   valid_time: '2022-03-30T00:00:00Z'
   atm_window_length: PT6H
   CASE: 'C48'
-  CASE_ENKF: 'C48'
+  CASE_ANL: 'C48'
   LEVS: '128'
 EOF

--- a/test/genYAML_prep_aero.sh
+++ b/test/genYAML_prep_aero.sh
@@ -19,6 +19,6 @@ config:
   valid_time: '2019-06-14T06:00:00Z'
   aero_window_length: PT6H
   CASE: 'C96'
-  CASE_ENKF: 'C48'
+  CASE_ANL: 'C48'
   LEVS: '128'
 EOF

--- a/test/genYAML_prep_land.sh
+++ b/test/genYAML_prep_land.sh
@@ -20,6 +20,6 @@ config:
   atm_window_length: PT6H
   land_window_length: PT6H
   CASE: 'C48'
-  CASE_ENKF: 'C48'
+  CASE_ANL: 'C48'
   LEVS: '128'
 EOF

--- a/ush/examples/run_jedi_exe/3denvar_hera.yaml
+++ b/ush/examples/run_jedi_exe/3denvar_hera.yaml
@@ -1,0 +1,38 @@
+working directory: /scratch2/NCEPDEV/stmp1/Cory.R.Martin/gdas_single_test_3denvar
+GDASApp home: /scratch1/NCEPDEV/da/Cory.R.Martin/GDASApp/work/GDASApp
+GDASApp mode: variational
+template: /scratch1/NCEPDEV/da/Cory.R.Martin/GDASApp/work/GDASApp/parm/atm/variational/3dvar_dripcg.yaml
+config:
+  berror_yaml: /scratch1/NCEPDEV/da/Cory.R.Martin/GDASApp/work/GDASApp/parm/atm/berror/hybvar_gsibec.yaml
+  obs_dir: obs
+  diag_dir: diags
+  crtm_coeff_dir: crtm
+  bias_in_dir: obs
+  bias_out_dir: bc
+  obs_yaml_dir: /scratch1/NCEPDEV/da/Cory.R.Martin/GDASApp/work/GDASApp/parm/atm/obs/config
+  executable: /scratch1/NCEPDEV/da/Cory.R.Martin/GDASApp/work/GDASApp/build/bin/fv3jedi_var.x
+  obs_list: /scratch1/NCEPDEV/da/Cory.R.Martin/GDASApp/work/GDASApp/parm/atm/obs/lists/gdas_prototype_3d.yaml
+  gdas_fix_root: /scratch1/NCEPDEV/da/Cory.R.Martin/GDASApp/fix
+  atm: true
+  layout_x: 1
+  layout_y: 1
+  atm_window_length: PT6H
+  valid_time: 2021-12-21T06:00:00Z
+  dump: gdas
+  case: C96
+  case_anl: C48
+  case_enkf: C48
+  staticb_type: gsibec
+  dohybvar: true
+  levs: 128
+  nmem: 10
+  comin_ges: /scratch1/NCEPDEV/da/Russ.Treadon/GDASApp/cases
+  interp_method: barycentric
+job options:
+  machine: hera
+  account: da-cpu
+  queue: debug
+  partition: hera
+  walltime: '30:00'
+  ntasks: 6
+  modulepath: /scratch1/NCEPDEV/da/Cory.R.Martin/GDASApp/work/GDASApp/modulefiles

--- a/ush/examples/run_jedi_exe/3denvar_hera.yaml
+++ b/ush/examples/run_jedi_exe/3denvar_hera.yaml
@@ -26,7 +26,6 @@ config:
   dohybvar: true
   levs: 128
   nmem: 10
-  comin_ges: /scratch1/NCEPDEV/da/Russ.Treadon/GDASApp/cases
   interp_method: barycentric
 job options:
   machine: hera

--- a/ush/examples/run_jedi_exe/3denvar_orion.yaml
+++ b/ush/examples/run_jedi_exe/3denvar_orion.yaml
@@ -1,0 +1,38 @@
+working directory: /work2/noaa/stmp/cmartin/gdas_single_test_3denvar
+GDASApp home: /work2/noaa/da/cmartin/GDASApp/work/GDASApp
+GDASApp mode: variational
+template: /work2/noaa/da/cmartin/GDASApp/work/GDASApp/parm/atm/variational/3dvar_dripcg.yaml
+config:
+  berror_yaml: /work2/noaa/da/cmartin/GDASApp/work/GDASApp/parm/atm/berror/hybvar_gsibec.yaml
+  obs_dir: obs
+  diag_dir: diags
+  crtm_coeff_dir: crtm
+  bias_in_dir: obs
+  bias_out_dir: bc
+  obs_yaml_dir: /work2/noaa/da/cmartin/GDASApp/work/GDASApp/parm/atm/obs/config
+  executable: /work2/noaa/da/cmartin/GDASApp/work/GDASApp/build/bin/fv3jedi_var.x
+  obs_list: /work2/noaa/da/cmartin/GDASApp/work/GDASApp/parm/atm/obs/lists/gdas_prototype_3d.yaml
+  gdas_fix_root: /work2/noaa/da/cmartin/GDASApp/fix
+  atm: true
+  layout_x: 1
+  layout_y: 1
+  atm_window_length: PT6H
+  valid_time: 2021-12-21T06:00:00Z
+  dump: gdas
+  case: C96
+  case_anl: C48
+  case_enkf: C48
+  staticb_type: gsibec
+  dohybvar: true
+  levs: 128
+  nmem: 10
+  comin_ges: /work2/noaa/da/rtreadon/GDASApp/cases
+  interp_method: barycentric
+job options:
+  machine: orion
+  account: da-cpu
+  queue: debug
+  partition: debug
+  walltime: '30:00'
+  ntasks: 6
+  modulepath: /work2/noaa/da/cmartin/GDASApp/work/GDASApp/modulefiles

--- a/ush/examples/run_jedi_exe/3denvar_orion.yaml
+++ b/ush/examples/run_jedi_exe/3denvar_orion.yaml
@@ -26,7 +26,6 @@ config:
   dohybvar: true
   levs: 128
   nmem: 10
-  comin_ges: /work2/noaa/da/rtreadon/GDASApp/cases
   interp_method: barycentric
 job options:
   machine: orion

--- a/ush/examples/run_jedi_exe/4dhofx_hera.yaml
+++ b/ush/examples/run_jedi_exe/4dhofx_hera.yaml
@@ -24,5 +24,5 @@ job options:
   partition: hera
   walltime: '30:00'
   ntasks: 6
-  ntasks-per-node: 2
+  ntasks-per-node: 1
   modulepath: /scratch1/NCEPDEV/da/Cory.R.Martin/GDASApp/work/GDASApp/modulefiles

--- a/ush/examples/run_jedi_exe/4dhofx_orion.yaml
+++ b/ush/examples/run_jedi_exe/4dhofx_orion.yaml
@@ -24,5 +24,5 @@ job options:
   partition: debug
   walltime: '30:00'
   ntasks: 6
-  ntasks-per-node: 2
+  ntasks-per-node: 1
   modulepath: /work2/noaa/da/cmartin/GDASApp/work/GDASApp/modulefiles

--- a/ush/examples/run_jedi_exe/letkf_hera.yaml
+++ b/ush/examples/run_jedi_exe/letkf_hera.yaml
@@ -22,7 +22,6 @@ config:
   case_enkf: C48
   levs: 128
   nmem: 10
-  comin_ges: /scratch1/NCEPDEV/da/Russ.Treadon/GDASApp/cases
   interp_method: barycentric
 job options:
   machine: hera

--- a/ush/examples/run_jedi_exe/letkf_hera.yaml
+++ b/ush/examples/run_jedi_exe/letkf_hera.yaml
@@ -19,10 +19,7 @@ config:
   valid_time: 2021-12-21T06:00:00Z
   dump: gdas
   case: C48
-  case_anl: C48
   case_enkf: C48
-  staticb_type: gsibec
-  dohybvar: no
   levs: 128
   nmem: 10
   comin_ges: /scratch1/NCEPDEV/da/Russ.Treadon/GDASApp/cases

--- a/ush/examples/run_jedi_exe/letkf_orion.yaml
+++ b/ush/examples/run_jedi_exe/letkf_orion.yaml
@@ -22,7 +22,6 @@ config:
   case_enkf: C48
   levs: 128
   nmem: 10
-  comin_ges: /work2/noaa/da/rtreadon/GDASApp/cases
   interp_method: barycentric
 job options:
   machine: orion

--- a/ush/examples/run_jedi_exe/letkf_orion.yaml
+++ b/ush/examples/run_jedi_exe/letkf_orion.yaml
@@ -19,19 +19,16 @@ config:
   valid_time: 2021-12-21T06:00:00Z
   dump: gdas
   case: C48
-  case_anl: C48
   case_enkf: C48
-  staticb_type: gsibec
-  dohybvar: no
   levs: 128
   nmem: 10
   comin_ges: /work2/noaa/da/rtreadon/GDASApp/cases
   interp_method: barycentric
 job options:
-  machine: hera
+  machine: orion
   account: da-cpu
   queue: debug
-  partition: hera
+  partition: debug
   walltime: '30:00'
   ntasks: 6
   modulepath: /work2/noaa/da/cmartin/GDASApp/work/GDASApp/modulefiles

--- a/ush/run_jedi_exe.py
+++ b/ush/run_jedi_exe.py
@@ -75,8 +75,8 @@ def run_jedi_exe(yamlconfig):
     os.environ['assim_freq'] = str(assim_freq)
     oprefix = executable_subconfig['dump'] + ".t" + str(cyc) + "z."
     gprefix = executable_subconfig['dump'] + ".t" + str(gcyc) + "z."
-    comin = executable_subconfig.get('comin_ges', './')
-    comin_ges_ens = os.path.join(comin, 'enkfgdas.' + str(gPDY), str(gcyc))
+    comin = executable_subconfig.get('gdas_fix_root', './')
+    comin_ges_ens = os.path.join(comin, 'cases', 'enkfgdas.' + str(gPDY), str(gcyc))
 
     single_exec = True
     var_config = {

--- a/ush/run_jedi_exe.py
+++ b/ush/run_jedi_exe.py
@@ -77,7 +77,7 @@ def run_jedi_exe(yamlconfig):
     oprefix = executable_subconfig['dump'] + ".t" + str(cyc) + "z."
     gprefix = executable_subconfig['dump'] + ".t" + str(gcyc) + "z."
     comin = executable_subconfig.get('comin_ges', './')
-    comin_ges_ens = os.path.join(comin, 'enkfgdas.' + str(gPDY), str(gcyc), 'atmos')
+    comin_ges_ens = os.path.join(comin, 'enkfgdas.' + str(gPDY), str(gcyc))
 
     single_exec = True
     var_config = {

--- a/ush/run_jedi_exe.py
+++ b/ush/run_jedi_exe.py
@@ -8,8 +8,6 @@ import subprocess
 import sys
 import yaml
 
-from ufsda.genYAML import genYAML
-
 
 def export_envar(yamlfile, bashout):
 
@@ -59,6 +57,7 @@ def run_jedi_exe(yamlconfig):
     import ufsda
     from ufsda.misc_utils import calc_fcst_steps
     from ufsda.stage import gdas_single_cycle, gdas_fix, background_ens, atm_obs, bias_obs
+    from ufsda.genYAML import genYAML
 
     # compute config for YAML for executable
     executable_subconfig = all_config_dict['config']

--- a/ush/ufsda/genYAML.py
+++ b/ush/ufsda/genYAML.py
@@ -115,8 +115,8 @@ def get_runtime_config(config_dict):
         npx_ges_var: f"{int(os.environ['CASE'][1:]) + 1}",
         npy_ges_var: f"{int(os.environ['CASE'][1:]) + 1}",
         npz_ges_var: f"{int(os.environ['LEVS']) - 1}",
-        npx_anl_var: f"{int(os.environ['CASE_ENKF'][1:]) + 1}",
-        npy_anl_var: f"{int(os.environ['CASE_ENKF'][1:]) + 1}",
+        npx_anl_var: f"{int(os.environ['CASE_ANL'][1:]) + 1}",
+        npy_anl_var: f"{int(os.environ['CASE_ANL'][1:]) + 1}",
         npz_anl_var: f"{int(os.environ['LEVS']) - 1}",
     }
 

--- a/ush/ufsda/misc_utils.py
+++ b/ush/ufsda/misc_utils.py
@@ -154,8 +154,8 @@ def get_env_config(component='atm'):
     config['npx_ges'] = int(os.environ['CASE'][1:]) + 1
     config['npy_ges'] = int(os.environ['CASE'][1:]) + 1
     config['npz_ges'] = int(os.environ['LEVS']) - 1
-    config['npx_anl'] = int(os.environ['CASE_ENKF'][1:]) + 1
-    config['npy_anl'] = int(os.environ['CASE_ENKF'][1:]) + 1
+    config['npx_anl'] = int(os.environ['CASE_ANL'][1:]) + 1
+    config['npy_anl'] = int(os.environ['CASE_ANL'][1:]) + 1
     config['npz_anl'] = int(os.environ['LEVS']) - 1
 
     return config

--- a/ush/ufsda/stage.py
+++ b/ush/ufsda/stage.py
@@ -55,11 +55,7 @@ def gdas_fix(input_fix_dir, working_dir, config):
 
     # link gsibec staticb
     if staticb_source in ['gsibec']:
-        if dohybvar:
-            case_gsibec = case_anl
-        else:
-            case_gsibec = case
-        ufsda.disk_utils.symlink(os.path.join(input_fix_dir, staticb_source, case_gsibec),
+        ufsda.disk_utils.symlink(os.path.join(input_fix_dir, staticb_source, case),
                                  config['fv3jedi_staticb_dir'])
 
     # link akbk file
@@ -321,7 +317,7 @@ def gdas_single_cycle(config):
     if config['DOHYBVAR']:
         for imem in range(1, config['NMEM_ENKF']+1):
             memchar = f"mem{imem:03d}"
-            print(f"background_ens:  stage {memchar}")
+            logging.info("Stage hybvar ens {memchar}")
             rst_dir = os.path.join(config['COMIN_GES_ENS'], memchar, 'atmos', 'RESTART')
             ges_dir = os.path.join(config['COMIN_GES_ENS'], memchar, 'atmos', 'RESTART_GES')
             jedi_bkg_mem = os.path.join(config['DATA'], 'ens')
@@ -461,7 +457,7 @@ def background_ens(config):
     """
     for imem in range(1, config['NMEM_ENKF']+1):
         memchar = f"mem{imem:03d}"
-        print(f"background_ens:  stage {memchar}")
+        logging.info("Stage background_ens {memchar}")
         rst_dir = os.path.join(config['COMIN_GES_ENS'], memchar, 'atmos', 'RESTART')
         ges_dir = os.path.join(config['COMIN_GES_ENS'], memchar, 'atmos', 'RESTART_GES')
         jedi_bkg_mem = os.path.join(config['DATA'], 'bkg', memchar)

--- a/ush/ufsda/stage.py
+++ b/ush/ufsda/stage.py
@@ -309,6 +309,7 @@ def gdas_single_cycle(config):
     if config['DOHYBVAR']:
         background_ens(config)
 
+
 def background(config):
     """
     Stage backgrounds and create links for analysis
@@ -318,16 +319,8 @@ def background(config):
     - mkdir analysis/anl
     """
     rst_dir = os.path.join(config['background_dir'], 'RESTART')
-##  ges_dir = os.path.join(config['background_dir'], 'RESTART_GES')
     jedi_bkg_dir = os.path.join(config['DATA'], 'bkg')
     jedi_anl_dir = os.path.join(config['DATA'], 'anl')
-
-    # copy RESTART to RESTART_GES
-##    try:
-##        shutil.copytree(rst_dir, ges_dir)
-##    except FileExistsError:
-##        shutil.rmtree(ges_dir)
-##        shutil.copytree(rst_dir, ges_dir)
     try:
         os.symlink(rst_dir, jedi_bkg_dir)
     except FileExistsError:
@@ -427,8 +420,9 @@ def background_ens(config):
     """
 
     dohybvar = config['DOHYBVAR']
-    bkgdir = 'ens' 
-    if not dohybvar: bkgdir = 'bkg'
+    bkgdir = 'ens'
+    if not dohybvar:
+        bkgdir = 'bkg'
 
     for imem in range(1, config['NMEM_ENKF']+1):
         memchar = f"mem{imem:03d}"

--- a/ush/ufsda/stage.py
+++ b/ush/ufsda/stage.py
@@ -47,16 +47,9 @@ def gdas_fix(input_fix_dir, working_dir, config):
 
     # figure out staticb source
     staticb_source = config.get('STATICB_TYPE', 'gsibec')
-
-    # link bump staticb
-    if staticb_source in ['bump']:
-        ufsda.disk_utils.symlink(os.path.join(input_fix_dir, staticb_source, case_anl),
-                                 config['fv3jedi_staticb_dir'])
-
-    # link gsibec staticb
-    if staticb_source in ['gsibec']:
-        ufsda.disk_utils.symlink(os.path.join(input_fix_dir, staticb_source, case),
-                                 config['fv3jedi_staticb_dir'])
+    case_berror = case if staticb_source in ['gsibec'] else case_anl
+    ufsda.disk_utils.symlink(os.path.join(input_fix_dir, staticb_source, case_berror),
+                             config['fv3jedi_staticb_dir'])
 
     # link akbk file
     ufsda.disk_utils.symlink(os.path.join(input_fix_dir, 'fv3jedi',

--- a/ush/ufsda/stage.py
+++ b/ush/ufsda/stage.py
@@ -312,11 +312,10 @@ def gdas_single_cycle(config):
 
 def background(config):
     """
-    Stage backgrounds and create links for analysis
+    Stage backgrounds and create analysis directory
     This involves:
-    - cp RESTART to RESTART_GES
-    - ln RESTART_GES to analysis/bkg
-    - mkdir analysis/anl
+    - ln RESTART to bkg_dir
+    - mkdir anl
     """
     rst_dir = os.path.join(config['background_dir'], 'RESTART')
     jedi_bkg_dir = os.path.join(config['DATA'], 'bkg')
@@ -412,16 +411,15 @@ def berror(config):
 
 def background_ens(config):
     """
-    Stage backgrounds and create links for analysis
+    Stage backgrounds and optionally create analysis directories
     This involves:
-    - cp RESTART to RESTART_GES
-    - ln RESTART_GES to analysis/bkg
-    - mkdir analysis/anl
+    - ln member RESTART to bkg_mem
+    - optionally mkdir anl_mem
     """
 
-    dohybvar = config['DOHYBVAR']
+    # set background directory keyword based on dohybvar
     bkgdir = 'ens'
-    if not dohybvar:
+    if not config['DOHYBVAR']:
         bkgdir = 'bkg'
 
     for imem in range(1, config['NMEM_ENKF']+1):
@@ -430,7 +428,7 @@ def background_ens(config):
         rst_dir = os.path.join(config['COMIN_GES_ENS'], memchar, 'atmos', 'RESTART')
         jedi_bkg_dir = os.path.join(config['DATA'], bkgdir)
         jedi_bkg_mem = os.path.join(config['DATA'], bkgdir, memchar)
-        jedi_anl_dir = os.path.join(config['DATA'], 'anl', memchar)
+        jedi_anl_mem = os.path.join(config['DATA'], 'anl', memchar)
         mkdir(jedi_bkg_dir)
         try:
             os.symlink(rst_dir, jedi_bkg_mem)
@@ -440,4 +438,4 @@ def background_ens(config):
 
         # do not create member analysis directories for dohybvar
         if not config['DOHYBVAR']:
-            mkdir(jedi_anl_dir)
+            mkdir(jedi_anl_mem)

--- a/ush/ufsda/ufs_yaml.py
+++ b/ush/ufsda/ufs_yaml.py
@@ -108,7 +108,7 @@ def get_cycle_vars():
 def get_exp_vars():
     # variables computed from shell variables but not time dependent
     exp_dict = {}
-    npx_anl = str(int(os.getenv('CASE_ENKF', os.environ['CASE'])[1:]) + 1)
+    npx_anl = str(int(os.getenv('CASE_ANL', os.environ['CASE'])[1:]) + 1)
     npx = str(int(os.environ['CASE'][1:]) + 1)
     exp_dict['npx_anl'] = npx_anl
     exp_dict['npy_anl'] = npx_anl


### PR DESCRIPTION
The changes in this PR add the option to launch `fv3jedi_var.x` in 3denvar mode via `ush/run_jedi_exe.py`.   This functionality is useful since operational GSI-based global and regional DA systems run in a hybrid model in which the static background error is augmented with an ensemble component (envar).   

This PR adds four new files:
- `parm/atm/berror/hybvar_gsibec.yaml` - hybrid background error yaml file using `gsibec` for static-B along with a 10 member ensemble
- `test/atm/run_jedi_exe_3denvar.sh` - ctest using `run_jedi_exe.py` to launch `fv3jedi_var.x` in 3denvar mode 
- `ush/examples/run_jedi_exe/3denvar_hera.yaml` - configuration file used by `run_jedi_exe.py` to run 3denvar sample case on Hera
- `ush/examples/run_jedi_exe/3denvar_orion.yaml` - configuration file used by `run_jedi_exe.py` to run 3denvar sample case on Orion

Eleven existing files are modified:
- `CMakeLists.txt` - update gsibec to tag 1.0.7.   Previously pointed at head of gsibec develop.  This is problematic since the head of gsibec develop is not always function and/or requires specific hashes of other JEDI components.
- `parm/atm/obs/config/sondes.yaml` - replace `surface_geometric_height` with `surface_geopotential_height` to avoid `fv3jedi_var.x` segmentation fault
- `test/atm/CMakeLists.txt` - add `test_gdasapp_run_jedi_exe_3denvar`
- `test/genYAML_prep.sh` - replace `CASE_ENKF` with `CASE_ANL`
- `test/genYAML_prep_aero.sh` - replace `CASE_ENKF` with `CASE_ANL`
- `test/genYAML_prep_land.sh` - replace `CASE_ENKF` with `CASE_ANL`
- `ush/run_jedi_exe.py` - remove `atmos` from enkfgdas root path.   This change is necessitate by changes in the g-w GFS directory structure.   The `atmos` directory is now located in `memXXX` directories.
- `ush/ufsda/genYAML.py` - replace `CASE_ENKF` with `CASE_ANL`
- `ush/ufsda/misc_utils.py` - replace `CASE_ENKF` with `CASE_ANL`
- `ush/ufsda/stage.py` - add `atmos` to the `memXXX` path for ensemble members, enhance error checking for `dohybvar = .true.` option, add logic to ensure correct `gsibec` static-B is linked to the run directory.
- `ush/ufsda/ufs_yaml.py` - replace `CASE_ENKF` with `CASE_ANL`

Fixes #402 