### PR TITLE
parm/atm/obs/testing: satwind.yaml and scatwind.yaml with passing benchmarks

### DIFF
--- a/parm/atm/obs/testing/satwind.yaml
+++ b/parm/atm/obs/testing/satwind.yaml
@@ -304,7 +304,7 @@ obs pre filters:
             name: MetaData/pressure
           xvals: [110000.,105000.,100000.,95000.,90000.,85000.,80000.,75000.,70000.,65000.,60000.,55000.,50000.,45000.,40000.,35000.,30000.,25000.,20000.,15000.,10000.,7500.,5000.,4000.,3000.,2000.,1000.,500.,400.,300.,200.,100.,0.]   #Pressure (Pa)
           errors: [3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.8,3.9,3.9,4.,4.5,6.1,6.,6.5,7.3,7.6,7.,7.5,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.,7.]
-  # Type 255 (GOES low-level picture triplet cloud drift): According to prepbufr table this should no longer exist??
+  # Type 255 (LEOGEO):
   - filter: Perform Action
     filter variables:
     - name: windEastward
@@ -646,11 +646,34 @@ obs prior filters:
       name: reject
 # NESDIS obs are also subject to the experr_norm test defined as:
 #
-# if (10. - 0.1*(expectedError))/(ob_speed)>0.9, or ob_speed<0.1, reject, applies to Types [240,245,246,247,251]
+# if (10. - 0.1*(expectedError))/(ob_speed)>0.9, or ob_speed<0.1, reject, applies to NESDIS winds
 #
-# This is not implemented in the YAML file because we do not have the capability to compute
-# the norm, lacking the required math operators. Instead, this will likely have to be
-# implemented as an ObsFunction like the SatWindsLNVDCheck test.
+# CLEARED: With caveat that float precision/handling differences can generate different acceptance criteria
+# between UFO and GSO for observations with an experr_norm value right around the maxvalue.
+  - filter: Bounds Check
+    filter variables:
+    - name: windEastward
+    - name: windNorthward
+    where:
+    - variable: MetaData/satelliteIdentifier
+      is_in: 250-299
+    test variables:
+    - name: ObsFunction/SatWindsErrnormCheck
+    maxvalue: 0.9
+    action:
+      name: reject
+#
+  # Reject all Type=240 (GOES SWIR) AMVs: These are not currently assimilated in GSI and they have missing-values
+  # assigned to ob-errors
+  - filter: Perform Action
+    filter variables:
+    - name: windEastward
+    - name: windNorthward
+    where:
+    - variable: ObsType/windEastward
+      is_in: 240
+    action:
+      name: reject
 #
 # setupw criteria
 #
@@ -847,25 +870,140 @@ obs post filters:
     maxvalue: 3.
     action:
       name: reject
+  # All satwinds must adjust errors based on ObsErrorFactorPressureCheck
+  # prior to the SPDB check (i.e. the gross-error check). The gross-error
+  # check uses the adjusted errors for error-bound tightening and rejection,
+  # so this check has to come first. This check will inflate errors for obs
+  # that are too close to either the model top or bottom.
+  - filter: Perform Action
+    filter variables:
+    - name: windEastward
+    where:
+      - variable:
+          name: ObsType/windEastward
+        is_in: 240-260
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorPressureCheck
+        options:
+          variable: windEastward
+          inflation factor: 4.0
+
+  - filter: Perform Action
+    filter variables:
+    - name: windNorthward
+    where:
+      - variable:
+          name: ObsType/windNorthward
+        is_in: 240-260
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorPressureCheck
+        options:
+          variable: windNorthward
+          inflation factor: 4.0
   #
