### PR TITLE
update atm var and ens ctests to new GFS COM directory structure (#455)

### DIFF
--- a/test/atm/global-workflow/config.atmanl
+++ b/test/atm/global-workflow/config.atmanl
@@ -1,7 +1,7 @@
-#!/bin/bash -x
+#! /usr/bin/env bash
 
 ########## config.atmanl ##########
-# configuration common to all atm analysis tasks
+# configuration common to all atm var analysis tasks
 
 echo "BEGIN: config.atmanl"
 
@@ -10,13 +10,6 @@ export OBS_LIST=@OBS_LIST@
 export ATMVARYAML=${HOMEgfs}/sorc/gdas.cd/parm/atm/variational/3dvar_dripcg.yaml
 export STATICB_TYPE="identity"
 export BERROR_YAML=${HOMEgfs}/sorc/gdas.cd/parm/atm/berror/staticb_${STATICB_TYPE}.yaml
-export FV3JEDI_FIX=${HOMEgfs}/fix/gdas
-export R2D2_OBS_DB='ufsda_test'
-export R2D2_OBS_DUMP='oper_gdas'
-export R2D2_OBS_SRC='ncdiag'
-export R2D2_BC_SRC='gsi'
-export R2D2_BC_DUMP='oper_gdas'
-export R2D2_ARCH_DB='local'
 export INTERP_METHOD='barycentric'
 
 export layout_x=1

--- a/test/atm/global-workflow/config.base.emc.dyn
+++ b/test/atm/global-workflow/config.base.emc.dyn
@@ -23,16 +23,16 @@ HPSS_PROJECT=emc-global
 
 # Directories relative to installation areas:
 export HOMEgfs=@HOMEgfs@
-export PARMgfs=$HOMEgfs/parm
-export FIXgfs=$HOMEgfs/fix
-export USHgfs=$HOMEgfs/ush
-export UTILgfs=$HOMEgfs/util
-export EXECgfs=$HOMEgfs/exec
-export SCRgfs=$HOMEgfs/scripts
+export PARMgfs=${HOMEgfs}/parm
+export FIXgfs=${HOMEgfs}/fix
+export USHgfs=${HOMEgfs}/ush
+export UTILgfs=${HOMEgfs}/util
+export EXECgfs=${HOMEgfs}/exec
+export SCRgfs=${HOMEgfs}/scripts
 
-export FIXcice=$HOMEgfs/fix/cice
-export FIXmom=$HOMEgfs/fix/mom6
-export FIXreg2grb2=$HOMEgfs/fix/reg2grb2
+export FIXcice=${HOMEgfs}/fix/cice
+export FIXmom=${HOMEgfs}/fix/mom6
+export FIXreg2grb2=${HOMEgfs}/fix/reg2grb2
 
 ########################################################################
 
@@ -40,7 +40,7 @@ export FIXreg2grb2=$HOMEgfs/fix/reg2grb2
 export PACKAGEROOT="@PACKAGEROOT@"    # TODO: set via prod_envir in Ops
 export COMROOT="@COMROOT@"    # TODO: set via prod_envir in Ops
 export COMINsyn="@COMINsyn@"
-export DMPDIR=@DUMPDIR@
+export DMPDIR="@DMPDIR@"
 
 # USER specific paths
 export HOMEDIR="@HOMEDIR@"
@@ -74,10 +74,10 @@ export MODE="@MODE@" # cycled/forecast-only
 # CLEAR
 ####################################################
 # Build paths relative to $HOMEgfs
-export FIXgsi="$HOMEgfs/fix/gsi"
-export HOMEfv3gfs="$HOMEgfs/sorc/fv3gfs.fd"
-export HOMEpost="$HOMEgfs"
-export HOMEobsproc="$BASE_GIT/obsproc/v1.0.2"
+export FIXgsi="${HOMEgfs}/fix/gsi"
+export HOMEfv3gfs="${HOMEgfs}/sorc/fv3gfs.fd"
+export HOMEpost="${HOMEgfs}"
+export HOMEobsproc="${BASE_GIT}/obsproc/v1.1.2"
 
 # CONVENIENT utility scripts and other environment parameters
 export NCP="/bin/cp -p"
@@ -87,54 +87,41 @@ export VERBOSE="YES"
 export KEEPDATA="NO"
 export CHGRP_RSTPROD="@CHGRP_RSTPROD@"
 export CHGRP_CMD="@CHGRP_CMD@"
-export NEMSIOGET="$HOMEgfs/exec/nemsio_get"
 export NCDUMP="@NCDUMP@"
 export NCLEN="$HOMEgfs/ush/getncdimlen"
 
 # Machine environment, jobs, and other utility scripts
-export BASE_ENV="$HOMEgfs/env"
-export BASE_JOB="$HOMEgfs/jobs/rocoto"
+export BASE_ENV="${HOMEgfs}/env"
+export BASE_JOB="${HOMEgfs}/jobs/rocoto"
 
 # EXPERIMENT specific environment parameters
 export SDATE=@SDATE@
-export FDATE=@FDATE@
 export EDATE=@EDATE@
 export EXP_WARM_START="@EXP_WARM_START@"
 export assim_freq=6
 export PSLOT="@PSLOT@"
-export EXPDIR="@EXPDIR@/$PSLOT"
-export ROTDIR="@ROTDIR@/$PSLOT"
+export EXPDIR="@EXPDIR@/${PSLOT}"
+export ROTDIR="@ROTDIR@/${PSLOT}"
 export ROTDIR_DUMP="YES"                #Note: A value of "NO" does not currently work
 export DUMP_SUFFIX=""
-if [[ "$CDATE" -ge "2019092100" && "$CDATE" -le "2019110700" ]]; then
+if [[ "${CDATE}" -ge "2019092100" && "${CDATE}" -le "2019110700" ]]; then
     export DUMP_SUFFIX="p"              # Use dumps from NCO GFS v15.3 parallel
 fi
 export DATAROOT="@DATAPATH@/RUNDIR"  # TODO: set via prod_envir in Ops
 export RUNDIR="${DATAROOT}"  # TODO: Should be removed; use DATAROOT instead
-export ARCDIR="$NOSCRUB/archive/$PSLOT"
-export ICSDIR="@ICSDIR@"
+export ARCDIR="${NOSCRUB}/archive/${PSLOT}"
 export ATARDIR="@ATARDIR@"
 
 # Commonly defined parameters in JJOBS
 export envir=${envir:-"prod"}
-export NET="gfs"
-export RUN=${RUN:-${CDUMP:-"gfs"}}
-CDUMP_OBS="${CDUMP}"
-if [ "${CDUMP_OBS}" = "enkfgdas" ]; then
-    CDUMP_OBS="gdas"
-fi
-export COMIN_OBS=${DMPDIR}/${CDUMP_OBS}.${PDY}/$cyc/atmos
-export COMIN_GES_OBS=${DMPDIR}/${CDUMP_OBS}.${PDY}/$cyc/atmos
-export COMINatmos=${ROTDIR}/${CDUMP}.${PDY}/${cyc}/atmos
-export COMOUTatmos=${ROTDIR}/${CDUMP}.${PDY}/${cyc}/atmos
-export COMINwave=${ROTDIR}/${CDUMP}.${PDY}/${cyc}/wave
-export COMOUTwave=${ROTDIR}/${CDUMP}.${PDY}/${cyc}/wave
-export COMINocean=${ROTDIR}/${CDUMP}.${PDY}/${cyc}/ocean
-export COMOUTocean=${ROTDIR}/${CDUMP}.${PDY}/${cyc}/ocean
-export COMINice=${ROTDIR}/${CDUMP}.${PDY}/${cyc}/ice
-export COMOUTice=${ROTDIR}/${CDUMP}.${PDY}/${cyc}/ice
-export COMINaero=${ROTDIR}/${CDUMP}.${PDY}/${cyc}/chem
-export COMOUTaero=${ROTDIR}/${CDUMP}.${PDY}/${cyc}/chem
+export NET="gfs"  # NET is defined in the job-card (ecf)
+export RUN=${RUN:-${CDUMP:-"gfs"}}  # RUN is defined in the job-card (ecf); CDUMP is used at EMC as a RUN proxy
+# TODO: determine where is RUN actually used in the workflow other than here
+# TODO: is it possible to replace all instances of ${CDUMP} to ${RUN} to be
+#       consistent w/ EE2?
+
+# Get all the COM path templates
+source "${EXPDIR}/config.com"
 
 export ERRSCRIPT=${ERRSCRIPT:-'eval [[ $err = 0 ]]'}
 export LOGSCRIPT=${LOGSCRIPT:-""}
@@ -144,12 +131,13 @@ export REDOUT="1>"
 export REDERR="2>"
 
 export SENDECF=${SENDECF:-"NO"}
-export SENDCOM=${SENDCOM:-"NO"}
+export SENDCOM=${SENDCOM:-"YES"}
 export SENDSDM=${SENDSDM:-"NO"}
 export SENDDBN_NTC=${SENDDBN_NTC:-"NO"}
 export SENDDBN=${SENDDBN:-"NO"}
-export UTILROOT=@UTILROOT@
+export UTILROOT="@UTILROOT@"
 export DBNROOT=${DBNROOT:-${UTILROOT}/fakedbn}
+
 
 # APP settings
 export APP=@APP@
@@ -166,6 +154,28 @@ export WAVE_CDUMP="" # When to include wave suite: gdas, gfs, or both
 export DOBNDPNT_WAVE="NO"
 export cplwav2atm=".false."
 export FRAC_GRID=".true."
+
+# Set operational resolution
+export OPS_RES="C768" # Do not change
+
+# Resolution specific parameters
+export LEVS=128
+export CASE="@CASECTL@"
+export CASE_ANL="$CASE"
+export CASE_ENKF="@CASEENS@"
+
+# TODO: This should not depend on $CASE or $CASE_ENKF
+# These are the currently available grid-combinations
+case "${CASE}" in
+    "C48") export OCNRES=500;;
+    "C96") export OCNRES=100;;
+    "C192") export OCNRES=050;;
+    "C384") export OCNRES=025;;
+    "C768") export OCNRES=025;;
+    *) export OCNRES=025;;
+esac
+export ICERES=${OCNRES}
+export waveGRD='gnh_10m aoc_9km gsh_15m'
 
 case "${APP}" in
   ATM)
