### PR TITLE
Add a marine obs list that points to obs available on hpc

### DIFF
--- a/parm/soca/obs/obs_list.yaml
+++ b/parm/soca/obs/obs_list.yaml
@@ -1,8 +1,15 @@
 observers:
 - !INC ${OBS_YAML_DIR}/adt_all.yaml
-- !INC ${OBS_YAML_DIR}/adt_j3.yaml
-- !INC ${OBS_YAML_DIR}/adt_j2.yaml
-#- !INC ${OBS_YAML_DIR}/salt_profile_fnmoc.yaml
-- !INC ${OBS_YAML_DIR}/sss_smap.yaml
-- !INC ${OBS_YAML_DIR}/sst_noaa19_l3u.yaml
-- !INC ${OBS_YAML_DIR}/icec_emc.yaml
+- !INC ${OBS_YAML_DIR}/adt_j3_egm2008.yaml
+- !INC ${OBS_YAML_DIR}/adt_3a_egm2008.yaml
+- !INC ${OBS_YAML_DIR}/adt_3b_egm2008.yaml
+- !INC ${OBS_YAML_DIR}/adt_c2_egm2008.yaml
+- !INC ${OBS_YAML_DIR}/adt_sa_egm2008.yaml
+- !INC ${OBS_YAML_DIR}/sst_viirs_npp_l3u_so025.yaml
+#- !INC ${OBS_YAML_DIR}/sst_metopa_l3u_so025.yaml
+#- !INC ${OBS_YAML_DIR}/sst_metopb_l3u_so025.yaml
+#- !INC ${OBS_YAML_DIR}/sst_metopc_l3u_so025.yaml
+- !INC ${OBS_YAML_DIR}/icec_ssmis_f17_north.yaml
+#- !INC ${OBS_YAML_DIR}/icec_ssmis_f17_south.yaml
+#- !INC ${OBS_YAML_DIR}/icec_ssmis_f18_north.yaml
+- !INC ${OBS_YAML_DIR}/icec_ssmis_f18_south.yaml

--- a/parm/soca/obs/obs_list_small.yaml
+++ b/parm/soca/obs/obs_list_small.yaml
@@ -1,0 +1,8 @@
+observers:
+- !INC ${OBS_YAML_DIR}/adt_all.yaml
+- !INC ${OBS_YAML_DIR}/adt_j3.yaml
+- !INC ${OBS_YAML_DIR}/adt_j2.yaml
+#- !INC ${OBS_YAML_DIR}/salt_profile_fnmoc.yaml
+- !INC ${OBS_YAML_DIR}/sss_smap.yaml
+- !INC ${OBS_YAML_DIR}/sst_noaa19_l3u.yaml
+- !INC ${OBS_YAML_DIR}/icec_emc.yaml

--- a/test/soca/CMakeLists.txt
+++ b/test/soca/CMakeLists.txt
@@ -44,7 +44,7 @@ file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/test/soca/testinput)
 
 # list of test input files to install
 list(APPEND test_input
-  ${PROJECT_SOURCE_DIR}/parm/soca/obs/obs_list.yaml
+  ${PROJECT_SOURCE_DIR}/parm/soca/obs/obs_list_small.yaml
   ${PROJECT_SOURCE_DIR}/test/soca/testinput/dumy.yaml
   )
 

--- a/test/soca/gw/run_jjobs.yaml.test
+++ b/test/soca/gw/run_jjobs.yaml.test
@@ -43,7 +43,7 @@ setup_expt config:
   ocnanal:
     SOCA_INPUT_FIX_DIR: @HOMEgfs@/sorc/gdas.cd/build/soca_static
     CASE_ANL: C48
-    SOCA_OBS_LIST: @HOMEgfs@/sorc/gdas.cd/parm/soca/obs/obs_list.yaml
+    SOCA_OBS_LIST: @HOMEgfs@/sorc/gdas.cd/parm/soca/obs/obs_list_small.yaml
     COMIN_OBS: @HOMEgfs@/sorc/gdas.cd/build/test/soca/obs/r2d2-shared
     SOCA_NINNER: 1
     R2D2_OBS_SRC: gdasapp


### PR DESCRIPTION
What was done:
- renamed the old `obs_list.yaml`, `obs_list_small.yaml`. That list is pointing to tiny files that we generate in the ctests
- add a list that will allow making use of observations currently staged in the R2D2 data base on Orion and Hera

Needed for [global-workflow/pull/1963](https://github.com/NOAA-EMC/global-workflow/pull/1963)