-  # All satwinds subject to a SPDB check (function may be broken?)
-  #   We are ignoring this filter for now, and will come back to
-  #   the issue of how to handle this SPDB check later. For now,
-  #   observations that are GSI-rejected based on this test are
-  #   not being considered when checking acceptance compliance.
-  #- filter: Bounds Check
-  #  filter variables:
-  #  - name: windEastward
-  #  - name: windNorthward
-  #  test variables:
-  #  - name: ObsFunction/SatWindsSPDBCheck
-  #    options:
-  #      error_min: 1.4
-  #      error_max: 20.0
-  #  maxvalue: 1.75
-  #  action:
-  #    name: reject
-  #  defer to post: true
+  # All satwinds subject to a gross-error check that contains significant
+  # modifiers for satwinds with a negative speed-bias. ALL wind gross-error
+  # checks are currently being done by the SatWindsSPDBCheck.
+  # CLEARED
+  - filter: Background Check
+    filter variables:
+    - name: windEastward
+    function absolute threshold:
+    - name: ObsFunction/SatWindsSPDBCheck
+      options:
+        wndtype: [  240,  241,  242,  243,  244,  245,  246,  247,  248,  249, 250,  251,  252,  253,   254,  255,  256,  257,  258,  259,  260]
+        cgross:  [  2.5,  2.5,  2.5,  1.5,  2.5,  1.3,  1.3,  2.5,  2.5,  2.5, 2.5,  1.3,  2.5,  1.5,   1.5,  2.5,  2.5,  2.5,  2.5,  2.5,  2.5]
+        error_min: [1.4,  1.4,  1.4,  1.4,  1.4,  1.4,  1.4,  1.4,  1.4,  1.4, 1.4,  1.4,  1.4,  1.4,   1.4,  1.4,  1.4,  1.4,  1.4,  1.4,  1.4]
+        error_max: [6.1,  6.1, 15.0, 15.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.1, 20.1, 20.1, 20.1, 20.1, 20.1]
+        variable: windEastward
+    action:
+      name: reject
+
+  - filter: Background Check
+    filter variables:
+    - name: windNorthward
+    function absolute threshold:
+    - name: ObsFunction/SatWindsSPDBCheck
+      options:
+        wndtype: [  240,  241,  242,  243,  244,  245,  246,  247,  248,  249, 250,  251,  252,  253,   254,  255,  256,  257,  258,  259,  260]
+        cgross:  [  2.5,  2.5,  2.5,  1.5,  2.5,  1.3,  1.3,  2.5,  2.5,  2.5, 2.5,  1.3,  2.5,  1.5,   1.5,  2.5,  2.5,  2.5,  2.5,  2.5,  2.5]
+        error_min: [1.4,  1.4,  1.4,  1.4,  1.4,  1.4,  1.4,  1.4,  1.4,  1.4, 1.4,  1.4,  1.4,  1.4,   1.4,  1.4,  1.4,  1.4,  1.4,  1.4,  1.4]
+        error_max: [6.1,  6.1, 15.0, 15.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.1, 20.1, 20.1, 20.1, 20.1, 20.1]
+        variable: windNorthward
+    action:
+      name: reject
+  # The last error inflation check is for duplicate observations. This one needs
+  # to come last, because we don't want to inflate errors for duplication if one
+  # of the duplicates should be rejected.
+  - filter: BlackList
+    filter variables:
+    - name: windEastward
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorDuplicateCheck
+        options:
+          use_air_pressure: true
+          variable: windEastward
+  - filter: BlackList
+    filter variables:
+    - name: windNorthward
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorDuplicateCheck
+        options:
+          use_air_pressure: true
+          variable: windNorthward
+  # We are extending this to an additional filter that inflates final ob-errors across-the-board by
+  # 1/0.8 = 1.25. This is caused by the GSI value of nvqc being set to .true. in the global operational
+  # configuration, see: https://github.com/NOAA-EMC/global-workflow/blob/d5ae3328fa4041b177357b1133f6b92e81c859d7/scripts/exglobal_atmos_analysis.sh#L750
+  # This setting activates Line 1229 of setupw.f90 to scale ratio_errors by 0.8, which is applied in
+  # the denominator of the final ob-error, so 1/0.8 = 1.25 factor of ob-error inflation.
+  #
+  # If this nvqc functionality were to be switched off (i.e. if variational qc were to be turned off),
+  # you would want to remove this last inflation filter.
+  - filter: Perform Action
+    filter variables:
+    - name: windEastward
+    where:
+    - variable: ObsType/windEastward
+      is_in: 240-260
+    action:
+      name: inflate error
+      inflation factor: 1.25
+#
+  - filter: Perform Action
+    filter variables:
+    - name: windNorthward
+    where:
+    - variable: ObsType/windNorthward
+      is_in: 240-260
+    action:
+      name: inflate error
+      inflation factor: 1.25
+# END OF FILTERS
 linear obs operator:
   name: Identity
 