@@ -193,19 +203,19 @@ case "${APP}" in
     export CCPP_SUITE="FV3_GFS_v17_coupled_p8"
     export confignamevarfornems="cpld"
 
-    if [[ "$APP" =~ A$ ]]; then
+    if [[ "${APP}" =~ A$ ]]; then
         export DO_AERO="YES"
         export confignamevarfornems="${confignamevarfornems}_aero"
     fi
 
-    if [[ "$APP" =~ ^S2SW ]]; then
+    if [[ "${APP}" =~ ^S2SW ]]; then
         export DO_WAVE="YES"
         export WAVE_CDUMP="both"
         export cplwav2atm=".true."
-        export confignamevarfornems="${confignamevarfornems}_wave"
+        export confignamevarfornems="${confignamevarfornems}_outerwave"
     fi
 
-    source $EXPDIR/config.defaults.s2sw
+    source ${EXPDIR}/config.defaults.s2sw
 
     ;;
   *)
@@ -214,29 +224,11 @@ case "${APP}" in
     ;;
 esac
 
-# Set operational resolution
-export OPS_RES="C768" # Do not change
-
-# Resolution specific parameters
-export LEVS=128
-export CASE="@CASECTL@"
-export CASE_ANL="$CASE"
-export CASE_ENKF="@CASEENS@"
-case "$CASE" in
-    "C48") export OCNRES=500;;
-    "C96") export OCNRES=100;;
-    "C192") export OCNRES=050;;
-    "C384") export OCNRES=025;;
-    "C768") export OCNRES=025;;
-    *) export OCNRES=025;;
-esac
-export ICERES=$OCNRES
-
 # Surface cycle update frequency
