### PR TITLE
Add global attributes to IODA conversion output files

### DIFF
--- a/utils/obsproc/NetCDFToIodaConverter.h
+++ b/utils/obsproc/NetCDFToIodaConverter.h
@@ -25,7 +25,6 @@ namespace gdasapp {
                        // for now in the children classes
     int nfMetadata_;    // number of float metadata fields
     int niMetadata_;    // number of int metadata fields
-    int nsGlobalAttr_;  // number of str global attribute fields
 
     // Non optional metadata
     Eigen::ArrayXf longitude_;  // geo-location_
@@ -45,8 +44,7 @@ namespace gdasapp {
     std::vector<std::string> intMetadataName_;    // String descriptor of the integer metadata
 
     // Optional global attributes
-    Eigen::Array<std::string, Eigen::Dynamic, 1> strGlobalAttr_;
-    std::vector<std::string> strGlobalAttrName_;  // String descriptor of the float metadata
+    std::map<std::string, std::string> strGlobalAttr_;
 
     // Constructor
     explicit IodaVars(const int nobs = 0,
@@ -61,11 +59,10 @@ namespace gdasapp {
       floatMetadata_(location_, fmnames.size()),
       floatMetadataName_(fmnames),
       intMetadata_(location_, imnames.size()),
-      intMetadataName_(imnames),
-      strGlobalAttrName_(sganames)
-    {
-      oops::Log::trace() << "IodaVars::IodaVars created." << std::endl;
-    }
+      intMetadataName_(imnames)
+      { 
+        oops::Log::trace() << "IodaVars::IodaVars created." << std::endl;
+      }
 
     // Append an other instance of IodaVars
     void append(const IodaVars& other) {
@@ -240,7 +237,13 @@ namespace gdasapp {
           ogrp.vars.createWithScales<int>("PreQC/"+variable_,
                                             {ogrp.vars["Location"]}, int_params);
 
+        // add input filenames to IODA file global attributes
         ogrp.atts.add<std::string>("obs_source_files", inputFilenames_);
+
+        for (const auto& globalAttr : iodaVars.strGlobalAttr_) {
+          ogrp.atts.add<std::string>(globalAttr.first , globalAttr.second);
+        }
+
 
         // Create the optional IODA integer metadata
         ioda::Variable tmpIntMeta;

--- a/utils/obsproc/NetCDFToIodaConverter.h
+++ b/utils/obsproc/NetCDFToIodaConverter.h
@@ -25,6 +25,7 @@ namespace gdasapp {
                        // for now in the children classes
     int nfMetadata_;    // number of float metadata fields
     int niMetadata_;    // number of int metadata fields
+    int nsGlobalAttr_;  // number of str global attribute fields
 
     // Non optional metadata
     Eigen::ArrayXf longitude_;  // geo-location_
@@ -43,10 +44,15 @@ namespace gdasapp {
     Eigen::ArrayXXf intMetadata_;                  // Optional array of integer metadata
     std::vector<std::string> intMetadataName_;    // String descriptor of the integer metadata
 
+    // Optional global attributes
+    Eigen::Array<std::string, Eigen::Dynamic, 1> strGlobalAttr_;
+    std::vector<std::string> strGlobalAttrName_;  // String descriptor of the float metadata
+
     // Constructor
     explicit IodaVars(const int nobs = 0,
                       const std::vector<std::string> fmnames = {},
-                      const std::vector<std::string> imnames = {}) :
+                      const std::vector<std::string> imnames = {},
+                      const std::vector<std::string> sganames = {}) :
       location_(nobs), nVars_(1), nfMetadata_(fmnames.size()), niMetadata_(imnames.size()),
       longitude_(location_), latitude_(location_), datetime_(location_),
       obsVal_(location_),
@@ -55,7 +61,8 @@ namespace gdasapp {
       floatMetadata_(location_, fmnames.size()),
       floatMetadataName_(fmnames),
       intMetadata_(location_, imnames.size()),
-      intMetadataName_(imnames)
+      intMetadataName_(imnames),
+      strGlobalAttrName_(sganames)
     {
       oops::Log::trace() << "IodaVars::IodaVars created." << std::endl;
     }
@@ -233,6 +240,8 @@ namespace gdasapp {
           ogrp.vars.createWithScales<int>("PreQC/"+variable_,
                                             {ogrp.vars["Location"]}, int_params);
 
+        ogrp.atts.add<std::string>("obs_source_files", inputFilenames_);
+
         // Create the optional IODA integer metadata
         ioda::Variable tmpIntMeta;
         int count = 0;
@@ -254,7 +263,7 @@ namespace gdasapp {
         }
 
         // Write obs info to group
-        oops::Log::info() << "Writting ioda file" << std::endl;
+        oops::Log::info() << "Writing ioda file" << std::endl;
         iodaLon.writeWithEigenRegular(iodaVarsAll.longitude_);
         iodaLat.writeWithEigenRegular(iodaVarsAll.latitude_);
         iodaDatetime.writeWithEigenRegular(iodaVarsAll.datetime_);

--- a/utils/obsproc/NetCDFToIodaConverter.h
+++ b/utils/obsproc/NetCDFToIodaConverter.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <iostream>
+#include <map>
 #include <string>
 #include <vector>
 
@@ -49,8 +50,7 @@ namespace gdasapp {
     // Constructor
     explicit IodaVars(const int nobs = 0,
                       const std::vector<std::string> fmnames = {},
-                      const std::vector<std::string> imnames = {},
-                      const std::vector<std::string> sganames = {}) :
+                      const std::vector<std::string> imnames = {}) :
       location_(nobs), nVars_(1), nfMetadata_(fmnames.size()), niMetadata_(imnames.size()),
       longitude_(location_), latitude_(location_), datetime_(location_),
       obsVal_(location_),
@@ -60,9 +60,9 @@ namespace gdasapp {
       floatMetadataName_(fmnames),
       intMetadata_(location_, imnames.size()),
       intMetadataName_(imnames)
-      { 
-        oops::Log::trace() << "IodaVars::IodaVars created." << std::endl;
-      }
+    {
+      oops::Log::trace() << "IodaVars::IodaVars created." << std::endl;
+    }
 
     // Append an other instance of IodaVars
     void append(const IodaVars& other) {
@@ -240,10 +240,10 @@ namespace gdasapp {
         // add input filenames to IODA file global attributes
         ogrp.atts.add<std::string>("obs_source_files", inputFilenames_);
 
+        // add global attributes collected from the specific converter
         for (const auto& globalAttr : iodaVars.strGlobalAttr_) {
           ogrp.atts.add<std::string>(globalAttr.first , globalAttr.second);
         }
-
 
         // Create the optional IODA integer metadata
         ioda::Variable tmpIntMeta;

--- a/utils/obsproc/Rads2Ioda.h
+++ b/utils/obsproc/Rads2Ioda.h
@@ -66,17 +66,22 @@ namespace gdasapp {
       altimeterMap["JASON-3"] = 5;
       altimeterMap["CRYOSAT2"] = 6;
       altimeterMap["SARAL"] = 7;
- 
+
       // Read optional integer metadata "mission"
       std::string mission_name;
       ncFile.getAtt("mission_name").getValues(mission_name);
       int mission_index = altimeterMap[mission_name];   // mission name mapped to integer
 
+      // convert mission map to string to add to global attributes
       std::stringstream mapStr;
       for (const auto& mapEntry : altimeterMap) {
-        mapStr << mapEntry.first << " = " << mapEntry.second << " : " ;
+        mapStr << mapEntry.first << " = " << mapEntry.second << " ";
       }
       iodaVars.strGlobalAttr_["mission_index"] = mapStr.str();
+
+      std::string references;
+      ncFile.getAtt("references").getValues(references);
+      iodaVars.strGlobalAttr_["references"] = references;
 
       // Read optional integer metadata "pass" and "cycle"
       int pass[iodaVars.location_];  // NOLINT

--- a/utils/obsproc/Rads2Ioda.h
+++ b/utils/obsproc/Rads2Ioda.h
@@ -40,11 +40,8 @@ namespace gdasapp {
       // Set the float metadata name
       std::vector<std::string> floatMetadataNames = {"mdt"};
 
-      // Set the float metadata name
-      std::vector<std::string> strGlobalAttrNames = {"testing"};
-
       // Create instance of iodaVars object
-      gdasapp::IodaVars iodaVars(nobs, floatMetadataNames, intMetadataNames, strGlobalAttrNames);
+      gdasapp::IodaVars iodaVars(nobs, floatMetadataNames, intMetadataNames);
 
       // Read non-optional metadata: datetime, longitude and latitude
       int lat[iodaVars.location_];  // NOLINT
@@ -60,10 +57,26 @@ namespace gdasapp {
       ncFile.getVar("time_mjd").getVar(datetime);
       iodaVars.referenceDate_ = "seconds since 1858-11-17T00:00:00Z";
 
+      std::map<std::string, int> altimeterMap;
+      // TODO(All): This is incomplete, add missions to the list below
+      altimeterMap["SNTNL-3A"] = 1;
+      altimeterMap["SNTNL-3B"] = 2;
+      altimeterMap["JASON-1"] = 3;
+      altimeterMap["JASON-2"] = 4;
+      altimeterMap["JASON-3"] = 5;
+      altimeterMap["CRYOSAT2"] = 6;
+      altimeterMap["SARAL"] = 7;
+ 
       // Read optional integer metadata "mission"
       std::string mission_name;
       ncFile.getAtt("mission_name").getValues(mission_name);
-      int mission_index = altimeterMissions(mission_name);   // mission name mapped to integer
+      int mission_index = altimeterMap[mission_name];   // mission name mapped to integer
+
+      std::stringstream mapStr;
+      for (const auto& mapEntry : altimeterMap) {
+        mapStr << mapEntry.first << " = " << mapEntry.second << " : " ;
+      }
+      iodaVars.strGlobalAttr_["mission_index"] = mapStr.str();
 
       // Read optional integer metadata "pass" and "cycle"
       int pass[iodaVars.location_];  // NOLINT
@@ -99,18 +112,5 @@ namespace gdasapp {
       }
       return iodaVars;
     };
-    int altimeterMissions(std::string missionName) {
-      std::map<std::string, int> altimeterMap;
-      // TODO(All): This is incomplete, add missions to the list below
-      //            and add to global attribute
-      altimeterMap["SNTNL-3A"] = 1;
-      altimeterMap["SNTNL-3B"] = 2;
-      altimeterMap["JASON-1"] = 3;
-      altimeterMap["JASON-2"] = 4;
-      altimeterMap["JASON-3"] = 5;
-      altimeterMap["CRYOSAT2"] = 6;
-      altimeterMap["SARAL"] = 7;
-      return altimeterMap[missionName];
-    }
   };  // class Rads2Ioda
 }  // namespace gdasapp

--- a/utils/obsproc/Rads2Ioda.h
+++ b/utils/obsproc/Rads2Ioda.h
@@ -40,8 +40,11 @@ namespace gdasapp {
       // Set the float metadata name
       std::vector<std::string> floatMetadataNames = {"mdt"};
 
+      // Set the float metadata name
+      std::vector<std::string> strGlobalAttrNames = {"testing"};
+
       // Create instance of iodaVars object
-      gdasapp::IodaVars iodaVars(nobs, floatMetadataNames, intMetadataNames);
+      gdasapp::IodaVars iodaVars(nobs, floatMetadataNames, intMetadataNames, strGlobalAttrNames);
 
       // Read non-optional metadata: datetime, longitude and latitude
       int lat[iodaVars.location_];  // NOLINT


### PR DESCRIPTION
- Adds facility for global attributes to IODA converters
- Adds input observation source files as global attribute to all converts
- Adds to the rads converter attribute with mission-to-mission-number-index (to decode mission index associated with individual observations
- Adds lit reference to rads converter (to show off reading from attributes in originating file)

In the process of this the function in the rads converter that assigned the mission numbers was removed and the map declaration and assignment moved to the converter method to allow access to the map to convert to a string. Am open to other ways to approach this.

Resolves https://github.com/NOAA-EMC/GDASApp/issues/685