+passedBenchmark: 1025814 # 2 variables (u,v), both passing 512907 obs, including 512907 GSI/UFO agreements, and:
+                         # 16 GOES AMVs (6 u-obs, 6 v-obs) that are rejected by the SatWindsErrnormCheck in UFO
+                         # but are retained in GSI's equivalent experr_norm check. All 6 of these disagreements
+                         # have error norm values at almost exactly 0.9, indicating a float precision/handling
+                         # difference between UFO and GSI generating the disagreement.
+                         #
+                         # NOTE: This benchmark is specifically for a test with assim_freq=6, which based on
+                         #       JEDI convention, cuts off data from the front-end of the time-window that is
+                         #       retained in GSI. This can generate some problems with the assigned ob-errors,
+                         #       particularly the UFO assigning lower ob-errors because the reduced number of
+                         #       observations being assimilated will allow for fewer duplicate-ob matches than
+                         #       found in GSI, which will cause GSI to downweight observations within the UFO's
+                         #       truncated time-window that UFO will not downweight. This is happening on 3 of
+                         #       the satwinds in this dataset. Setting the assim_freq=12, which expands the
+                         #       UFO time-window wide enough to capture all of the observations that are being
+                         #       assimilated in GSI from this test-data, results in these ob-error differences
+                         #       disappearing.

