### PR TITLE
Remove the WORKDIR prior to populating the directory

### DIFF
--- a/test/land/test_imsproc.sh
+++ b/test/land/test_imsproc.sh
@@ -22,6 +22,9 @@ RSTDIR=$GDASAPP_TESTDATA/lowres/gdas.$GYMD/$GHR/model_data/atmos/restart
 export OBSDIR=$GDASAPP_TESTDATA/land/snow_ice_cover
 export TSTUB="oro_C${RES}.mx100"
 
+if [[ -e $WORKDIR ]]; then
+  rm -rf $WORKDIR
+fi
 mkdir -p $WORKDIR
 cd $WORKDIR
 


### PR DESCRIPTION
The `test_imsproc.sh` does not remove or empty the `WORKDIR` prior to populating the directory. This PR removed the `WORKDIR` so that the `test_gdasapp_land_imsproc` created a clean `WORKDIR` each time when the script runs. (https://github.com/NOAA-EMC/GDASApp/pull/461#issuecomment-1538348274)