-if [[ "$CDUMP" == "gdas" ]] ; then
+if [[ "${CDUMP}" =~ "gdas" ]] ; then
    export FHCYC=1
    export FTSFS=10
-elif [[ "$CDUMP" == "gfs" ]] ; then
+elif [[ "${CDUMP}" =~ "gfs" ]] ; then
    export FHCYC=24
 fi
 
@@ -254,11 +246,11 @@ export gfs_cyc=@gfs_cyc@ # 0: no GFS cycle, 1: 00Z only, 2: 00Z and 12Z only, 4:
 # GFS output and frequency
 export FHMIN_GFS=0
 
-export FHMAX_GFS_00=${FHMAX_GFS_00:-384}
-export FHMAX_GFS_06=${FHMAX_GFS_06:-384}
-export FHMAX_GFS_12=${FHMAX_GFS_12:-384}
-export FHMAX_GFS_18=${FHMAX_GFS_18:-384}
-export FHMAX_GFS=$(eval echo \${FHMAX_GFS_$cyc})
+export FHMAX_GFS_00=${FHMAX_GFS_00:-120}
+export FHMAX_GFS_06=${FHMAX_GFS_06:-120}
+export FHMAX_GFS_12=${FHMAX_GFS_12:-120}
+export FHMAX_GFS_18=${FHMAX_GFS_18:-120}
+export FHMAX_GFS=$(eval echo \${FHMAX_GFS_${cyc}})
 
 export FHOUT_GFS=${FHOUT_GFS:-3}
 export FHMAX_HF_GFS=${FHMAX_HF_GFS:-0}
