### PR TITLE
added JGLOBAL_PREP_OCEAN_OBS to ctests

### DIFF
--- a/test/soca/gw/CMakeLists.txt
+++ b/test/soca/gw/CMakeLists.txt
@@ -43,7 +43,8 @@ set(jjob_list "JGDAS_GLOBAL_OCEAN_ANALYSIS_PREP"
               "JGDAS_GLOBAL_OCEAN_ANALYSIS_RUN"
               "JGDAS_GLOBAL_OCEAN_ANALYSIS_CHKPT"
               "JGDAS_GLOBAL_OCEAN_ANALYSIS_POST"
-              "JGDAS_GLOBAL_OCEAN_ANALYSIS_VRFY")
+              "JGDAS_GLOBAL_OCEAN_ANALYSIS_VRFY"
+              "JGLOBAL_PREP_OCEAN_OBS")
 
 set(setup "")
 foreach(jjob ${jjob_list})


### PR DESCRIPTION
Just as advertised - stub JGLOBAL_PREP_OCEAN_OBS has been merged into g-w so this should work. It is at the end of the jjob ctests as running it seemed to interfere with ones that followed it, and at some point that will have to be addressed