### PR TITLE
replace params with local configration in soca utility

### DIFF
--- a/utils/soca/gdas_postprocincr.h
+++ b/utils/soca/gdas_postprocincr.h
@@ -159,10 +159,9 @@ class PostProcIncr {
       return socaIncr;
     }
     oops::Log::info() << "======      applying specified change of variables" << std::endl;
-    soca::LinearVariableChangeParameters params;
-    params.deserialize(lvcConfig_);
-    oops::Log::info() <<  params << std::endl;
-    soca::LinearVariableChange lvc(this->geom_, params);
+    oops::Log::info() <<  lvcConfig_ << std::endl;
+    eckit::LocalConfiguration lvcConfig_;
+    soca::LinearVariableChange lvc(this->geom_, lvcConfig_);
     oops::Log::info() <<  "traj: " << xTraj_ << std::endl;
     lvc.changeVarTraj(xTraj_, socaIncrVar_);
     lvc.changeVarTL(socaIncr, socaIncrVar_);


### PR DESCRIPTION
The build of GDASApp `develop` at [`9fa348f`](https://github.com/NOAA-EMC/GDASApp/commit/9fa348f92a0bd5f3d073f22e73bf06dd6ad9db15) aborts when compiling `utils/soca/gdas_postprocincr.h`.   Issue #589 documents details.

This PR is opened to bring a source code change to `gdas_postprocincr.h` into `develop`.

Fixes #589