@@ -273,51 +265,30 @@ export ILPOST=1           # gempak output frequency up to F120
 # GFS restart interval in hours
 export restart_interval_gfs=0
 
-# I/O QUILTING, true--use Write Component; false--use GFDL FMS
-# if quilting=true, choose OUTPUT_GRID as cubed_sphere_grid in netcdf or gaussian_grid
-# if gaussian_grid, set OUTPUT_FILE for nemsio or netcdf
-# WRITE_DOPOST=true, use inline POST
 export QUILTING=".true."
 export OUTPUT_GRID="gaussian_grid"
-export OUTPUT_FILE="netcdf"
-export WRITE_DOPOST=".true."
+export WRITE_DOPOST=".true." # WRITE_DOPOST=true, use inline POST
 export WRITE_NSFLIP=".true."
-
-# suffix options depending on file format
-if [ $OUTPUT_FILE = "netcdf" ]; then
-    export SUFFIX=".nc"
-    export NEMSIO_IN=".false."
-    export NETCDF_IN=".true."
-else
-    export SUFFIX=".nemsio"
-    export NEMSIO_IN=".true."
-    export NETCDF_IN=".false."
-fi
 
 # IAU related parameters
 export DOIAU="YES"        # Enable 4DIAU for control with 3 increments
 export IAUFHRS="3,6,9"
-export IAU_FHROT=$(echo $IAUFHRS | cut -c1)
+export IAU_FHROT=$(echo ${IAUFHRS} | cut -c1)
 export IAU_DELTHRS=6
 export IAU_OFFSET=6
 export DOIAU_ENKF=${DOIAU:-"YES"}   # Enable 4DIAU for EnKF ensemble
 export IAUFHRS_ENKF="3,6,9"
 export IAU_DELTHRS_ENKF=6
-# Check if cycle is cold starting, DOIAU off, or free-forecast mode
-if [[ "$MODE" = "cycled" && "$SDATE" = "$CDATE" && $EXP_WARM_START = ".false." ]] || [[ "$DOIAU" = "NO" ]] || [[ "$MODE" = "forecast-only" && $EXP_WARM_START = ".false." ]] ; then
-  export IAU_OFFSET=0
-  export IAU_FHROT=0
-fi
 
 # Use Jacobians in eupd and thereby remove need to run eomg
 export lobsdiag_forenkf=".true."
 
 # run GLDAS to spin up land ICs
-export DO_GLDAS="YES"
+export DO_GLDAS="NO"
 export gldas_cyc=00
 
 # Exception handling that when DO_GLDAS is set, the FHOUT must be 1
-if [ $DO_GLDAS = "YES" ]; then
+if [[ ${DO_GLDAS} = "YES" ]]; then
   export FHOUT=1
 fi
 
