### PR TITLE
Changing handling of var.yaml to correct vrfy bug

### DIFF
--- a/scripts/exgdas_global_marine_analysis_run.sh
+++ b/scripts/exgdas_global_marine_analysis_run.sh
@@ -39,8 +39,9 @@ function clean_yaml()
 
 ################################################################################
 # run 3DVAR FGAT
-clean_yaml var.yaml
-$APRUN_OCNANAL $JEDI_BIN/soca_var.x var.yaml
+cp var.yaml cleaned_var.yaml
+clean_yaml cleaned_var.yaml
+$APRUN_OCNANAL $JEDI_BIN/soca_var.x cleaned_var.yaml
 export err=$?; err_chk
 
 ################################################################################

--- a/scripts/exgdas_global_marine_analysis_run.sh
+++ b/scripts/exgdas_global_marine_analysis_run.sh
@@ -39,9 +39,9 @@ function clean_yaml()
 
 ################################################################################
 # run 3DVAR FGAT
-cp var.yaml cleaned_var.yaml
-clean_yaml cleaned_var.yaml
-$APRUN_OCNANAL $JEDI_BIN/soca_var.x cleaned_var.yaml
+cp var.yaml var_original.yaml
+clean_yaml var.yaml
+$APRUN_OCNANAL $JEDI_BIN/soca_var.x var.yaml
 export err=$?; err_chk
 
 ################################################################################

--- a/scripts/exgdas_global_marine_analysis_vrfy.py
+++ b/scripts/exgdas_global_marine_analysis_vrfy.py
@@ -303,7 +303,7 @@ plot_horizontal_slice(config)
 
 evadir = os.path.join(HOMEgfs, 'sorc', f'{RUN}.cd', 'ush', 'eva')
 marinetemplate = os.path.join(evadir, 'marine_gdas_plots.yaml')
-varyaml = os.path.join(comout, 'yaml', 'var.yaml')
+varyaml = os.path.join(comout, 'yaml', 'var_original.yaml')
 
 # it would be better to refrence the dirs explicitly with the comout path
 # but eva doesn't allow for specifying output directories


### PR DESCRIPTION
Currently the vrfy task fails when `ush/eva/gen_eva_obs_yaml.py` tries to ingest `var.yaml` when in encounters the line 304  `pattern: %mem%` because it doesn't like the unquoted % sign. `var.yaml` starts out with this quoted  like so: `pattern: '%mem%'`, but `scripts/exgdas_global_marine_analysis_run.sh ` strips the single quotes out of `var.yaml` apparently to placate `soca_var.x`. This PR changes the handling of `var.yaml` in `scripts/exgdas_global_marine_analysis_run.sh` so that the original is preserved for the vrfy task and its handling of yaml for eva in that it copies the file to a new name to be fed to `soca_var.x`

Tested with the soca ctest suite. vrfy still fails, but at a later point.