### PR TITLE
generalize layout for reading GSI static-B

### DIFF
--- a/parm/atm/berror/hybvar_gsibec.yaml
+++ b/parm/atm/berror/hybvar_gsibec.yaml
@@ -9,8 +9,8 @@ components:
         gsi error covariance file: &gsiberr $(DATA)/berror/gsi-coeffs-gfs-global.nc4
 #       gsi error covariance file: &gsiberr $(DATA)/berror/global_berror.f77
         gsi berror namelist file: &gsibnml $(DATA)/berror/gfs_gsi_global.nml
-        processor layout x direction: &layout_gsib_x 3
-        processor layout y direction: &layout_gsib_y 2
+        processor layout x direction: &layout_gsib_x $(layout_gsib_x)
+        processor layout y direction: &layout_gsib_y $(layout_gsib_y)
         debugging mode: false
     saber outer blocks:
     - saber block name: gsi interpolation to model grid

--- a/parm/atm/berror/staticb_gsibec.yaml
+++ b/parm/atm/berror/staticb_gsibec.yaml
@@ -7,8 +7,8 @@ saber central block:
     gsi error covariance file: &gsiberr $(DATA)/berror/gsi-coeffs-gfs-global.nc4
 #   gsi error covariance file: &gsiberr $(DATA)/berror/global_berror.f77
     gsi berror namelist file: &gsibnml $(DATA)/berror/gfs_gsi_global.nml
-    processor layout x direction: &layout_gsib_x 3
-    processor layout y direction: &layout_gsib_y 2
+    processor layout x direction: &layout_gsib_x $(layout_gsib_x)
+    processor layout y direction: &layout_gsib_y $(layout_gsib_y)
     debugging mode: false
 saber outer blocks:
 - saber block name: gsi interpolation to model grid


### PR DESCRIPTION
This PR replaces the hardwired {3,2} layout for reading the GSI static-B with variables {`layout_gsib_x`, `layout_gsib_y`}.   Modifications are made to g-w `config.resources` to set the new variables. 

Fixes #680
Depends on g-w issue [#1936](https://github.com/NOAA-EMC/global-workflow/issues/1936) 