@@ -331,12 +302,14 @@ export imp_physics=@IMP_PHYSICS@
 
 # Shared parameters
 # DA engine
-export DO_JEDIVAR=@DO_JEDIVAR@
-export DO_JEDIENS=@DO_JEDIENS@
+export DO_JEDIVAR="@DO_JEDIVAR@"
+export DO_JEDIENS="@DO_JEDIENS@"
 export DO_JEDIOCNVAR="NO"
+export DO_JEDILANDDA="NO"
+export DO_MERGENSST="NO"
 
 # Hybrid related
-export DOHYBVAR="YES"
+export DOHYBVAR="@DOHYBVAR@"
 export NMEM_ENKF=@NMEM_ENKF@
 export NMEM_EFCS=30
 export SMOOTH_ENKF="NO"
@@ -344,10 +317,11 @@ export l4densvar=".true."
 export lwrite4danl=".true."
 
 # EnKF output frequency
-if [ $DOHYBVAR = "YES" ]; then
+if [[ ${DOHYBVAR} = "YES" ]]; then
     export FHMIN_ENKF=3
     export FHMAX_ENKF=9
     export FHMAX_ENKF_GFS=120
+    export FHOUT_ENKF_GFS=3
     if [ $l4densvar = ".true." ]; then
         export FHOUT=1
         export FHOUT_ENKF=1
@@ -356,9 +330,23 @@ if [ $DOHYBVAR = "YES" ]; then
     fi
 fi
 
+# if 3DVAR and IAU
+if [[ ${DOHYBVAR} == "NO" && ${DOIAU} == "YES"  ]]; then
+    export IAUFHRS="6"
+    export IAU_FHROT="3"
+    export IAU_FILTER_INCREMENTS=".true."
+    export IAUFHRS_ENKF="6"
+fi
+
+# Check if cycle is cold starting, DOIAU off, or free-forecast mode
+if [[ "${MODE}" = "cycled" && "${SDATE}" = "${CDATE}" && ${EXP_WARM_START} = ".false." ]] || [[ "${DOIAU}" = "NO" ]] || [[ "${MODE}" = "forecast-only" && ${EXP_WARM_START} = ".false." ]] ; then
+  export IAU_OFFSET=0
+  export IAU_FHROT=0
+fi
+
 # turned on nsst in anal and/or fcst steps, and turn off rtgsst
 export DONST="YES"
-if [ $DONST = "YES" ]; then export FNTSFA="        "; fi
+if [[ ${DONST} = "YES" ]]; then export FNTSFA="        "; fi
 
 # The switch to apply SST elevation correction or not
 export nst_anl=.true.
@@ -372,10 +360,8 @@ export MAKE_ACFTBUFR="@MAKE_ACFTBUFR@"
 # Analysis increments to zero in CALCINCEXEC
 export INCREMENTS_TO_ZERO="'liq_wat_inc','icmr_inc'"
 
-if [ $OUTPUT_FILE = "nemsio" ]; then
-    export DO_CALC_INCREMENT="YES"
-    export DO_CALC_ANALYSIS="NO"
-fi
+# Write analysis files for early cycle EnKF
+export DO_CALC_INCREMENT_ENKF_GFS="YES"
 
 # Stratospheric increments to zero
 export INCVARS_ZERO_STRAT="'sphum_inc','liq_wat_inc','icmr_inc'"
@@ -389,11 +375,12 @@ export binary_diag=".false."
 
 # Verification options
 export DO_METP="YES"         # Run METPLUS jobs - set METPLUS settings in config.metp
+export DO_FIT2OBS="NO"      # Run fit to observations package
 
 # Archiving options
 export HPSSARCH="@HPSSARCH@"        # save data to HPSS archive
 export LOCALARCH="@LOCALARCH@"        # save data to local archive
-if [[ $HPSSARCH = "YES" ]] && [[ $LOCALARCH = "YES" ]]; then
+if [[ ${HPSSARCH} = "YES" ]] && [[ ${LOCALARCH} = "YES" ]]; then
    echo "Both HPSS and local archiving selected.  Please choose one or the other."
    exit 2
 fi

