### PR TITLE
Fix issues on hera with test data

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,9 @@ if(BUILD_GDASBUNDLE)
   ecbuild_bundle( PROJECT oops  GIT "https://github.com/jcsda/oops.git"  BRANCH develop)
   ecbuild_bundle( PROJECT vader GIT "https://github.com/jcsda/vader.git" BRANCH develop )
   ecbuild_bundle( PROJECT saber GIT "https://github.com/jcsda/saber.git" BRANCH develop )
+  option(ENABLE_IODA_DATA "Obtain ioda test data from ioda-data repository (vs tarball)" ON)
   ecbuild_bundle( PROJECT ioda  GIT "https://github.com/jcsda/ioda.git" BRANCH develop  )
+  option(ENABLE_UFO_DATA "Obtain ufo test data from ufo-data repository (vs tarball)" ON)
   ecbuild_bundle( PROJECT ufo   GIT "https://github.com/jcsda/ufo.git" BRANCH develop )
 
 # FMS and FV3 dynamical core
@@ -87,6 +89,7 @@ if(BUILD_GDASBUNDLE)
 # fv3-jedi and associated repositories
   ecbuild_bundle( PROJECT femps       GIT "https://github.com/jcsda/femps.git"                BRANCH develop )
   ecbuild_bundle( PROJECT fv3-jedi-lm GIT "https://github.com/jcsda/fv3-jedi-linearmodel.git" BRANCH develop )
+  option(ENABLE_FV3_JEDI_DATA "Obtain fv3-jedi test data from fv3-jedi-data repository (vs tarball)" ON)
   ecbuild_bundle( PROJECT fv3-jedi    GIT "https://github.com/jcsda/fv3-jedi.git"             BRANCH develop )
 
 # SOCA associated repositories

--- a/build.sh
+++ b/build.sh
@@ -101,6 +101,12 @@ mkdir -p ${BUILD_DIR} && cd ${BUILD_DIR}
 WORKFLOW_BUILD=${WORKFLOW_BUILD:-"OFF"}
 CMAKE_OPTS+=" -DWORKFLOW_TESTS=${WORKFLOW_BUILD}"
 
+# JCSDA changed test data things, need to make a dummy CRTM directory
+if [[ $BUILD_TARGET == 'hera' ]]; then
+  mkdir -p $dir_root/test-data-release/
+  ln -sf $GDASAPP_TESTDATA/crtm $dir_root/test-data-release/crtm
+fi
+
 # Configure
 echo "Configuring ..."
 set -x


### PR DESCRIPTION
JCSDA changed the logic by which test data is downloaded.

First, new top level CMake flags have to be added, else it will try to download tarballs rather than use the cloned repos.
Second, CRTM has no choice, if they are not already available, the code will try to download a tarball.
These tarballs are currently unavailable from Hera, as the host server is blocked. The logic should work fine on other machines though.

This PR fixes this on Hera but including the CMake flags for all platforms, and staging/linking the CRTM coefficients from a place I have them already installed on Hera.