### PR TITLE
Updates to several yamls for land DA based on updated global-workflow.

### DIFF
--- a/parm/land/hofx/hofx_nomodel.yaml
+++ b/parm/land/hofx/hofx_nomodel.yaml
@@ -1,30 +1,30 @@
-window begin: '{{LAND_WINDOW_BEGIN}}'
+window begin: '{{ LAND_WINDOW_BEGIN | to_isotime }}'
 window length: $(LAND_WINDOW_LENGTH)
 geometry:
   fms initialization:
-    namelist filename: !ENV ${DATA}/fv3jedi/fmsmpp.nml
-    field table filename: !ENV ${DATA}/fv3jedi/field_table
-  akbk: !ENV ${DATA}/fv3jedi/akbk.nc4
+    namelist filename: $(DATA)/fv3jedi/fmsmpp.nml
+    field table filename: $(DATA)/fv3jedi/field_table
+  akbk: $(DATA)/fv3jedi/akbk.nc4
   layout:
-  - !ENV ${layout_x}
-  - !ENV ${layout_y}
+  - $(layout_x)
+  - $(layout_y)
   npx: $(npx_ges)
   npy: $(npy_ges)
   npz: $(npz_ges)
-  field metadata override: !ENV ${DATA}/fv3jedi/gfs-land.yaml
+  field metadata override: $(DATA)/fv3jedi/gfs-land.yaml
   time invariant fields:
     state fields:
-      datetime: '{{LAND_WINDOW_BEGIN}}'
+      datetime: '{{ LAND_WINDOW_BEGIN | to_isotime }}'
       filetype: fms restart
       skip coupler file: true
       state variables: [orog_filt]
-      datapath: !ENV ${FIXgfs}/fix_orog/${CASE}/
-      filename_orog: !ENV ${CASE}_oro_data.nc
+      datapath: $(FIXgfs)/fix_orog/${CASE}/
+      filename_orog: $(CASE)_oro_data.nc
 state:
-  datapath: !ENV ${DATA}/bkg
+  datapath: $(DATA)/bkg
   filetype: fms restart
-  datetime: '{{LAND_BKG_ISOTIME}}'
-  filename_sfcd: '{{LAND_BKG_YYYYmmddHHMMSS}}.sfc_data.nc'
-  filename_cplr: '{{LAND_BKG_YYYYmmddHHMMSS}}.coupler.res'
+  datetime: '{{ current_cycle | to_isotime }}'
+  filename_sfcd: '{{ current_cycle | to_fv3time }}.sfc_data.nc'
+  filename_cplr: '{{ current_cycle | to_fv3time }}.coupler.res'
   state variables: [snwdph,vtype,slmsk]
 observations: !INC ${OBS_LIST}

--- a/parm/land/letkfoi/letkfoi.yaml
+++ b/parm/land/letkfoi/letkfoi.yaml
@@ -1,37 +1,37 @@
 geometry:
   fms initialization:
-    namelist filename: !ENV ${DATA}/fv3jedi/fmsmpp.nml
-    field table filename: !ENV ${DATA}/fv3jedi/field_table
-  akbk: !ENV ${DATA}/fv3jedi/akbk.nc4
+    namelist filename: $(DATA)/fv3jedi/fmsmpp.nml
+    field table filename: $(DATA)/fv3jedi/field_table
+  akbk: $(DATA)/fv3jedi/akbk.nc4
   layout:
-  - !ENV ${layout_x}
-  - !ENV ${layout_y}
+  - $(layout_x)
+  - $(layout_y)
   npx: $(npx_ges)
   npy: $(npy_ges)
   npz: $(npz_ges)
-  field metadata override: !ENV ${DATA}/fv3jedi/gfs-land.yaml
+  field metadata override: $(DATA)/fv3jedi/gfs-land.yaml
   time invariant fields:
     state fields:
-      datetime: '{{LAND_WINDOW_BEGIN}}'
+      datetime: '{{ LAND_WINDOW_BEGIN | to_isotime }}'
       filetype: fms restart
       skip coupler file: true
       state variables: [orog_filt]
-      datapath: !ENV ${FIXgfs}/orog/${CASE}/
-      filename_orog: !ENV ${CASE}_oro_data.nc
+      datapath: $(FIXgfs)/orog/${CASE}/
+      filename_orog: $(CASE)_oro_data.nc
 
-window begin: '{{LAND_WINDOW_BEGIN}}'
+window begin: '{{ LAND_WINDOW_BEGIN | to_isotime }}'
 window length: $(LAND_WINDOW_LENGTH)
 
 background:
-   datetime: '{{LAND_BKG_ISOTIME}}'
+   datetime: '{{ current_cycle | to_isotime }}'
    members from template:
      template:
-       datetime: '{{LAND_BKG_ISOTIME}}'
+       datetime: '{{ current_cycle | to_isotime }}'
        filetype: fms restart
        state variables: [snwdph,vtype,slmsk]
-       datapath: !ENV ${DATA}/bkg/mem%mem%/RESTART
-       filename_sfcd: '{{LAND_BKG_YYYYmmddHHMMSS}}.sfc_data.nc'
-       filename_cplr: '{{LAND_BKG_YYYYmmddHHMMSS}}.coupler.res'
+       datapath: $(DATA)/bkg/mem%mem%/RESTART
+       filename_sfcd: '{{ current_cycle | to_fv3time }}.sfc_data.nc'
+       filename_cplr: '{{ current_cycle | to_fv3time }}.coupler.res'
      pattern: '%mem%'
      nmembers: 2
      zero padding: 3
@@ -51,10 +51,10 @@ local ensemble DA:
     mult: 1.0
 
 output increment:
-  datapath: !ENV ${DATA}/anl
+  datapath: $(DATA)/anl
   prefix: landinc
   filetype: fms restart
-  filename_sfcd: '{{LAND_BKG_YYYYmmddHHMMSS}}.sfc_data.nc'
-  filename_cplr: '{{LAND_BKG_YYYYmmddHHMMSS}}.coupler.res'
+  filename_sfcd: '{{ current_cycle | to_fv3time }}.sfc_data.nc'
+  filename_cplr: '{{ current_cycle | to_fv3time }}.coupler.res'
   state variables: [snwdph,vtype,slmsk]
 

--- a/parm/land/obs/config/adpsfc_snow.yaml
+++ b/parm/land/obs/config/adpsfc_snow.yaml
@@ -6,11 +6,11 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: !ENV ${DATA}/obs/${OPREFIX}adpsfc_snow_${CDATE}.nc4
+      obsfile: $(DATA)/obs/$(OPREFIX)adpsfc_snow_{{ current_cycle | to_YMDH }}.nc4
   obsdataout:
     engine:
       type: H5File
-      obsfile: !ENV ${DATA}/diags/diag_adpsfc_snow_${CDATE}.nc4
+      obsfile: $(DATA)/diags/diag_adpsfc_snow_{{ current_cycle | to_YMDH }}.nc4
   simulated variables: [totalSnowDepth]
 obs operator:
   name: Composite

--- a/parm/land/obs/config/ghcn_snow.yaml
+++ b/parm/land/obs/config/ghcn_snow.yaml
@@ -6,11 +6,11 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: !ENV ${DATA}/obs/${OPREFIX}ghcn_snow_${CDATE}.nc4
+      obsfile: $(DATA)/obs/$(OPREFIX)ghcn_snow_{{ current_cycle | to_YMDH }}.nc4
   obsdataout:
     engine:
       type: H5File
-      obsfile: !ENV ${DATA}/diags/diag_ghcn_snow_${CDATE}.nc4
+      obsfile: $(DATA)/diags/diag_ghcn_snow_{{ current_cycle | to_YMDH }}.nc4
 
 obs operator:
   name: Identity

--- a/parm/land/obs/config/ims_snow.yaml
+++ b/parm/land/obs/config/ims_snow.yaml
@@ -6,11 +6,11 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: !ENV ${DATA}/obs/${OPREFIX}ims_snow_${CDATE}.nc4
+      obsfile: $(DATA)/obs/$(OPREFIX)ims_snow_{{ current_cycle | to_YMDH }}.nc4
   obsdataout:
     engine:
       type: H5File
-      obsfile: !ENV ${DATA}/diags/diag_ims_snow_${CDATE}.nc4
+      obsfile: $(DATA)/diags/diag_ims_snow_{{ current_cycle | to_YMDH }}.nc4
   simulated variables: [totalSnowDepth]
 obs operator:
   name: Identity


### PR DESCRIPTION
This PR followed the PR #398 to update several yamls for land DA based on the updated global-workflow. 

- primarily removes all `!ENV` declarations in the yaml files to use variables from a dictionary rather than the `env`.
- uses `current_cycle` instead of derived variables e.g. `BKG_ISOTIME` etc. with `jinja2` templates to render the correct format.