--- a/test/atm/global-workflow/jjob_ens_init.sh
+++ b/test/atm/global-workflow/jjob_ens_init.sh
@@ -3,15 +3,16 @@ set -x
 bindir=$1
 srcdir=$2
 
-# run jjob
+# Set g-w HOMEgfs
 export HOMEgfs=$srcdir/../../ # TODO: HOMEgfs had to be hard-coded in config
-echo $HOMEgfs
 
-export EXPDIR=$bindir/test/atm/global-workflow/testrun/experiments/gdas_test
+# Set variables for ctest
+export PSLOT=gdas_test
+export EXPDIR=$bindir/test/atm/global-workflow/testrun/experiments/$PSLOT
 export PDY=20210323
 export cyc=18
 export CDATE=${PDY}${cyc}
-export ROTDIR=$bindir/test/atm/global-workflow/testrun/ROTDIRS
+export ROTDIR=$bindir/test/atm/global-workflow/testrun/ROTDIRS/$PSLOT
 export RUN=enkfgdas
 export CDUMP=enkfgdas
 export DATAROOT=$bindir/test/atm/global-workflow/testrun/RUNDIR
@@ -21,40 +22,76 @@ export jobid=$pid
 export COMROOT=$DATAROOT
 export NMEM_ENKF=3
 export ACCOUNT=da-cpu
+export COM_TOP=$ROTDIR
 
-# setup python path for workflow utilities and tasks
+# Set GFS COM paths
+source "${HOMEgfs}/ush/preamble.sh"
+source "${HOMEgfs}/parm/config/config.com"
+
+# Set python path for workflow utilities and tasks
 pygwPATH="${HOMEgfs}/ush/python:${HOMEgfs}/ush/python/pygw/src"
 PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${pygwPATH}"
 export PYTHONPATH
 
-# detemine machine from config.base
+# Detemine machine from config.base
 machine=$(echo `grep 'machine=' $EXPDIR/config.base | cut -d"=" -f2` | tr -d '"')
 
-# prepare background from previous cycle
+# Set date variables for previous cycle
 GDATE=`date +%Y%m%d%H -d "${CDATE:0:8} ${CDATE:8:2} - 6 hours"`
 gPDY=$(echo $GDATE | cut -c1-8)
 gcyc=$(echo $GDATE | cut -c9-10)
+GDUMP="gdas"
 
-mkdir -p $ROTDIR/gdas_test/gdas.$gPDY/$gcyc/atmos/
-flist="satbias tlapse"
+# Set file prefixes
+gprefix=$GDUMP.t${gcyc}z
+oprefix=$GDUMP.t${cyc}z
+
+# Generate gdas COM variables from templates
+RUN=${GDUMP} YMD=${PDY} HH=${cyc} generate_com -rx COM_OBS
+RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} generate_com -rx \
+    COM_ATMOS_ANALYSIS_PREV:COM_ATMOS_ANALYSIS_TMPL \
+
+# Link gdas radiance bias correction files
+dpath=gdas.$gPDY/$gcyc/analysis/atmos
+mkdir -p $COM_ATMOS_ANALYSIS_PREV
+flist="amsua_n19.satbias.nc4 amsua_n19.satbias_cov.nc4 amsua_n19.tlapse.txt"
 for file in $flist; do
