### PR TITLE
change CASE_ENKF to CASE_ANL in UFO testing script

### DIFF
--- a/ush/ufoeval/run_ufo_hofx_test.sh
+++ b/ush/ufoeval/run_ufo_hofx_test.sh
@@ -121,7 +121,7 @@ export cyc=${CDATE:8:2}
 export gPDY=${GDATE:0:8}
 export gcyc=${GDATE:8:2}
 export CASE="C768"
-export CASE_ENKF="C384"
+export CASE_ANL="C384"
 export LEVS="128"
 
 # Load Modules for GDASApp


### PR DESCRIPTION
#405 changed the scripts that compute the analysis resolution for the YAML files from `CASE_ENKF` to `CASE_ANL`.

The UFO driver testing scripts (such as what produce https://emc.ncep.noaa.gov/data_assimilation/JEDI/GDAS/UFO/acceptance/) need to also be updated to define these variables in its environment, otherwise it will fail.

This PR makes that change for ush/ufoeval/run_ufo_hofx_test.sh