### PR TITLE
Add GPSRO yaml file

### DIFF
--- a/parm/atm/obs/testing/gps_bend.yaml
+++ b/parm/atm/obs/testing/gps_bend.yaml
@@ -82,3 +82,5 @@ obs filters:
 #  threshold: 10
 #  action:
 #    name: reject
+
+passedBenchmark: 393457

--- a/parm/atm/obs/testing/gps_bend.yaml
+++ b/parm/atm/obs/testing/gps_bend.yaml
@@ -1,0 +1,84 @@
+obs space:
+  name: gnssrobndnbam
+  obsdatain:
+    engine:
+      type: H5File
+      obsfile: !ENV gps_bend_obs_${CDATE}.nc4 
+    obsgrouping:
+      group variables: [ 'sequenceNumber' ]
+      sort variable: 'impactHeightRO'
+      sort order: 'ascending'
+  obsdataout:
+    engine:
+      type: H5File
+      obsfile: !ENV gps_bend_diag_${CDATE}.nc4 
+  simulated variables: [bendingAngle]
+geovals:
+  filename: !ENV gps_bend_geoval_${CDATE}.nc4
+obs operator:
+  name: GnssroBndNBAM
+  obs options:
+    use_compress: 1
+    sr_steps: 2
+    vertlayer: full
+    super_ref_qc: NBAM
+obs filters:
+#1. gpstop
+- filter: Domain Check
+  filter variables:
+  - name: bendingAngle
+  where:
+  - variable:
+      name: MetaData/impactHeightRO
+    minvalue: 0
+    maxvalue: 55000.1
+  action:
+    name: reject
+#2. commgpstop
+- filter: Bounds Check
+  filter variables:
+  - name: bendingAngle
+  where:
+  - variable:
+      name: MetaData/satelliteIdentifier
+    is_in: 265,266,267,268,269
+  test variables:
+  - name: MetaData/impactHeightRO
+  maxvalue: 45000.1
+  action:
+    name: reject
+#3. metop below 8 km
+- filter: Bounds Check
+  filter variables:
+  - name: bendingAngle
+  where:
+  - variable:
+      name: MetaData/satelliteIdentifier
+    is_in: 3-5
+  test variables:
+  - name: MetaData/impactHeightRO
+  minvalue: 8000.1
+  action:
+    name: reject
+#4. assign obs error 
+- filter: ROobserror
+  filter variables:
+  - name: bendingAngle
+  errmodel: NBAM
+#5. RONBAM cut off check
+- filter: Background Check RONBAM
+  filter variables:
+  - name: bendingAngle
+#6. Obs error inflate
+- filter: Background Check RONBAM
+  filter variables:
+  - name: bendingAngle
+  action:
+    name: RONBAMErrInflate
+#7. Background check
+#- filter: Background Check
+#  filter variables:
+#  - name: bendingAngle
+#  threshold: 10
+#  action:
+#    name: reject


### PR DESCRIPTION
GPSRO data evaluation for UFO with NBAM operator is complete. Adding gps_bend.yaml to the testing directory.

Code changes have been made to UFO NBAM operator to replicate GSI. The HofX, QC, and Obs error plots for each satellite were documented in https://github.com/NOAA-EMC/JEDI-T2O/issues/58.
Related JCSDA-internal PRs explained the code changes in NBAM operator regarding super refraction, and obs error assignment. More details can be found in https://github.com/JCSDA-internal/ufo/pull/2960#issuecomment-1677530695 and https://github.com/JCSDA-internal/ufo/pull/3040.

GPSRO bending angle YAML were included in the testing directory.
Benchmarks were added
The YAML replicates GSI result in terms of HofX, QC, and observation error except for 1 data point out of 496,413 due to window of the cutoff QC filter.