### PR TITLE
Add functionality to locally change the weights used for the hybrid B

### DIFF
--- a/parm/soca/berror/soca_ensb.yaml
+++ b/parm/soca/berror/soca_ensb.yaml
@@ -30,6 +30,12 @@ steric height:
   linear variable changes:
   - linear variable change name: BalanceSOCA  # Only the steric balance is applied
 
+ensemble mean output:
+  datadir: ./static_ens
+  date: '{{ATM_WINDOW_BEGIN}}'
+  exp: ens_mean
+  type: incr
+
 ssh output:
   unbalanced:
     datadir: ./static_ens

--- a/parm/soca/berror/soca_ensweights.yaml
+++ b/parm/soca/berror/soca_ensweights.yaml
@@ -21,14 +21,14 @@ weights:
   ocean: 0.0625   # 25%      "       "
   # Apply localized weights to the ocean ens. B
   ocean local weights:
-  - lon: -200.0
-    lat: 10.0
+  - lon: -172.0
+    lat: 11.0
     amplitude: -1.0
-    length scale: 5000.0
-  - lon: -100.0
-    lat: 10.0
+    length scale: 700.0
+  - lon: -160.0
+    lat: 12.0
     amplitude: -1.0
-    length scale: 5000.0
+    length scale: 700.0
 
 output:
   datadir: ./

--- a/parm/soca/berror/soca_ensweights.yaml
+++ b/parm/soca/berror/soca_ensweights.yaml
@@ -19,6 +19,16 @@ weights:
   # Need to provide weights^2 when reading from file
   ice: 0.0025   #  5% of original variance
   ocean: 0.0625   # 25%      "       "
+  # Apply localized weights to the ocean ens. B
+  ocean local weights:
+  - lon: -200.0
+    lat: 10.0
+    amplitude: -1.0
+    length scale: 5000.0
+  - lon: -100.0
+    lat: 10.0
+    amplitude: -1.0
+    length scale: 5000.0
 
 output:
   datadir: ./

--- a/test/soca/testinput/socahybridweights.yaml
+++ b/test/soca/testinput/socahybridweights.yaml
@@ -16,8 +16,19 @@ background:
   read_from_file: 1
 
 weights:
-  ice: 0.1
-  ocean: 0.5
+  # Need to provide weights^2 when reading from file
+  ice: 0.0025   #  5% of original variance
+  ocean: 0.0625   # 25%      "       "
+  # Apply localized weights to the ocean ens. B
+  ocean local weights:
+  - lon: -172.0
+    lat: 11.0
+    amplitude: -1.0
+    length scale: 700.0
+  - lon: -160.0
+    lat: 12.0
+    amplitude: -1.0
+    length scale: 700.0
 
 output:
   datadir: ./

