### PR TITLE
Change EVA YAML templates to work with newest version of EVA

### DIFF
--- a/ush/eva/jedi_gsi_compare_conv.yaml
+++ b/ush/eva/jedi_gsi_compare_conv.yaml
@@ -2,9 +2,9 @@
 # based on obs spaces listed in JEDI YAML files
 diagnostics:
 - data:
-    type: IodaObsSpace
     datasets:
       - name: experiment
+        type: IodaObsSpace
         filenames:
           - @FILENAME@
         @CHANNELSKEY@

--- a/ush/eva/jedi_gsi_compare_rad.yaml
+++ b/ush/eva/jedi_gsi_compare_rad.yaml
@@ -2,9 +2,9 @@
 # based on obs spaces listed in JEDI YAML files
 diagnostics:
 - data:
-    type: IodaObsSpace
     datasets:
       - name: experiment
+        type: IodaObsSpace
         filenames:
           - @FILENAME@
         @CHANNELSKEY@

--- a/ush/eva/jedi_gsi_compare_rad_summary.yaml
+++ b/ush/eva/jedi_gsi_compare_rad_summary.yaml
@@ -2,9 +2,9 @@
 # based on obs spaces listed in JEDI YAML files
 diagnostics:
 - data:
-    type: IodaObsSpace
     datasets:
       - name: experiment
+        type: IodaObsSpace
         filenames:
           - @FILENAME@
         @CHANNELSKEY@

--- a/ush/eva/marine_gdas_plots.yaml
+++ b/ush/eva/marine_gdas_plots.yaml
@@ -2,9 +2,9 @@
 # based on obs spaces listed in JEDI YAML files
 diagnostics:
 - data:
-    type: IodaObsSpace
     datasets:
       - name: experiment
+        type: IodaObsSpace
         filenames:
           - @FILENAME@
         @CHANNELSKEY@


### PR DESCRIPTION
As the title says.
Closes #481 

A recent PR into EVA allows for multiple types of datasets per diagnostic, this changes the YAML structure, which now means these EVA templated YAMLs need modified.