### PR TITLE
Fixed typo in satwind_goes yaml files

### DIFF
--- a/parm/atm/obs/config/satwind_goes-16.yaml
+++ b/parm/atm/obs/config/satwind_goes-16.yaml
@@ -3,11 +3,11 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(DATA)/obs/$(OPREFIX)satwind.abi_goes-16.${{ current_cycle | to_YMDH }}.nc4
+      obsfile: $(DATA)/obs/$(OPREFIX)satwind.abi_goes-16.{{ current_cycle | to_YMDH }}.nc4
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(DATA)/diags/diag_satwind_abi_goes-16_${{ current_cycle | to_YMDH }}.nc4
+      obsfile: $(DATA)/diags/diag_satwind_abi_goes-16_{{ current_cycle | to_YMDH }}.nc4
   io pool:
     max pool size: 1
   simulated variables: [windEastward, windNorthward]

--- a/parm/atm/obs/config/satwind_goes-17.yaml
+++ b/parm/atm/obs/config/satwind_goes-17.yaml
@@ -3,11 +3,11 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(DATA)/obs/$(OPREFIX)satwind.abi_goes-17.${{ current_cycle | to_YMDH }}.nc4
+      obsfile: $(DATA)/obs/$(OPREFIX)satwind.abi_goes-17.{{ current_cycle | to_YMDH }}.nc4
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(DATA)/diags/diag_satwind_abi_goes-17_${{ current_cycle | to_YMDH }}.nc4
+      obsfile: $(DATA)/diags/diag_satwind_abi_goes-17_{{ current_cycle | to_YMDH }}.nc4
   io pool:
     max pool size: 1
   simulated variables: [windEastward, windNorthward]


### PR DESCRIPTION
Removed an extra '$' from the satwind_goes-*.yaml obs files. With the extra '$', the obs files will look something like: gdas.tHHz.satwind.abi_goes-16.$YYYYMMDDHH.nc4  rather than the correct gdas.tHHz.satwind.abi_goes-16.YYYYMMDDHH.nc4