--- a/parm/atm/obs/testing/scatwind.yaml
+++ b/parm/atm/obs/testing/scatwind.yaml
@@ -1,0 +1,242 @@
+obs space:
+  name: scatwind
+  obsdatain:
+    engine:
+      type: H5File
+      obsfile: !ENV scatwind_obs_${CDATE}.nc4
+  obsdataout:
+    engine:
+      type: H5File
+      obsfile: !ENV scatwind_diag_${CDATE}.nc4 
+  simulated variables: [windEastward, windNorthward]
+geovals:
+  filename: !ENV scatwind_geoval_${CDATE}.nc4
+vector ref: GsiHofXBc
+tolerance: 0.01
+obs operator:
+  name: VertInterp
+  apply near surface wind scaling: true
+#
+obs pre filters:
+  # Assign the initial observation error (constant value, 1.5 m/s right now).
+  - filter: Perform Action
+    filter variables:
+    - name: windEastward
+    - name: windNorthward
+    action:
+      name: assign error
+      error parameter: 1.5
+#obs prior filters:
+  #
+  # Reject all obs with PreQC mark already set above 3
+  # NOTE: All scatwinds have an automatic PreQC mark of 2 (hard-wired default from GSI)
+  # - filter: PreQC
+  #   maxvalue: 3
+  #   action:
+  #     name: reject
+  #
+obs post filters:
+  #
+  # Reject all ASCAT (Type 290) winds with tsavg <= 273.0 (surface temperature)
+  #
+  - filter: Perform Action
+    filter variables:
+    - name: windEastward
+    - name: windNorthward
+    where:
+    - variable: ObsType/windEastward
+      is_in: 290
+    - variable: GeoVaLs/surface_temperature
+      maxvalue: 273.
+    action:
+      name: reject
+  #
+  # Reject all ASCAT (Type 290) winds with isflg /= 0 (non-water surface)
+  #
+  - filter: Perform Action
+    filter variables:
+    - name: windEastward
+    - name: windNorthward
+    where:
+    - variable: ObsType/windEastward
+      is_in: 290
+    - variable: GeoVaLs/land_type_index_NPOESS
+      minvalue: 1. 
+    action:
+      name: reject
+  # Reject ASCAT (Type 290) when observed component deviates from background by more than 5.0 m/s
+  # NOTE: This check can reject a u- or v-component of the same observation independently, which
+  #       is fundamentally different from how GSI rejects obs (both components are rejected if
+  #       either component fails a check).
+  - filter: Background Check
+    filter variables:
+    - name: windEastward
+    - name: windNorthward
+    threshold: 5.
+    absolute threshold: 5.
+    where:
+    - variable: ObsType/windEastward
+      is_in: 290
+    action:
+      name: reject
+  # Reject OSCAT (Type 291) when observed component deviates from background by more than 6.0 m/s
+  # NOTE: This check can reject a u- or v-component of the same observation independently, which
+  #       is fundamentally different from how GSI rejects obs (both components are rejected if
+  #       either component fails a check).
+  - filter: Background Check
+    filter variables:
+    - name: windEastward
+    - name: windNorthward
+    threshold: 6.
+    absolute threshold: 6.
+    where:
+    - variable: ObsType/windEastward
+      is_in: 291
+    action:
+      name: reject
+  # Reject ASCAT (Type 290) when ambiguity check fails (returned value is negative)
+  - filter: Bounds Check
+    filter variables:
+    - name: windEastward
+    - name: windNorthward
+    where:
+    - variable: ObsType/windEastward
+      is_in: 290
+    test variables:
+    - name: ObsFunction/ScatWindsAmbiguityCheck
+      options:
+        test_hofx: GsiHofX
+        minimum_uv: 0.0001 # hard-coding a minimum-uv for transparancy, want this to basically be zero
+    maxvalue: 0.  
+    action:
+      name: reject
+#
+  # All scatwinds must adjust errors based on ObsErrorFactorPressureCheck.
+  # This check will inflate errors for obs that are too close to either
+  # the model top or bottom.
+  - filter: Perform Action
+    filter variables:
+    - name: windEastward
+    where:
+      - variable:
+          name: ObsType/windEastward
+        is_in: 290-291
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorPressureCheck
+        options:
+          variable: windEastward
+          inflation factor: 4.0
+#
+  - filter: Perform Action
+    filter variables:
+    - name: windNorthward
+    where:
+      - variable:
+          name: ObsType/windNorthward
+        is_in: 290-291
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorPressureCheck
+        options:
+          variable: windNorthward
+          inflation factor: 4.0
+  # All scatwinds subject to a gross error check. This is contained within
+  # the SatWindsSPDBCheck, although it is not exclusive to satwinds.
+  - filter: Background Check
+    filter variables:
+    - name: windEastward
+    function absolute threshold:
+    - name: ObsFunction/SatWindsSPDBCheck
+      options:
+        wndtype: [  290,  291]
+        cgross:  [  5.0,  5.0]
+        error_min: [1.4,  1.4]
+        error_max: [6.1,  6.1]
+        variable: windEastward
+    action:
+      name: reject
+
+  - filter: Background Check
+    filter variables:
+    - name: windNorthward
+    function absolute threshold:
+    - name: ObsFunction/SatWindsSPDBCheck
+      options:
+        wndtype: [  290,  291]
+        cgross:  [  5.0,  5.0]
+        error_min: [1.4,  1.4]
+        error_max: [6.1,  6.1]
+        variable: windNorthward
+    action:
+      name: reject
+  # The last error inflation check is for duplicate observations. This one needs
+  # to come last, because we don't want to inflate errors for duplication if one
+  # of the duplicates should be rejected.
+  - filter: BlackList
+    filter variables:
+    - name: windEastward
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorDuplicateCheck
+        options:
+          use_air_pressure: true
+          variable: windEastward
+  - filter: BlackList
+    filter variables:
+    - name: windNorthward
+    action:
+      name: inflate error
+      inflation variable:
+        name: ObsFunction/ObsErrorFactorDuplicateCheck
+        options:
+          use_air_pressure: true
+          variable: windNorthward
+  # There is no across-the-board inflation for nvqc=.true. for scatwinds, presumably because for
+  # this inflation to take place both nvqc must be .true. AND ibeta must be >0, see:
+  # https://github.com/NOAA-EMC/GSI/blob/14ae595af1b03471287d322596d35c0665336e95/src/gsi/setupw.f90#L1229
+  # GSI settings must have ibeta>0 for satwinds, but not for scatwinds.
+  #
+  # 
+  # If the ibeta settings for scatwinds were to change while nvqc remained .true., we would extend YAML to
+  # an additional filter that inflates final ob-errors across-the-board by 1/0.8 = 1.25. NOTE: the nvqc setting
+  # is defaulted to .false. in GSI code, but is overridden in global operational configuration. See:
+  # configuration, see: https://github.com/NOAA-EMC/global-workflow/blob/d5ae3328fa4041b177357b1133f6b92e81c859d7/scripts/exglobal_atmos_analysis.sh#L750
+  # This setting activates Line 1229 of setupw.f90 to scale ratio_errors by 0.8, which is applied in
+  # the denominator of the final ob-error, so 1/0.8 = 1.25 factor of ob-error inflation.
+  #
+  # If this functionality were to be activated for scatwinds, you would want to include this last inflation filter.
+#  - filter: Perform Action
+#    filter variables:
+#    - name: windEastward
+#    where:
+#    - variable: ObsType/windEastward
+#      is_in: 290-291
+#    action:
+#      name: inflate error
+#      inflation factor: 1.25
+#  - filter: Perform Action
+#    filter variables:
+#    - name: windNorthward
+#    where:
+#    - variable: ObsType/windNorthward
+#      is_in: 290-291
+#    action:
+#      name: inflate error
+#      inflation factor: 1.25
+linear obs operator:
+  name: Identity
+passedBenchmark: 52097 # 2 variables (u,v), u=26087 passing, v=26010 passing
+                       # GSI rejects both u- and v-component in first-guess check, UFO does not, but when UFO rej is reconciled btwn u and v these match GSI rej
+                       #   u: 207 obs pass with corresponding v being rejected, 25880 obs in UFO/GSI agreement
+                       #   v: 130 obs pass with corresponding u being rejected, 25880 obs in UFO/GSI agreement
+                       # 2 u- and 2 v-component obs pass in UFO that fail in GSI, only due to differences in assumed land-surface type (GSI=0, UFO=3)
+                       #
+                       # NOTE: These benchmark numbersare for a 6-hour time-window using the JEDI time-window convention only. The JEDI time-window convention
+                       #       differs from GSI and is less inclusive for observations at the beginning of the window. This can affect how the two systems
+                       #       employ ob-error inflation from duplicate observations, as the GSI has more observations at the beginning of the time-window to
+                       #       find duplicates. This can result in UFO ob-errors being smaller for some obs at the beginning of the UFO's JEDI-convention
+                       #       time-window.


### PR DESCRIPTION
These files:

- `parm/atm/obs/testing/satwind.yaml`
- `parm/atm/obs/testing/scatwind.yaml`

have been modified to include all necessary filters for UFO acceptance and ob-error assignment matching GSI, and have been given appropriate benchmarks to pass in testing. Any exceptions to UFO's acceptance or ob-error assignment are detailed in https://github.com/NOAA-EMC/JEDI-T2O/issues/47