### PR TITLE
Add gdas-utils symlink to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,4 @@ test-data-release/
 ufo/
 ufo-data/
 vader/
+/gdas-utils


### PR DESCRIPTION
A handsome genius (@guillaumevernieres) added this as a symlink from the utils/ directory, but if you are working in the repository after building, this will show up and potentially cause problems. This fixes that (hopefully).