### PR TITLE
Remove FRAC_GRID for consistency with G-W.

### DIFF
--- a/parm/land/letkfoi/apply_incr_nml.j2
+++ b/parm/land/letkfoi/apply_incr_nml.j2
@@ -2,7 +2,7 @@
   date_str = "{{ current_cycle | to_YMD }}",
   hour_str = "{{ current_cycle | strftime('%H') }}",
   res = {{ CASE[1:] }},
-  frac_grid = {{ FRAC_GRID | to_f90bool }},
+  frac_grid = .true.,
   rst_path = "{{ DATA }}/anl",
   inc_path = "{{ DATA }}/anl",
   orog_path = "{{ HOMEgfs }}/fix/orog/{{ CASE }}",


### PR DESCRIPTION
Replaced `FRAC_GRID `with `.true.` for consistency with the global-workflow [PR #1687](https://github.com/NOAA-EMC/global-workflow/pull/1687)