--- a/utils/soca/gdas_ens_handler.h
+++ b/utils/soca/gdas_ens_handler.h
@@ -104,6 +104,10 @@ namespace gdasapp {
       gdasapp_ens_utils::ensMoments(ensMembers, ensMean, ensStd, ensVariance);
       oops::Log::info() << "mean: " << ensMean << std::endl;
       oops::Log::info() << "std: " << ensStd << std::endl;
+      if ( fullConfig.has("ensemble mean output") ) {
+        const eckit::LocalConfiguration ensMeanOutputConfig(fullConfig, "ensemble mean output");
+        ensMean.write(ensMeanOutputConfig);
+      }
 
       // Remove mean from ensemble members
       for (size_t i = 0; i < postProcIncr.ensSize_; ++i) {
@@ -115,6 +119,7 @@ namespace gdasapp {
       eckit::LocalConfiguration stericVarChangeConfig;
       fullConfig.get("steric height", stericVarChangeConfig);
       oops::Log::info() << "steric config 0000: " << stericVarChangeConfig << std::endl;
+
       // Initialize trajectories
       const eckit::LocalConfiguration trajConfig(fullConfig, "trajectory");
       soca::State cycleTraj(geom, trajConfig);  // trajectory of the cycle
@@ -148,7 +153,7 @@ namespace gdasapp {
         soca::Increment incr = postProcIncr.appendLayer(ensMembers[i]);
 
         // Save total ssh
-        oops::Log::info() << "ssh ensemble memnber "  << i << std::endl;
+        oops::Log::info() << "ssh ensemble member "  << i << std::endl;
         soca::Increment ssh_tmp(geom, socaSshVar, postProcIncr.dt_);
         ssh_tmp = ensMembers[i];
         sshTotal.push_back(ssh_tmp);
@@ -186,14 +191,14 @@ namespace gdasapp {
 
         // Add the unbalanced ssh to the recentered perturbation
         // this assumes ssh_u is independent of the trajectory
-        oops::Log::info() << "&&&&& before adding ssh_u " << incr << std::endl;
+        oops::Log::debug() << "&&&&& before adding ssh_u " << incr << std::endl;
         atlas::FieldSet incrFs;
         incr.toFieldSet(incrFs);
         atlas::FieldSet sshNonStericFs;
         sshNonSteric[i].toFieldSet(sshNonStericFs);
         util::addFieldSets(incrFs, sshNonStericFs);
         incr.fromFieldSet(incrFs);
-        oops::Log::info() << "&&&&& after adding ssh_u " << incr << std::endl;
+        oops::Log::debug() << "&&&&& after adding ssh_u " << incr << std::endl;
 
         // Save final perturbation, used in the offline EnVAR
         result = postProcIncr.save(incr, i+1);

--- a/utils/soca/gdas_socahybridweights.h
+++ b/utils/soca/gdas_socahybridweights.h
@@ -45,7 +45,7 @@ namespace gdasapp {
 
       // Recompute weights
       for (auto & field : gaussIncrFs) {
-        std::cout << "---------- Field name: " << field.name() << std::endl;
+        oops::Log::info() << "---------- Field name: " << field.name() << std::endl;
         auto view = atlas::array::make_view<double, 2>(field);
         for (int jnode = 0; jnode < field.shape(0); ++jnode) {
           atlas::PointLonLat p1(lons[jnode], lats[jnode]);
@@ -107,7 +107,7 @@ namespace gdasapp {
       soca::Increment socaOcnHW(geom, socaOcnVars, dt);
       socaOcnHW.ones();
 
-      // Apply localized gaussians to the weights
+      /// Apply localized gaussians to the weights
       eckit::LocalConfiguration localWeightsConfigs(fullConfig, "weights.ocean local weights");
       std::vector<eckit::LocalConfiguration> localWeightsList =
         localWeightsConfigs.getSubConfigurations();

--- a/utils/soca/gdas_socahybridweights.h
+++ b/utils/soca/gdas_socahybridweights.h
@@ -3,12 +3,17 @@
 #include <filesystem>
 #include <iostream>
 #include <string>
+#include <vector>
 
 #include "eckit/config/LocalConfiguration.h"
 
 #include "atlas/field.h"
+#include "atlas/util/Earth.h"
+#include "atlas/util/Geometry.h"
+#include "atlas/util/Point.h"
 
 #include "oops/base/PostProcessor.h"
+#include "oops/generic/gc99.h"
 #include "oops/mpi/mpi.h"
 #include "oops/runs/Application.h"
 #include "oops/util/DateTime.h"
@@ -20,6 +25,38 @@
 #include "soca/State/State.h"
 
 namespace gdasapp {
+  // Create a simple mask based on a Gaussian function
+  void gaussianMask(const soca::Geometry & geom, soca::Increment & gaussIncr,
+                    eckit::LocalConfiguration conf) {
+      // Get the 2D grid
+      std::vector<double> lats;
+      std::vector<double> lons;
+      bool halo = true;
+      geom.latlon(lats, lons, halo);
+
+      // Prepare fieldset from increment
+      atlas::FieldSet gaussIncrFs;
+      gaussIncr.toFieldSet(gaussIncrFs);
+
+      // Get the GC99 parameters from config
+      double amp = conf.getDouble("amplitude");
+      double scale = conf.getDouble("length scale");
+      const atlas::PointLonLat p0(conf.getDouble("lon"), conf.getDouble("lat"));
+
+      // Recompute weights
+      for (auto & field : gaussIncrFs) {
+        std::cout << "---------- Field name: " << field.name() << std::endl;
+        auto view = atlas::array::make_view<double, 2>(field);
+        for (int jnode = 0; jnode < field.shape(0); ++jnode) {
+          atlas::PointLonLat p1(lons[jnode], lats[jnode]);
+          double d = atlas::util::Earth::distance(p0, p1)/1000.0;
+          for (int jlevel = 0; jlevel < field.shape(1); ++jlevel) {
+            view(jnode, jlevel) += amp * oops::gc99(d/scale);
+          }
+        }
+      }
+      gaussIncr.fromFieldSet(gaussIncrFs);
+  }
 
   class SocaHybridWeights : public oops::Application {
    public:
@@ -45,8 +82,7 @@ namespace gdasapp {
       socaVars += socaOcnVars;
 
       /// Read the background
-      // TODO(guillaume): Use the ice extent to set the weights ... no clue if this is
-      //       possible at this level
+      // TODO(guillaume): Use the ice extent to set the weights
       soca::State socaBkg(geom, socaVars, dt);
       const eckit::LocalConfiguration socaBkgConfig(fullConfig, "background");
       socaBkg.read(socaBkgConfig);
@@ -70,6 +106,17 @@ namespace gdasapp {
       /// Create fields of weights for the ocean
       soca::Increment socaOcnHW(geom, socaOcnVars, dt);
       socaOcnHW.ones();
+
+      // Apply localized gaussians to the weights
+      eckit::LocalConfiguration localWeightsConfigs(fullConfig, "weights.ocean local weights");
+      std::vector<eckit::LocalConfiguration> localWeightsList =
+        localWeightsConfigs.getSubConfigurations();
+      for (auto & conf : localWeightsList) {
+        gaussianMask(geom, socaOcnHW, conf);
+        oops::Log::info() << "Local weights for socaOcnHW: " << std::endl << conf << std::endl;
+        oops::Log::info() << socaOcnHW << std::endl;
+      }
+
       socaOcnHW *= wOcean;
       oops::Log::info() << "socaOcnHW: " << std::endl << socaOcnHW << std::endl;
       socaOcnHW.write(socaHWOutConfig);


### PR DESCRIPTION
#### Description
Short of figuring out a systematic way of locally  QC'ing the ensemble B, this PR add some functionality to "manually" mask out problematic regions.

#### What was done
- Optionally save the ensemble mean, currently just used for debugging
- Allow passing a list of parameters for masks based on a gc99 horizontal function. It's currently applied over the entire water column.