-   cp -r $GDASAPP_TESTDATA/lowres/gdas.$gPDY/$gcyc/atmos/*${file}* $ROTDIR/gdas_test/gdas.$gPDY/$gcyc/atmos/
+   ln -fs $GDASAPP_TESTDATA/lowres/$dpath/$gprefix.$file $COM_ATMOS_ANALYSIS_PREV/
 done
 
-# Copy tiled ges and atmf006 files to ROTDIR
-mkdir -p $ROTDIR/gdas_test/enkfgdas.$gPDY/$gcyc/atmos/
+# Link gdas observations
+dpath=gdas.$PDY/$cyc/obs
+mkdir -p $COM_OBS
+flist="amsua_n19.$CDATE.nc4 sondes.$CDATE.nc4"
+for file in $flist; do
+   ln -fs $GDASAPP_TESTDATA/lowres/$dpath/${oprefix}.$file $COM_OBS/
+done
+
+
+# Link tiled ges and atmf006 files to ROTDIR
+dpath=enkfgdas.$gPDY/$gcyc
 for imem in $(seq 1 $NMEM_ENKF); do
     memchar="mem"$(printf %03i $imem)
-    source=$GDASAPP_TESTDATA/lowres/enkfgdas.$gPDY/$gcyc/$memchar/atmos
-    target=$ROTDIR/gdas_test/enkfgdas.$gPDY/$gcyc/$memchar/atmos
+
+    MEMDIR=${memchar} RUN=${RUN} YMD=${gPDY} HH=${gcyc} generate_com -x \
+	COM_ATMOS_HISTORY_PREV_ENS:COM_ATMOS_HISTORY_TMPL \
+	COM_ATMOS_RESTART_PREV_ENS:COM_ATMOS_RESTART_TMPL
+    COM_ATMOS_RESTART_PREV_DIRNAME_ENS=$(dirname $COM_ATMOS_RESTART_PREV_ENS)
+
+    source=$GDASAPP_TESTDATA/lowres/$dpath/$memchar/model_data/atmos
+    target=$COM_ATMOS_RESTART_PREV_DIRNAME_ENS
     mkdir -p $target
-    rm -rf $target/RESTART
-    ln -fs $source/RESTART $target/
+    rm -rf $target/restart
+    ln -fs $source/restart $target/
 
+    source=$GDASAPP_TESTDATA/lowres/$dpath/$memchar/model_data/atmos/history
+    target=$COM_ATMOS_HISTORY_PREV_ENS
+    mkdir -p $target
+    rm -rf $target/enkfgdas.t${gcyc}z.atmf006.nc
     ln -fs $source/enkfgdas.t${gcyc}z.atmf006.nc $target/
-
 done
 
+# Execute j-job
 if [ $machine != 'HERA' ]; then
     ${HOMEgfs}/jobs/JGLOBAL_ATMENS_ANALYSIS_INITIALIZE
 else

--- a/test/atm/global-workflow/jjob_var_init.sh
+++ b/test/atm/global-workflow/jjob_var_init.sh
@@ -1,17 +1,19 @@
-#!/bin/bash
+#! /usr/bin/env bash
+
 set -x
 bindir=$1
 srcdir=$2
 
-# run jjob
+# Set g-w HOMEgfs
 export HOMEgfs=$srcdir/../../ # TODO: HOMEgfs had to be hard-coded in config
-echo $HOMEgfs
 
-export EXPDIR=$bindir/test/atm/global-workflow/testrun/experiments/gdas_test
+# Set variables for ctest
+export PSLOT=gdas_test
+export EXPDIR=$bindir/test/atm/global-workflow/testrun/experiments/$PSLOT
 export PDY=20210323
 export cyc=18
 export CDATE=${PDY}${cyc}
-export ROTDIR=$bindir/test/atm/global-workflow/testrun/ROTDIRS
+export ROTDIR=$bindir/test/atm/global-workflow/testrun/ROTDIRS/$PSLOT
 export RUN=gdas
 export CDUMP=gdas
 export DATAROOT=$bindir/test/atm/global-workflow/testrun/RUNDIR
@@ -20,26 +22,72 @@ export pid=${pid:-$$}
 export jobid=$pid
 export COMROOT=$DATAROOT
 export ACCOUNT=da-cpu
+export COM_TOP=$ROTDIR
 
-# setup python path for workflow utilities and tasks
+# Set GFS COM paths
+source "${HOMEgfs}/ush/preamble.sh"
+source "${HOMEgfs}/parm/config/config.com"
+
+# Set python path for workflow utilities and tasks
 pygwPATH="${HOMEgfs}/ush/python:${HOMEgfs}/ush/python/pygw/src"
 PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${pygwPATH}"
 export PYTHONPATH
 
-# detemine machine from config.base
+# Detemine machine from config.base
 machine=$(echo `grep 'machine=' $EXPDIR/config.base | cut -d"=" -f2` | tr -d '"')
 
-# prepare background from previous cycle
+# Set date variables for previous cycle
 GDATE=`date +%Y%m%d%H -d "${CDATE:0:8} ${CDATE:8:2} - 6 hours"`
 gPDY=$(echo $GDATE | cut -c1-8)
 gcyc=$(echo $GDATE | cut -c9-10)
-mkdir -p $ROTDIR/gdas_test/gdas.$gPDY/$gcyc/atmos/
+GDUMP="gdas"
 
-flist="abias atmf006 satbias tlapse RESTART"
+# Set file prefixes
+gprefix=$GDUMP.t${gcyc}z
+oprefix=$CDUMP.t${cyc}z
+
+# Generate COM variables from templates
+YMD=${PDY} HH=${cyc} generate_com -rx COM_OBS
+
+RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} generate_com -rx \
+    COM_ATMOS_ANALYSIS_PREV:COM_ATMOS_ANALYSIS_TMPL \
+    COM_ATMOS_HISTORY_PREV:COM_ATMOS_HISTORY_TMPL \
+    COM_ATMOS_RESTART_PREV:COM_ATMOS_RESTART_TMPL
+
+# Link radiance bias correction files
+dpath=gdas.$gPDY/$gcyc/analysis/atmos
+mkdir -p $COM_ATMOS_ANALYSIS_PREV
+flist="amsua_n19.satbias.nc4 amsua_n19.satbias_cov.nc4 amsua_n19.tlapse.txt"
 for file in $flist; do
-   cp -r $GDASAPP_TESTDATA/lowres/gdas.$gPDY/$gcyc/atmos/*${file}* $ROTDIR/gdas_test/gdas.$gPDY/$gcyc/atmos/
+   ln -fs $GDASAPP_TESTDATA/lowres/$dpath/$gprefix.$file $COM_ATMOS_ANALYSIS_PREV/
 done
 
+# Link atmospheric background on gaussian grid
+dpath=gdas.$gPDY/$gcyc/model_data/atmos/history
+mkdir -p $COM_ATMOS_HISTORY_PREV
+flist="atmf006.nc"
+for file in $flist; do
+   ln -fs $GDASAPP_TESTDATA/lowres/$dpath/${gprefix}.${file} $COM_ATMOS_HISTORY_PREV/
+done
+
+# Link atmospheric bacgkround on tiles
+dpath=gdas.$gPDY/$gcyc/model_data/atmos
+COM_ATMOS_RESTART_PREV_DIRNAME=$(dirname $COM_ATMOS_RESTART_PREV)
+mkdir -p $COM_ATMOS_RESTART_PREV_DIRNAME
+flist="restart"
+for file in $flist; do
+   ln -fs $GDASAPP_TESTDATA/lowres/$dpath/$file $COM_ATMOS_RESTART_PREV_DIRNAME/
+done
+
+# Link observations
+dpath=gdas.$PDY/$cyc/obs
+mkdir -p $COM_OBS
+flist="amsua_n19.$CDATE.nc4 sondes.$CDATE.nc4"
+for file in $flist; do
+   ln -fs $GDASAPP_TESTDATA/lowres/$dpath/${oprefix}.$file $COM_OBS/
+done
+
+# Execute j-job
 if [ $machine != 'HERA' ]; then
     ${HOMEgfs}/jobs/JGLOBAL_ATM_ANALYSIS_INITIALIZE
 else


### PR DESCRIPTION
The change in the GFS COM directory structure (g-w PR [#1421](https://github.com/NOAA-EMC/global-workflow/pull/1421)) requires updates to the ATM variational and local ensemble DA ctests.   This PR updates the j-job drivers for the var and ens initialize jobs.   Two config files are also updated to be more consistent with g-w. 

The data directories in `GDASAPP_TESTDATA` also need to be remapped to the new GFS COM directory structure.   `GDASAPP_TESTDATA=/scratch1/NCEPDEV/stmp2/Russ.Treadon/CI/GDASApp/data/lowres/` contains the remapped directories used by the ATM var and ens ctests.   The updated directories need to be copied to the official locations on Hera and Orion as part of this PR.

Fixes #455