### PR TITLE
Update test reference for both satwind and scatwind.

### DIFF
--- a/parm/atm/obs/testing/satwind.yaml
+++ b/parm/atm/obs/testing/satwind.yaml
@@ -989,7 +989,8 @@ obs post filters:
 linear obs operator:
   name: Identity
 
-passedBenchmark: 1025814 # 2 variables (u,v), both passing 512907 obs, including 512907 GSI/UFO agreements, and:
+#passedBenchmark: 1025814# 2 variables (u,v), both passing 512907 obs, including 512907 GSI/UFO agreements, and:
+passedBenchmark: 1150870 # 2 variables (u,v), both passing 575435 obs, including 512907 GSI/UFO agreements, and:
                          # 16 GOES AMVs (6 u-obs, 6 v-obs) that are rejected by the SatWindsErrnormCheck in UFO
                          # but are retained in GSI's equivalent experr_norm check. All 6 of these disagreements
                          # have error norm values at almost exactly 0.9, indicating a float precision/handling

--- a/parm/atm/obs/testing/satwind_noqc.yaml
+++ b/parm/atm/obs/testing/satwind_noqc.yaml
@@ -1,0 +1,18 @@
+obs space:
+  name: satwind
+  obsdatain:
+    engine:
+      type: H5File
+      obsfile: !ENV satwind_obs_${CDATE}.nc4
+  obsdataout:
+    engine:
+      type: H5File
+      obsfile: !ENV satwind_diag_${CDATE}.nc4
+  simulated variables: [windEastward, windNorthward]
+geovals:
+  filename: !ENV satwind_geoval_${CDATE}.nc4
+obs operator:
+  name: VertInterp
+
+vector ref: GsiHofXBc
+tolerance: 1.e-5

--- a/parm/atm/obs/testing/scatwind.yaml
+++ b/parm/atm/obs/testing/scatwind.yaml
@@ -60,8 +60,8 @@ obs post filters:
     where:
     - variable: ObsType/windEastward
       is_in: 290
-    - variable: GeoVaLs/land_type_index_NPOESS
-      minvalue: 1. 
+    - variable: GeoVaLs/water_area_fraction
+      maxvalue: 0.001 
     action:
       name: reject
   # Reject ASCAT (Type 290) when observed component deviates from background by more than 5.0 m/s
@@ -144,12 +144,12 @@ obs post filters:
           variable: windNorthward
           inflation factor: 4.0
   # All scatwinds subject to a gross error check. This is contained within
-  # the SatWindsSPDBCheck, although it is not exclusive to satwinds.
+  # the WindsSPDBCheck, although it is not exclusive to satwinds.
   - filter: Background Check
     filter variables:
     - name: windEastward
     function absolute threshold:
-    - name: ObsFunction/SatWindsSPDBCheck
+    - name: ObsFunction/WindsSPDBCheck
       options:
         wndtype: [  290,  291]
         cgross:  [  5.0,  5.0]
@@ -163,7 +163,7 @@ obs post filters:
     filter variables:
     - name: windNorthward
     function absolute threshold:
-    - name: ObsFunction/SatWindsSPDBCheck
+    - name: ObsFunction/WindsSPDBCheck
       options:
         wndtype: [  290,  291]
         cgross:  [  5.0,  5.0]
@@ -175,7 +175,7 @@ obs post filters:
   # The last error inflation check is for duplicate observations. This one needs
   # to come last, because we don't want to inflate errors for duplication if one
   # of the duplicates should be rejected.
-  - filter: BlackList
+  - filter: RejectList
     filter variables:
     - name: windEastward
     action:
@@ -185,7 +185,7 @@ obs post filters:
         options:
           use_air_pressure: true
           variable: windEastward
-  - filter: BlackList
+  - filter: RejectList
     filter variables:
     - name: windNorthward
     action:
@@ -229,7 +229,8 @@ obs post filters:
 #      inflation factor: 1.25
 linear obs operator:
   name: Identity
-passedBenchmark: 52097 # 2 variables (u,v), u=26087 passing, v=26010 passing
+#passedBenchmark: 52097 # 2 variables (u,v), u=26087 passing, v=26010 passing
+passedBenchmark: 52109 # 2 variables (u,v), u=26093 passing, v=26016 passing
                        # GSI rejects both u- and v-component in first-guess check, UFO does not, but when UFO rej is reconciled btwn u and v these match GSI rej
                        #   u: 207 obs pass with corresponding v being rejected, 25880 obs in UFO/GSI agreement
                        #   v: 130 obs pass with corresponding u being rejected, 25880 obs in UFO/GSI agreement

--- a/parm/atm/obs/testing/scatwind_noqc.yaml
+++ b/parm/atm/obs/testing/scatwind_noqc.yaml
@@ -1,0 +1,21 @@
+obs space:
+  name: scatwind
+  obsdatain:
+    engine:
+      type: H5File
+      obsfile: !ENV scatwind_obs_${CDATE}.nc4
+  obsdataout:
+    engine:
+      type: H5File
+      obsfile: !ENV scatwind_diag_${CDATE}.nc4 
+  simulated variables: [windEastward, windNorthward]
+geovals:
+  filename: !ENV scatwind_geoval_${CDATE}.nc4
+vector ref: GsiHofXBc
+tolerance: 0.01
+obs operator:
+  name: VertInterp
+  apply near surface wind scaling: true
+
+vector ref: GsiHofXBc
+tolerance: 1.e-5


### PR DESCRIPTION
Minor changes....

Modifications made for satwind and scatwind with the following:

- Update benchmark 
   More number of observations passed QC with the current UFO develop
   6 more points for scatwind and 25056 points more for satwind.
   (Looks a lot more passed for satwind, probably because we do not do data thinning for satwind.)

- Change BlackList to RejectList for scatwind
- Update ObsFunction SatWindsSPDBCheck to WindsSPDBCheck for scatwind (satwind had already been fixed in previous PR)
- Change `land_Type_index_NPOESS` with `water_area_fraction` for scatwind
- Add tests without QC
