### PR TITLE
Add underscore (_) to IodaVar class member variable names 

### DIFF
--- a/utils/obsproc/Ghrsst2Ioda.h
+++ b/utils/obsproc/Ghrsst2Ioda.h
@@ -167,26 +167,26 @@ namespace gdasapp {
       gdasapp::IodaVars iodaVars(nobs, {}, {});
 
       // unix epoch at Jan 01 1981 00:00:00 GMT+0000
-      iodaVars.referenceDate = refDate;
-      oops::Log::info() << "--- time: " << iodaVars.referenceDate << std::endl;
+      iodaVars.referenceDate_ = refDate;
+      oops::Log::info() << "--- time: " << iodaVars.referenceDate_ << std::endl;
 
       // Store into eigen arrays
       int loc(0);
       for (int i = 0; i < sst_s.size(); i++) {
         for (int j = 0; j < sst_s[0].size(); j++) {
-          iodaVars.longitude(loc) = lon2d_s[i][j];
-          iodaVars.latitude(loc)  = lat2d_s[i][j];
-          iodaVars.obsVal(loc)    = sst_s[i][j];
-          iodaVars.obsError(loc)  = obserror_s[i][j];
-          iodaVars.preQc(loc)     = 0;
-          iodaVars.datetime(loc)  = seconds_s[i][j];
+          iodaVars.longitude_(loc) = lon2d_s[i][j];
+          iodaVars.latitude_(loc)  = lat2d_s[i][j];
+          iodaVars.obsVal_(loc)    = sst_s[i][j];
+          iodaVars.obsError_(loc)  = obserror_s[i][j];
+          iodaVars.preQc_(loc)     = 0;
+          iodaVars.datetime_(loc)  = seconds_s[i][j];
           loc += 1;
         }
       }
 
       // Remove
       Eigen::Array<bool, Eigen::Dynamic, 1> boundsCheck =
-        (iodaVars.obsVal > -3.0 && iodaVars.obsVal < 50.0);
+        (iodaVars.obsVal_ > -3.0 && iodaVars.obsVal_ < 50.0);
       iodaVars.trim(boundsCheck);
 
       return iodaVars;

--- a/utils/obsproc/IcecAmsr2Ioda.h
+++ b/utils/obsproc/IcecAmsr2Ioda.h
@@ -42,27 +42,27 @@ namespace gdasapp {
       // Create instance of iodaVars object
       gdasapp::IodaVars iodaVars(nobs, {}, {});
 
-      oops::Log::debug() << "--- iodaVars.location: " << iodaVars.location << std::endl;
+      oops::Log::debug() << "--- iodaVars.location_: " << iodaVars.location_ << std::endl;
 
       // Read non-optional metadata: longitude and latitude
-      std::vector<float> oneDimLatVal(iodaVars.location);
+      std::vector<float> oneDimLatVal(iodaVars.location_);
       ncFile.getVar("Latitude").getVar(oneDimLatVal.data());
 
-      std::vector<float> oneDimLonVal(iodaVars.location);
+      std::vector<float> oneDimLonVal(iodaVars.location_);
       ncFile.getVar("Longitude").getVar(oneDimLonVal.data());
 
       // Read Quality Flags as a preQc
-      std::vector<int64_t> oneDimFlagsVal(iodaVars.location);
+      std::vector<int64_t> oneDimFlagsVal(iodaVars.location_);
       ncFile.getVar("Flags").getVar(oneDimFlagsVal.data());
 
       // Get Ice_Concentration obs values
-      std::vector<int> oneDimObsVal(iodaVars.location);
+      std::vector<int> oneDimObsVal(iodaVars.location_);
       ncFile.getVar("NASA_Team_2_Ice_Concentration").getVar(oneDimObsVal.data());
 
       // Read and process the dateTime
       std::vector<int> oneTmpdateTimeVal(ntimes);
       ncFile.getVar("Scan_Time").getVar(oneTmpdateTimeVal.data());
-      iodaVars.referenceDate = "seconds since 1970-01-01T00:00:00Z";
+      iodaVars.referenceDate_ = "seconds since 1970-01-01T00:00:00Z";
 
       std::tm timeinfo = {};
       for (int i = 0; i < ntimes; i += dimTimeSize) {
@@ -77,16 +77,16 @@ namespace gdasapp {
 
         // Calculate and store the seconds since the Unix epoch
         time_t epochtime = std::mktime(&timeinfo);
-        iodaVars.datetime(i/6) = static_cast<int64_t>(epochtime);
+        iodaVars.datetime_(i/6) = static_cast<int64_t>(epochtime);
       }
 
       // Update non-optional Eigen arrays
-      for (int i = 0; i < iodaVars.location; i++) {
-        iodaVars.longitude(i) = oneDimLonVal[i];
-        iodaVars.latitude(i) = oneDimLatVal[i];
-        iodaVars.obsVal(i) = static_cast<int64_t>(oneDimObsVal[i]*0.01);
-        iodaVars.obsError(i) = 0.1;  // Do something for obs error
-        iodaVars.preQc(i) = oneDimFlagsVal[i];
+      for (int i = 0; i < iodaVars.location_; i++) {
+        iodaVars.longitude_(i) = oneDimLonVal[i];
+        iodaVars.latitude_(i) = oneDimLatVal[i];
+        iodaVars.obsVal_(i) = static_cast<int64_t>(oneDimObsVal[i]*0.01);
+        iodaVars.obsError_(i) = 0.1;  // Do something for obs error
+        iodaVars.preQc_(i) = oneDimFlagsVal[i];
       }
       return iodaVars;
     };

--- a/utils/obsproc/NetCDFToIodaConverter.h
+++ b/utils/obsproc/NetCDFToIodaConverter.h
@@ -20,42 +20,42 @@ namespace gdasapp {
   // A simple data structure to organize the info to provide to the ioda
   // writter
   struct IodaVars {
-    int location;      // Number of observation per variable
-    int nVars;         // number of obs variables, should be set to
+    int location_;      // Number of observation per variable
+    int nVars_;         // number of obs variables, should be set to
                        // for now in the children classes
-    int nfMetadata;    // number of float metadata fields
-    int niMetadata;    // number of int metadata fields
+    int nfMetadata_;    // number of float metadata fields
+    int niMetadata_;    // number of int metadata fields
 
     // Non optional metadata
-    Eigen::ArrayXf longitude;  // geo-location
-    Eigen::ArrayXf latitude;   //     "
-    Eigen::Array<int64_t, Eigen::Dynamic, 1> datetime;   // Epoch date in seconds
-    std::string referenceDate;                           // Reference date for epoch time
+    Eigen::ArrayXf longitude_;  // geo-location_
+    Eigen::ArrayXf latitude_;   //     "
+    Eigen::Array<int64_t, Eigen::Dynamic, 1> datetime_;   // Epoch date in seconds
+    std::string referenceDate_;                           // Reference date for epoch time
 
     // Obs info
-    Eigen::ArrayXf obsVal;     // Observation value
-    Eigen::ArrayXf obsError;   //      "      error
-    Eigen::ArrayXi preQc;      // Quality control flag
+    Eigen::ArrayXf obsVal_;     // Observation value
+    Eigen::ArrayXf obsError_;   //      "      error
+    Eigen::ArrayXi preQc_;      // Quality control flag
 
     // Optional metadata
-    Eigen::ArrayXXf floatMetadata;                // Optional array of float metadata
-    std::vector<std::string> floatMetadataName;  // String descriptor of the float metadata
-    Eigen::ArrayXXf intMetadata;                  // Optional array of integer metadata
-    std::vector<std::string> intMetadataName;    // String descriptor of the integer metadata
+    Eigen::ArrayXXf floatMetadata_;                // Optional array of float metadata
+    std::vector<std::string> floatMetadataName_;  // String descriptor of the float metadata
+    Eigen::ArrayXXf intMetadata_;                  // Optional array of integer metadata
+    std::vector<std::string> intMetadataName_;    // String descriptor of the integer metadata
 
     // Constructor
     explicit IodaVars(const int nobs = 0,
                       const std::vector<std::string> fmnames = {},
                       const std::vector<std::string> imnames = {}) :
-      location(nobs), nVars(1), nfMetadata(fmnames.size()), niMetadata(imnames.size()),
-      longitude(location), latitude(location), datetime(location),
-      obsVal(location),
-      obsError(location),
-      preQc(location),
-      floatMetadata(location, fmnames.size()),
-      floatMetadataName(fmnames),
-      intMetadata(location, imnames.size()),
-      intMetadataName(imnames)
+      location_(nobs), nVars_(1), nfMetadata_(fmnames.size()), niMetadata_(imnames.size()),
+      longitude_(location_), latitude_(location_), datetime_(location_),
+      obsVal_(location_),
+      obsError_(location_),
+      preQc_(location_),
+      floatMetadata_(location_, fmnames.size()),
+      floatMetadataName_(fmnames),
+      intMetadata_(location_, imnames.size()),
+      intMetadataName_(imnames)
     {
       oops::Log::trace() << "IodaVars::IodaVars created." << std::endl;
     }
@@ -63,72 +63,72 @@ namespace gdasapp {
     // Append an other instance of IodaVars
     void append(const IodaVars& other) {
       // Check if the two instances can be concatenated
-      ASSERT(nVars == other.nVars);
-      ASSERT(nfMetadata == other.nfMetadata);
-      ASSERT(niMetadata == other.niMetadata);
-      ASSERT(floatMetadataName == floatMetadataName);
-      ASSERT(intMetadataName == intMetadataName);
+      ASSERT(nVars_ == other.nVars_);
+      ASSERT(nfMetadata_ == other.nfMetadata_);
+      ASSERT(niMetadata_ == other.niMetadata_);
+      ASSERT(floatMetadataName_ == floatMetadataName_);
+      ASSERT(intMetadataName_ == intMetadataName_);
 
       // Concatenate Eigen arrays and vectors
-      longitude.conservativeResize(location + other.location);
-      latitude.conservativeResize(location + other.location);
-      datetime.conservativeResize(location + other.location);
-      obsVal.conservativeResize(location + other.location);
-      obsError.conservativeResize(location + other.location);
-      preQc.conservativeResize(location + other.location);
-      floatMetadata.conservativeResize(location + other.location, nfMetadata);
-      intMetadata.conservativeResize(location + other.location, niMetadata);
+      longitude_.conservativeResize(location_ + other.location_);
+      latitude_.conservativeResize(location_ + other.location_);
+      datetime_.conservativeResize(location_ + other.location_);
+      obsVal_.conservativeResize(location_ + other.location_);
+      obsError_.conservativeResize(location_ + other.location_);
+      preQc_.conservativeResize(location_ + other.location_);
+      floatMetadata_.conservativeResize(location_ + other.location_, nfMetadata_);
+      intMetadata_.conservativeResize(location_ + other.location_, niMetadata_);
 
       // Copy data from the 'other' object to this object
-      longitude.tail(other.location) = other.longitude;
-      latitude.tail(other.location) = other.latitude;
-      datetime.tail(other.location) = other.datetime;
-      obsVal.tail(other.location) = other.obsVal;
-      obsError.tail(other.location) = other.obsError;
-      preQc.tail(other.location) = other.preQc;
-      floatMetadata.bottomRows(other.location) = other.floatMetadata;
-      intMetadata.bottomRows(other.location) = other.intMetadata;
+      longitude_.tail(other.location_) = other.longitude_;
+      latitude_.tail(other.location_) = other.latitude_;
+      datetime_.tail(other.location_) = other.datetime_;
+      obsVal_.tail(other.location_) = other.obsVal_;
+      obsError_.tail(other.location_) = other.obsError_;
+      preQc_.tail(other.location_) = other.preQc_;
+      floatMetadata_.bottomRows(other.location_) = other.floatMetadata_;
+      intMetadata_.bottomRows(other.location_) = other.intMetadata_;
 
       // Update obs count
-      location += other.location;
+      location_ += other.location_;
       oops::Log::trace() << "IodaVars::IodaVars done appending." << std::endl;
     }
     void trim(const Eigen::Array<bool, Eigen::Dynamic, 1>& mask ) {
       int newlocation = mask.count();
 
-      IodaVars iodaVarsMasked(newlocation,  this->floatMetadataName, this->intMetadataName);
+      IodaVars iodaVarsMasked(newlocation,  floatMetadataName_, intMetadataName_);
 
       // this feels downright crude, but apparently numpy-type masks are on the todo list for Eigen
       int j = 0;
-      for (int i = 0; i < this->location; i++) {
+      for (int i = 0; i < location_; i++) {
         if (mask(i)) {
-          iodaVarsMasked.longitude(j) = this->longitude(i);
-          iodaVarsMasked.latitude(j) = this->latitude(i);
-          iodaVarsMasked.obsVal(j) = this->obsVal(i);
-          iodaVarsMasked.obsError(j) = this->obsError(i);
-          iodaVarsMasked.preQc(j) = this->preQc(i);
-          iodaVarsMasked.datetime(j) = this->datetime(i);
-          for (int k = 0; k < this->nfMetadata; k++) {
-            iodaVarsMasked.intMetadata(j, k) = this->intMetadata(i, k);
+          iodaVarsMasked.longitude_(j) = longitude_(i);
+          iodaVarsMasked.latitude_(j) = latitude_(i);
+          iodaVarsMasked.obsVal_(j) = obsVal_(i);
+          iodaVarsMasked.obsError_(j) = obsError_(i);
+          iodaVarsMasked.preQc_(j) = preQc_(i);
+          iodaVarsMasked.datetime_(j) = datetime_(i);
+          for (int k = 0; k < nfMetadata_; k++) {
+            iodaVarsMasked.intMetadata_(j, k) = intMetadata_(i, k);
             }
-          for (int k = 0; k < this->niMetadata; k++) {
-            iodaVarsMasked.intMetadata(j, k) = this->intMetadata(i, k);
+          for (int k = 0; k < niMetadata_; k++) {
+            iodaVarsMasked.intMetadata_(j, k) = intMetadata_(i, k);
             }
         j++;
         }  // end if (mask(i))
       }
 
-      this->longitude = iodaVarsMasked.longitude;
-      this->latitude = iodaVarsMasked.latitude;
-      this->datetime = iodaVarsMasked.datetime;
-      this->obsVal = iodaVarsMasked.obsVal;
-      this->obsError = iodaVarsMasked.obsError;
-      this->preQc = iodaVarsMasked.preQc;
-      this->floatMetadata = iodaVarsMasked.floatMetadata;
-      this->intMetadata = iodaVarsMasked.intMetadata;
+      longitude_ = iodaVarsMasked.longitude_;
+      latitude_ = iodaVarsMasked.latitude_;
+      datetime_ = iodaVarsMasked.datetime_;
+      obsVal_ = iodaVarsMasked.obsVal_;
+      obsError_ = iodaVarsMasked.obsError_;
+      preQc_ = iodaVarsMasked.preQc_;
+      floatMetadata_ = iodaVarsMasked.floatMetadata_;
+      intMetadata_ = iodaVarsMasked.intMetadata_;
 
       // Update obs count
-      this->location = iodaVarsMasked.location;
+      location_ = iodaVarsMasked.location_;
       oops::Log::info() << "IodaVars::IodaVars done masking." << std::endl;
     }
   };
@@ -174,22 +174,24 @@ namespace gdasapp {
       for (int i = myrank + comm_.size(); i < inputFilenames_.size(); i += comm_.size()) {
         iodaVars.append(providerToIodaVars(inputFilenames_[i]));
         oops::Log::info() << " appending: " << inputFilenames_[i] << std::endl;
-        oops::Log::info() << " obs count: " << iodaVars.location << std::endl;
+        oops::Log::info() << " obs count: " << iodaVars.location_ << std::endl;
       }
-      nobs = iodaVars.location;
+      nobs = iodaVars.location_;
 
       // Get the total number of obs across pe's
       int nobsAll(0);
       comm_.allReduce(nobs, nobsAll, eckit::mpi::sum());
-      gdasapp::IodaVars iodaVarsAll(nobsAll, iodaVars.floatMetadataName, iodaVars.intMetadataName);
+      gdasapp::IodaVars iodaVarsAll(nobsAll,
+                                    iodaVars.floatMetadataName_,
+                                    iodaVars.intMetadataName_);
 
       // Gather iodaVars arrays
-      gatherObs(iodaVars.longitude, iodaVarsAll.longitude);
-      gatherObs(iodaVars.latitude, iodaVarsAll.latitude);
-      gatherObs(iodaVars.datetime, iodaVarsAll.datetime);
-      gatherObs(iodaVars.obsVal, iodaVarsAll.obsVal);
-      gatherObs(iodaVars.obsError, iodaVarsAll.obsError);
-      gatherObs(iodaVars.preQc, iodaVarsAll.preQc);
+      gatherObs(iodaVars.longitude_, iodaVarsAll.longitude_);
+      gatherObs(iodaVars.latitude_, iodaVarsAll.latitude_);
+      gatherObs(iodaVars.datetime_, iodaVarsAll.datetime_);
+      gatherObs(iodaVars.obsVal_, iodaVarsAll.obsVal_);
+      gatherObs(iodaVars.obsError_, iodaVarsAll.obsError_);
+      gatherObs(iodaVars.preQc_, iodaVarsAll.preQc_);
 
       // Create empty group backed by HDF file
       if (oops::mpi::world().rank() == 0) {
@@ -199,7 +201,7 @@ namespace gdasapp {
 
         // Update the group with the location dimension
         ioda::NewDimensionScales_t
-          newDims {ioda::NewDimensionScale<int>("Location", iodaVarsAll.location)};
+          newDims {ioda::NewDimensionScale<int>("Location", iodaVarsAll.location_)};
         ioda::ObsGroup ogrp = ioda::ObsGroup::generate(group, newDims);
 
         // Set up the creation parameters
@@ -211,7 +213,7 @@ namespace gdasapp {
         ioda::Variable iodaDatetime =
           ogrp.vars.createWithScales<int64_t>("MetaData/dateTime",
                                           {ogrp.vars["Location"]}, long_params);
-        iodaDatetime.atts.add<std::string>("units", {iodaVars.referenceDate}, {1});
+        iodaDatetime.atts.add<std::string>("units", {iodaVars.referenceDate_}, {1});
         ioda::Variable iodaLat =
           ogrp.vars.createWithScales<float>("MetaData/latitude",
                                             {ogrp.vars["Location"]}, float_params);
@@ -233,31 +235,31 @@ namespace gdasapp {
         // Create the optional IODA integer metadata
         ioda::Variable tmpIntMeta;
         int count = 0;
-        for (const std::string& strMeta : iodaVars.intMetadataName) {
+        for (const std::string& strMeta : iodaVars.intMetadataName_) {
           tmpIntMeta = ogrp.vars.createWithScales<int>("MetaData/"+strMeta,
                                                          {ogrp.vars["Location"]}, int_params);
-          tmpIntMeta.writeWithEigenRegular(iodaVars.intMetadata.col(count));
+          tmpIntMeta.writeWithEigenRegular(iodaVars.intMetadata_.col(count));
           count++;
         }
 
         // Create the optional IODA float metadata
         ioda::Variable tmpFloatMeta;
         count = 0;
-        for (const std::string& strMeta : iodaVars.floatMetadataName) {
+        for (const std::string& strMeta : iodaVars.floatMetadataName_) {
           tmpFloatMeta = ogrp.vars.createWithScales<float>("MetaData/"+strMeta,
                                                       {ogrp.vars["Location"]}, float_params);
-          tmpFloatMeta.writeWithEigenRegular(iodaVars.floatMetadata.col(count));
+          tmpFloatMeta.writeWithEigenRegular(iodaVars.floatMetadata_.col(count));
           count++;
         }
 
         // Write obs info to group
         oops::Log::info() << "Writting ioda file" << std::endl;
-        iodaLon.writeWithEigenRegular(iodaVarsAll.longitude);
-        iodaLat.writeWithEigenRegular(iodaVarsAll.latitude);
-        iodaDatetime.writeWithEigenRegular(iodaVarsAll.datetime);
-        iodaObsVal.writeWithEigenRegular(iodaVarsAll.obsVal);
-        iodaObsErr.writeWithEigenRegular(iodaVarsAll.obsError);
-        iodaPreQc.writeWithEigenRegular(iodaVarsAll.preQc);
+        iodaLon.writeWithEigenRegular(iodaVarsAll.longitude_);
+        iodaLat.writeWithEigenRegular(iodaVarsAll.latitude_);
+        iodaDatetime.writeWithEigenRegular(iodaVarsAll.datetime_);
+        iodaObsVal.writeWithEigenRegular(iodaVarsAll.obsVal_);
+        iodaObsErr.writeWithEigenRegular(iodaVarsAll.obsError_);
+        iodaPreQc.writeWithEigenRegular(iodaVarsAll.preQc_);
       }
     }
 

--- a/utils/obsproc/Rads2Ioda.h
+++ b/utils/obsproc/Rads2Ioda.h
@@ -44,18 +44,18 @@ namespace gdasapp {
       gdasapp::IodaVars iodaVars(nobs, floatMetadataNames, intMetadataNames);
 
       // Read non-optional metadata: datetime, longitude and latitude
-      int lat[iodaVars.location];  // NOLINT
+      int lat[iodaVars.location_];  // NOLINT
       ncFile.getVar("lat").getVar(lat);
 
-      int lon[iodaVars.location];  // NOLINT
+      int lon[iodaVars.location_];  // NOLINT
       ncFile.getVar("lon").getVar(lon);
 
       float geoscaleFactor;
       ncFile.getVar("lon").getAtt("scale_factor").getValues(&geoscaleFactor);
 
-      float datetime[iodaVars.location];  // NOLINT
+      float datetime[iodaVars.location_];  // NOLINT
       ncFile.getVar("time_mjd").getVar(datetime);
-      iodaVars.referenceDate = "seconds since 1858-11-17T00:00:00Z";
+      iodaVars.referenceDate_ = "seconds since 1858-11-17T00:00:00Z";
 
       // Read optional integer metadata "mission"
       std::string mission_name;
@@ -63,35 +63,36 @@ namespace gdasapp {
       int mission_index = altimeterMissions(mission_name);   // mission name mapped to integer
 
       // Read optional integer metadata "pass" and "cycle"
-      int pass[iodaVars.location];  // NOLINT
+      int pass[iodaVars.location_];  // NOLINT
       ncFile.getVar("pass").getVar(pass);
-      int cycle[iodaVars.location];  // NOLINT
+      int cycle[iodaVars.location_];  // NOLINT
       ncFile.getVar("cycle").getVar(cycle);
 
-      for (int i = 0; i < iodaVars.location; i++) {
-        iodaVars.intMetadata.row(i) << pass[i], cycle[i], mission_index;
+      for (int i = 0; i < iodaVars.location_; i++) {
+        iodaVars.intMetadata_.row(i) << pass[i], cycle[i], mission_index;
       }
 
       // Get adt_egm2008 obs values and attributes
-      int adt[iodaVars.location];  // NOLINT
+      int adt[iodaVars.location_];  // NOLINT
       ncFile.getVar("adt_egm2008").getVar(adt);
       float scaleFactor;
       ncFile.getVar("adt_egm2008").getAtt("scale_factor").getValues(&scaleFactor);
 
       // Read sla
-      int sla[iodaVars.location];  // NOLINT
+      int sla[iodaVars.location_];  // NOLINT
       ncFile.getVar("sla").getVar(sla);
 
       // Update non-optional Eigen arrays
-      for (int i = 0; i < iodaVars.location; i++) {
-        iodaVars.longitude(i) = static_cast<float>(lon[i])*geoscaleFactor;
-        iodaVars.latitude(i) = static_cast<float>(lat[i])*geoscaleFactor;
-        iodaVars.datetime(i) = static_cast<int64_t>(datetime[i]*86400.0f);
-        iodaVars.obsVal(i) = static_cast<float>(adt[i])*scaleFactor;
-        iodaVars.obsError(i) = 0.1;  // Do something for obs error
-        iodaVars.preQc(i) = 0;
+      for (int i = 0; i < iodaVars.location_; i++) {
+        iodaVars.longitude_(i) = static_cast<float>(lon[i])*geoscaleFactor;
+        iodaVars.latitude_(i) = static_cast<float>(lat[i])*geoscaleFactor;
+        iodaVars.datetime_(i) = static_cast<int64_t>(datetime[i]*86400.0f);
+        iodaVars.obsVal_(i) = static_cast<float>(adt[i])*scaleFactor;
+        iodaVars.obsError_(i) = 0.1;  // Do something for obs error
+        iodaVars.preQc_(i) = 0;
         // Save MDT in optional floatMetadata
-        iodaVars.floatMetadata(i, 0) = iodaVars.obsVal(i) - static_cast<float>(sla[i])*scaleFactor;
+        iodaVars.floatMetadata_(i, 0) = iodaVars.obsVal_(i) -
+                                        static_cast<float>(sla[i])*scaleFactor;
       }
       return iodaVars;
     };

--- a/utils/obsproc/Smap2Ioda.h
+++ b/utils/obsproc/Smap2Ioda.h
@@ -67,7 +67,7 @@ namespace gdasapp {
       netCDF::NcGroupAtt attributeStartDay = ncFile.getAtt("REV_START_DAY_OF_YEAR");
       attributeStartDay.getValues(&startDay);
 
-      iodaVars.referenceDate = "seconds since 1970-01-01T00:00:00Z";
+      iodaVars.referenceDate_ = "seconds since 1970-01-01T00:00:00Z";
 
       // calculate the seconds of Jan 1 of startyear since unix epoch
       std::tm tm{};
@@ -82,12 +82,12 @@ namespace gdasapp {
       for (int i = 0; i < dim0; i++) {
         for (int j = 0; j < dim1; j++) {
           loc = i * dim1 + j;
-          iodaVars.longitude(loc) = lon[i][j];
-          iodaVars.latitude(loc) = lat[i][j];
-          iodaVars.obsVal(loc) = sss[i][j];
-          iodaVars.obsError(loc) = sss_error[i][j];
-          iodaVars.preQc(loc) = sss_qc[i][j];
-          iodaVars.datetime(loc) =  static_cast<int64_t>(obsTime[j] + unixStartDay);
+          iodaVars.longitude_(loc) = lon[i][j];
+          iodaVars.latitude_(loc) = lat[i][j];
+          iodaVars.obsVal_(loc) = sss[i][j];
+          iodaVars.obsError_(loc) = sss_error[i][j];
+          iodaVars.preQc_(loc) = sss_qc[i][j];
+          iodaVars.datetime_(loc) =  static_cast<int64_t>(obsTime[j] + unixStartDay);
         }
       }
       return iodaVars;

--- a/utils/obsproc/Smos2Ioda.h
+++ b/utils/obsproc/Smos2Ioda.h
@@ -45,45 +45,45 @@ namespace gdasapp {
       // Create instance of iodaVars object
       gdasapp::IodaVars iodaVars(nobs, floatMetadataNames, intMetadataNames);
 
-      std::vector<float> lat(iodaVars.location);
+      std::vector<float> lat(iodaVars.location_);
       ncFile.getVar("Latitude").getVar(lat.data());
 
-      std::vector<float> lon(iodaVars.location);
+      std::vector<float> lon(iodaVars.location_);
       ncFile.getVar("Longitude").getVar(lon.data());
 
-      std::vector<float> sss(iodaVars.location);
+      std::vector<float> sss(iodaVars.location_);
       ncFile.getVar("SSS_corr").getVar(sss.data());
 
-      std::vector<float> sss_error(iodaVars.location);
+      std::vector<float> sss_error(iodaVars.location_);
       ncFile.getVar("Sigma_SSS_corr").getVar(sss_error.data());
 
-      std::vector< uint16_t > sss_qc(iodaVars.location);
+      std::vector< uint16_t > sss_qc(iodaVars.location_);
       ncFile.getVar("Dg_quality_SSS_corr").getVar(sss_qc.data());
 
       // according to https://earth.esa.int/eogateway/documents/20142/0/SMOS-L2-Aux-Data-Product-Specification.pdf,
       // this is UTC decimal days after MJD2000 which is
       // Jan 01 2000 00:00:00 GMT+0000
-      std::vector<float> datetime(iodaVars.location);
-      ncFile.getVar("Mean_acq_time").getVar(datetime.data());
+      std::vector<float> datetime_(iodaVars.location_);
+      ncFile.getVar("Mean_acq_time").getVar(datetime_.data());
 
-      iodaVars.referenceDate = "seconds since 1970-01-01T00:00:00Z";
+      iodaVars.referenceDate_ = "seconds since 1970-01-01T00:00:00Z";
 
       // unix epoch (seconds after iodaVars.referenceDate) at
       // Jan 01 2000 00:00:00 GMT+0000
       const int mjd2000 = 946684800;
 
       // TODO(AFE) maybe use Eigen Maps here
-      for (int i = 0; i < iodaVars.location; i++) {
-        iodaVars.longitude(i) = lon[i];
-        iodaVars.latitude(i) = lat[i];
-        iodaVars.obsVal(i) = sss[i];
-        iodaVars.obsError(i) = sss_error[i];
-        iodaVars.preQc(i) = sss_qc[i];
-        iodaVars.datetime(i) =  static_cast<int64_t>(datetime[i]*86400.0f) + mjd2000;
+      for (int i = 0; i < iodaVars.location_; i++) {
+        iodaVars.longitude_(i) = lon[i];
+        iodaVars.latitude_(i) = lat[i];
+        iodaVars.obsVal_(i) = sss[i];
+        iodaVars.obsError_(i) = sss_error[i];
+        iodaVars.preQc_(i) = sss_qc[i];
+        iodaVars.datetime_(i) =  static_cast<int64_t>(datetime_[i]*86400.0f) + mjd2000;
       }
 
       // basic test for iodaVars.trim
-      Eigen::Array<bool, Eigen::Dynamic, 1> mask = (iodaVars.obsVal > 0.0);
+      Eigen::Array<bool, Eigen::Dynamic, 1> mask = (iodaVars.obsVal_ > 0.0);
       iodaVars.trim(mask);
 
       return iodaVars;


### PR DESCRIPTION
All `IodaVars` class member variable names `varName` and references changed to `varName_` to reflect convention. `this->` removed where present.

Tested with gdas-util ctests on Hera.

Addresses https://github.com/NOAA-EMC/GDASApp/issues/669


