### PR TITLE
Marine iodaconv: Add metadata to the ioda writer

### DIFF
--- a/utils/obsproc/NetCDFToIodaConverter.h
+++ b/utils/obsproc/NetCDFToIodaConverter.h
@@ -29,7 +29,7 @@ namespace gdasapp {
     // Non optional metadata
     Eigen::ArrayXf longitude;  //
     Eigen::ArrayXf latitude;   //      "      error
-    Eigen::Array<long, Eigen::Dynamic, 1> datetime;   // Epoch date in seconds
+    Eigen::Array<int64_t, Eigen::Dynamic, 1> datetime;   // Epoch date in seconds
     std::string referenceDate;                        // Reference date for epoch time
 
     // Obs info
@@ -44,8 +44,8 @@ namespace gdasapp {
     std::vector<std::string> intMetadataName;    // String descriptor of the integer metadata
 
     explicit IodaVars(const int nobs = 0,
-                      const std::vector<std::string> fmnames= {},
-                      const std::vector<std::string> imnames= {}) :
+                      const std::vector<std::string> fmnames = {},
+                      const std::vector<std::string> imnames = {}) :
       location(nobs), nVars(1), nfMetadata(fmnames.size()), niMetadata(imnames.size()),
       longitude(location), latitude(location), datetime(location),
       obsVal(location),
@@ -66,16 +66,13 @@ namespace gdasapp {
       // time window info
       std::string winbegin;
       std::string winend;
-      std::string obsvar;
       fullConfig.get("window begin", winbegin);
       fullConfig.get("window end", winend);
-      fullConfig.get("variable", obsvar);
       windowBegin_ = util::DateTime(winbegin);
       windowEnd_ = util::DateTime(winend);
-      variable_ = obsvar;
+      variable_ = "None";
       oops::Log::info() << "--- Window begin: " << winbegin << std::endl;
       oops::Log::info() << "--- Window end: " << winend << std::endl;
-      oops::Log::info() << "--- Variable: " << obsvar << std::endl;
 
       // get input netcdf files
       fullConfig.get("input files", inputFilenames_);
@@ -92,7 +89,6 @@ namespace gdasapp {
       const eckit::mpi::Comm & comm = oops::mpi::world();
 
       // Extract ioda variables from the provider's files
-      //gdasapp::IodaVars iodaVars;
       int myrank  = comm.rank();
       int nobs(0);
 
@@ -122,8 +118,8 @@ namespace gdasapp {
       gatherObs(comm, iodaVars.obsError, iodaVarsAll.obsError);
       gatherObs(comm, iodaVars.preQc, iodaVarsAll.preQc);
 
-      //Eigen::ArrayXXi tmpXX
-      //gatherObs(comm,
+      // Eigen::ArrayXXi tmpXX
+      // gatherObs(comm,
       //          iodaVars.intMetadata.reshaped(iodaVars.intMetadata.size(), 1),
       //          iodaVarsAll.intMetadata.reshaped(iodaVarsAll.intMetadata.size(), 1));
 
@@ -148,11 +144,11 @@ namespace gdasapp {
         // Set up the creation parameters
         ioda::VariableCreationParameters float_params = createVariableParams<float>();
         ioda::VariableCreationParameters int_params = createVariableParams<int>();
-        ioda::VariableCreationParameters long_params = createVariableParams<long>();
+        ioda::VariableCreationParameters long_params = createVariableParams<int64_t>();
 
         // Create the mendatory IODA variables
         ioda::Variable iodaDatetime =
-          ogrp.vars.createWithScales<long>("MetaData/dateTime",
+          ogrp.vars.createWithScales<int64_t>("MetaData/dateTime",
                                           {ogrp.vars["Location"]}, long_params);
         iodaDatetime.atts.add<std::string>("units", {iodaVars.referenceDate}, {1});
         ioda::Variable iodaLat =

--- a/utils/obsproc/NetCDFToIodaConverter.h
+++ b/utils/obsproc/NetCDFToIodaConverter.h
@@ -101,13 +101,6 @@ namespace gdasapp {
 
       // Get the total number of obs across pe's
       comm.allReduce(nobs, nobs, eckit::mpi::sum());
-      oops::Log::debug() << " my rank : " << myrank
-                         << " Num pe's: " << comm.size()
-                         << " nfm: " << iodaVars.nfMetadata
-                         << " nim: " << iodaVars.niMetadata
-                         << " nobs: " << nobs << std::endl;
-      oops::Log::debug() << " float metadata : " << iodaVars.floatMetadataName << std::endl;
-      oops::Log::debug() << " int metadata : " << iodaVars.intMetadataName << std::endl;
       gdasapp::IodaVars iodaVarsAll(nobs, iodaVars.floatMetadataName, iodaVars.intMetadataName);
 
       // Gather iodaVars arrays
@@ -117,17 +110,6 @@ namespace gdasapp {
       gatherObs(comm, iodaVars.obsVal, iodaVarsAll.obsVal);
       gatherObs(comm, iodaVars.obsError, iodaVarsAll.obsError);
       gatherObs(comm, iodaVars.preQc, iodaVarsAll.preQc);
-
-      // Eigen::ArrayXXi tmpXX
-      // gatherObs(comm,
-      //          iodaVars.intMetadata.reshaped(iodaVars.intMetadata.size(), 1),
-      //          iodaVarsAll.intMetadata.reshaped(iodaVarsAll.intMetadata.size(), 1));
-
-      oops::Log::debug() << "--- all nobs: " << iodaVarsAll.obsVal.size() << std::endl;
-      oops::Log::debug() << "--- all obsVal: " << iodaVarsAll.obsVal << std::endl;
-      oops::Log::debug() << "--- all obsError: " << iodaVarsAll.obsError << std::endl;
-      oops::Log::debug() << "--- all preQc: " << iodaVarsAll.preQc << std::endl;
-      oops::Log::debug() << "--- all longitude: " << iodaVarsAll.longitude << std::endl;
 
       // Create empty group backed by HDF file
       if (oops::mpi::world().rank() == 0) {

--- a/utils/obsproc/NetCDFToIodaConverter.h
+++ b/utils/obsproc/NetCDFToIodaConverter.h
@@ -140,6 +140,12 @@ namespace gdasapp {
                                             {ogrp.vars["Location"]}, float_params);
         // TODO(All): Decide on what to use for the Epoch date
         adtIodaDatetime.atts.add<std::string>("units", {"seconds since 9999-04-15T12:00:00Z"}, {1});
+      ioda::Variable latIodaVal =
+        ogrp.vars.createWithScales<float>("MetaData/latitude",
+                                          {ogrp.vars["Location"]}, float_params);
+      ioda::Variable lonIodaVal =
+        ogrp.vars.createWithScales<float>("MetaData/longitude",
+                                          {ogrp.vars["Location"]}, float_params);
 
         ioda::Variable adtIodaObsVal =
           ogrp.vars.createWithScales<float>("ObsValue/"+variable_,

--- a/utils/obsproc/Rads2Ioda.h
+++ b/utils/obsproc/Rads2Ioda.h
@@ -1,8 +1,10 @@
 #pragma once
 
 #include <iostream>
+#include <map>
 #include <netcdf>    // NOLINT (using C API)
 #include <string>
+#include <vector>
 
 #include "eckit/config/LocalConfiguration.h"
 
@@ -18,7 +20,8 @@ namespace gdasapp {
   class Rads2Ioda : public NetCDFToIodaConverter {
    public:
     explicit Rads2Ioda(const eckit::Configuration & fullConfig)
-    : NetCDFToIodaConverter(fullConfig) {
+      : NetCDFToIodaConverter(fullConfig) {
+      variable_ = "absoluteDynamicTopography";
     }
 
     // Read netcdf file and populate iodaVars
@@ -52,7 +55,7 @@ namespace gdasapp {
 
       float datetime[iodaVars.location];  // NOLINT
       ncFile.getVar("time_mjd").getVar(datetime);
-      iodaVars.referenceDate = "seconds since 1858-11-17T00:00:00Z";  // TODO(Guillaume) get it from the file
+      iodaVars.referenceDate = "seconds since 1858-11-17T00:00:00Z";
 
       // Read optional integer metadata "mission"
       std::string mission_name;
@@ -86,7 +89,7 @@ namespace gdasapp {
       for (int i = 0; i < iodaVars.location; i++) {
         iodaVars.longitude(i) = static_cast<float>(lon[i])*geoscaleFactor;
         iodaVars.latitude(i) = static_cast<float>(lat[i])*geoscaleFactor;
-        iodaVars.datetime(i) = static_cast<long>(datetime[i]*86400.0f);
+        iodaVars.datetime(i) = static_cast<int64_t>(datetime[i]*86400.0f);
         iodaVars.obsVal(i) = static_cast<float>(adt[i])*scaleFactor;
         iodaVars.obsError(i) = 0.1;  // Do something for obs error
         iodaVars.preQc(i) = 0;

--- a/utils/obsproc/Rads2Ioda.h
+++ b/utils/obsproc/Rads2Ioda.h
@@ -61,7 +61,6 @@ namespace gdasapp {
       std::string mission_name;
       ncFile.getAtt("mission_name").getValues(mission_name);
       int mission_index = altimeterMissions(mission_name);   // mission name mapped to integer
-      Eigen::VectorXi mission(iodaVars.location);
 
       // Read optional integer metadata "pass" and "cycle"
       int pass[iodaVars.location];  // NOLINT
@@ -99,12 +98,15 @@ namespace gdasapp {
     };
     int altimeterMissions(std::string missionName) {
       std::map<std::string, int> altimeterMap;
-      // TODO(All): This is incomplete, add missions to the list below
+      // TODO(All): This is incomplete, add missions to the list below 
+      //            and add to global attribute
       altimeterMap["SNTNL-3A"] = 1;
       altimeterMap["SNTNL-3B"] = 2;
       altimeterMap["JASON-1"] = 3;
       altimeterMap["JASON-2"] = 4;
       altimeterMap["JASON-3"] = 5;
+      altimeterMap["CRYOSAT2"] = 6;
+      altimeterMap["SARAL"] = 7;
       return altimeterMap[missionName];
     }
   };  // class Rads2Ioda

--- a/utils/obsproc/Rads2Ioda.h
+++ b/utils/obsproc/Rads2Ioda.h
@@ -69,9 +69,7 @@ namespace gdasapp {
       ncFile.getVar("cycle").getVar(cycle);
 
       for (int i = 0; i < iodaVars.location; i++) {
-        iodaVars.intMetadata(i, 0) = pass[i];
-        iodaVars.intMetadata(i, 1) = cycle[i];
-        iodaVars.intMetadata(i, 2) = mission_index;
+        iodaVars.intMetadata.row(i) << pass[i], cycle[i], mission_index;
       }
 
       // Get adt_egm2008 obs values and attributes
@@ -92,13 +90,14 @@ namespace gdasapp {
         iodaVars.obsVal(i) = static_cast<float>(adt[i])*scaleFactor;
         iodaVars.obsError(i) = 0.1;  // Do something for obs error
         iodaVars.preQc(i) = 0;
+        // Save MDT in optional floatMetadata
         iodaVars.floatMetadata(i, 0) = iodaVars.obsVal(i) - static_cast<float>(sla[i])*scaleFactor;
       }
       return iodaVars;
     };
     int altimeterMissions(std::string missionName) {
       std::map<std::string, int> altimeterMap;
-      // TODO(All): This is incomplete, add missions to the list below 
+      // TODO(All): This is incomplete, add missions to the list below
       //            and add to global attribute
       altimeterMap["SNTNL-3A"] = 1;
       altimeterMap["SNTNL-3B"] = 2;

--- a/utils/obsproc/Rads2Ioda.h
+++ b/utils/obsproc/Rads2Ioda.h
@@ -40,6 +40,19 @@ namespace gdasapp {
       // Create instance of iodaVars object
       gdasapp::IodaVars iodaVars(nobs, floatMetadataNames, intMetadataNames);
 
+      // Read non-optional metadata: datetime, longitude and latitude
+      netCDF::NcVar latNcVar = ncFile.getVar("lat");
+      int latVal[iodaVars.location];  // NOLINT (can't pass vector to getVar below)
+      latNcVar.getVar(latVal);
+
+      netCDF::NcVar lonNcVar = ncFile.getVar("lon");
+      int lonVal[iodaVars.location];  // NOLINT (can't pass vector to getVar below)
+      lonNcVar.getVar(lonVal);
+      std::string geounits;
+      lonNcVar.getAtt("units").getValues(geounits);
+      float geoscaleFactor;
+      lonNcVar.getAtt("scale_factor").getValues(&geoscaleFactor);
+
       // Get adt_egm2008 obs values and attributes
       netCDF::NcVar adtNcVar = ncFile.getVar("adt_egm2008");
       int adtObsVal[iodaVars.location];  // NOLINT (can't pass vector to getVar below)

--- a/utils/obsproc/applications/CMakeLists.txt
+++ b/utils/obsproc/applications/CMakeLists.txt
@@ -1,9 +1,9 @@
-list( APPEND gdasapp_rads2ioda_src_files
+list( APPEND gdasapp_provider2ioda_src_files
   gdas_obsprovider2ioda.cc
   gdas_obsprovider2ioda.h
   )
 ecbuild_add_executable( TARGET gdas_obsprovider2ioda.x
-                        SOURCES ${gdasapp_rads2ioda_src_files} )
+                        SOURCES ${gdasapp_provider2ioda_src_files} )
 
 target_compile_features( gdas_obsprovider2ioda.x PUBLIC cxx_std_17)
 target_link_libraries( gdas_obsprovider2ioda.x PUBLIC oops ioda NetCDF::NetCDF_CXX)

--- a/utils/test/prepdata.sh
+++ b/utils/test/prepdata.sh
@@ -1,17 +1,28 @@
 #!/bin/bash
 set -e
 
+cdl2nc4() {
+
+  local output_nc4="$1"
+  local input_cdl="$2"
+
+  echo "Generating ${output_nc4}"
+  ncgen -o "$output_nc4" "$input_cdl"
+}
+
 project_source_dir=$1
 
-ncgen -o rads_adt_3a_2021181.nc4 ${project_source_dir}/testdata/rads_adt_3a_2021181.cdl
-ncgen -o rads_adt_3b_2021181.nc4 ${project_source_dir}/testdata/rads_adt_3b_2021181.cdl
-ncgen -o icec_amsr2_north_1.nc4 ${project_source_dir}/testdata/icec_amsr2_north_1.cdl
-ncgen -o icec_amsr2_north_2.nc4 ${project_source_dir}/testdata/icec_amsr2_north_2.cdl
-ncgen -o icec_amsr2_south_1.nc4 ${project_source_dir}/testdata/icec_amsr2_south_1.cdl
-ncgen -o icec_amsr2_south_2.nc4 ${project_source_dir}/testdata/icec_amsr2_south_2.cdl
-ncgen -o sss_smap_1.nc4 ${project_source_dir}/testdata/sss_smap_1.cdl
-ncgen -o sss_smap_2.nc4 ${project_source_dir}/testdata/sss_smap_2.cdl
-ncgen -o sss_smos_1.nc4 ${project_source_dir}/testdata/sss_smos_1.cdl
-ncgen -o sss_smos_2.nc4 ${project_source_dir}/testdata/sss_smos_2.cdl
-ncgen -o ghrsst_sst_mb_202107010000.nc4 ${project_source_dir}/testdata/ghrsst_sst_mb_202107010000.cdl
-ncgen -o ghrsst_sst_mb_202107010100.nc4 ${project_source_dir}/testdata/ghrsst_sst_mb_202107010100.cdl
+
+cdl2nc4 rads_adt_3a_2021181.nc4 ${project_source_dir}/testdata/rads_adt_3a_2021181.cdl
+cdl2nc4 rads_adt_3b_2021181.nc4 ${project_source_dir}/testdata/rads_adt_3b_2021181.cdl
+cdl2nc4 icec_amsr2_north_1.nc4 ${project_source_dir}/testdata/icec_amsr2_north_1.cdl
+cdl2nc4 icec_amsr2_north_2.nc4 ${project_source_dir}/testdata/icec_amsr2_north_2.cdl
+cdl2nc4 icec_amsr2_south_1.nc4 ${project_source_dir}/testdata/icec_amsr2_south_1.cdl
+cdl2nc4 icec_amsr2_south_2.nc4 ${project_source_dir}/testdata/icec_amsr2_south_2.cdl
+# TODO(Andy): Fix the corrupted cdl files below
+#cdl2nc4 sss_smap_1.nc4 ${project_source_dir}/testdata/sss_smap_1.cdl
+#cdl2nc4 sss_smap_2.nc4 ${project_source_dir}/testdata/sss_smap_2.cdl
+#cdl2nc4 sss_smos_1.nc4 ${project_source_dir}/testdata/sss_smos_1.cdl
+#cdl2nc4 sss_smos_2.nc4 ${project_source_dir}/testdata/sss_smos_2.cdl
+cdl2nc4 ghrsst_sst_mb_202107010000.nc4 ${project_source_dir}/testdata/ghrsst_sst_mb_202107010000.cdl
+cdl2nc4 ghrsst_sst_mb_202107010100.nc4 ${project_source_dir}/testdata/ghrsst_sst_mb_202107010100.cdl

--- a/utils/test/testinput/gdas_rads2ioda.yaml
+++ b/utils/test/testinput/gdas_rads2ioda.yaml
@@ -5,4 +5,4 @@ variable: absoluteDynamicTopography
 output file: rads_adt_j3_2021182.ioda.nc
 input files:
 - rads_adt_j3_2021182.nc4
-- rads_adt_j3_2021182.nc4
+#- rads_adt_j3_2021182.nc4

--- a/utils/test/testinput/gdas_rads2ioda.yaml
+++ b/utils/test/testinput/gdas_rads2ioda.yaml
@@ -1,7 +1,6 @@
 provider: RADS
 window begin: 2018-04-15T06:00:00Z
 window end: 2018-04-15T12:00:00Z
-variable: absoluteDynamicTopography
 output file: rads_adt_j3_2021182.ioda.nc
 input files:
 - rads_adt_j3_2021182.nc4


### PR DESCRIPTION
## Description
This feature branch adds the option to pass integer and float metadata to the ioda writer. 

### Issues not addressed
- @AndrewEichmann-NOAA : The cdl to nc4 for sss doesn't seem to be working. I commented it out n this PR. 
- I have yet to implement an "allgather" for the optional metadata, so the concatenation is currently not correct
- While testing on my laptop yesterday, I noticed that the application freezes when trying to concatenate more than 4 files. No idea if this is a hardware or code issue. A problem for today. 
