### PR TITLE
use jinja2 filter for boolean conversions

### DIFF
--- a/parm/land/letkfoi/apply_incr_nml.j2
+++ b/parm/land/letkfoi/apply_incr_nml.j2
@@ -2,7 +2,7 @@
   date_str = "{{ current_cycle | to_YMD }}",
   hour_str = "{{ current_cycle | strftime('%H') }}",
   res = {{ CASE[1:] }},
-  frac_grid = {{ FRAC_GRID }},
+  frac_grid = {{ FRAC_GRID | to_f90bool }},
   rst_path = "{{ DATA }}/anl",
   inc_path = "{{ DATA }}/anl",
   orog_path = "{{ HOMEgfs }}/fix/orog/{{ CASE }}",


### PR DESCRIPTION
Use a jinja filter to translate python bool to Fortran bool in the land analysis increment executable.
The global-workflow land DA PR https://github.com/NOAA-EMC/global-workflow/pull/1635 has been updated to use this