### PR TITLE
update aero bump yaml based on updated fv3jedi and global-workflow

### DIFF
--- a/parm/aero/berror/staticb_bump.yaml
+++ b/parm/aero/berror/staticb_bump.yaml
@@ -1,7 +1,7 @@
 covariance model: SABER
 saber central block:
   saber block name: BUMP_NICAS
-  bump:
+  read:
     io:
       data directory: &staticb_aero_dir $(DATA)/berror
       files prefix: 'nicas_aero'
@@ -41,7 +41,7 @@ saber central block:
     - parameter: universe radius
       file:
         filetype: fms restart
-        datetime: 2016-06-30T00:00:00Z
+        datetime: '2016-06-30T00:00:00Z'
         set datetime on read: true
         psinfile: true
         datapath: *staticb_aero_dir
@@ -55,7 +55,7 @@ saber central block:
     - parameter: StdDev
       file:
         filetype: fms restart
-        datetime: 2016-06-30T00:00:00Z
+        datetime: '2016-06-30T00:00:00Z'
         set datetime on read: true
         psinfile: true
         datapath: *staticb_aero_dir


### PR DESCRIPTION
This PR updates the template staticb_bump.yaml in parm/aero/berror for aerosol DA based on the updated BUMP in fv3-jedi and the updated global-workflow.

- replace key word "**bump**" to "**read**".
- change **datetime: 2016-06-30T00:00:00Z** to **datetime: '2016-06-30T00:00:00Z'**, because JSON in g-w can not work with type datetime.