### PR TITLE
Add Obs. trimming function to IODA converter of icec and sss_smap

### DIFF
--- a/utils/obsproc/IcecAmsr2Ioda.h
+++ b/utils/obsproc/IcecAmsr2Ioda.h
@@ -84,10 +84,15 @@ namespace gdasapp {
       for (int i = 0; i < iodaVars.location_; i++) {
         iodaVars.longitude_(i) = oneDimLonVal[i];
         iodaVars.latitude_(i) = oneDimLatVal[i];
-        iodaVars.obsVal_(i) = static_cast<int64_t>(oneDimObsVal[i]*0.01);
+        iodaVars.obsVal_(i) = static_cast<float>(oneDimObsVal[i]*0.01);
         iodaVars.obsError_(i) = 0.1;  // Do something for obs error
         iodaVars.preQc_(i) = oneDimFlagsVal[i];
       }
+
+      // basic test for iodaVars.trim
+      Eigen::Array<bool, Eigen::Dynamic, 1> mask = (iodaVars.obsVal_ >= 0.0);
+      iodaVars.trim(mask);
+
       return iodaVars;
     };
   };  // class IcecAmsr2Ioda

--- a/utils/obsproc/Smap2Ioda.h
+++ b/utils/obsproc/Smap2Ioda.h
@@ -90,6 +90,11 @@ namespace gdasapp {
           iodaVars.datetime_(loc) =  static_cast<int64_t>(obsTime[j] + unixStartDay);
         }
       }
+
+      // basic test for iodaVars.trim
+      Eigen::Array<bool, Eigen::Dynamic, 1> mask = (iodaVars.obsVal_ > 0.0);
+      iodaVars.trim(mask);
+
       return iodaVars;
     };
   };  // class Smap2Ioda


### PR DESCRIPTION
- Adds the basic trim function to icec_amsr2 and sss_smap
- Excludes ioda converter for adt_rads

Closes to https://github.com/NOAA-EMC/GDASApp/issues/682