### PR TITLE
Fix the failing test_gdasapp_land_letkfoi_snowda

### DIFF
--- a/test/land/letkfoi_land.yaml
+++ b/test/land/letkfoi_land.yaml
@@ -64,7 +64,7 @@ observations:
       where:
       - minvalue: '-999.0'
         variable:
-          name: MetaData/height
+          name: MetaData/stationElevation
     - filter: Domain Check
       where:
       - maxvalue: '1.5'


### PR DESCRIPTION
The failing test_gdasapp_land_letkfoi_snowda was caused by the recent updates by changing the `MetaData/height` to `MetaData/stationElevation`. 

I regenerated the observation file to include `MetaData/stationElevation`. Please (on hera) replace the following snow obs data: 

`/scratch1/NCEPDEV/da/Cory.R.Martin/CI/GDASApp/data/land/snow_depth/GTS/202103/adpsfc_snow_2021032318.nc4`
WITH:
`/scratch1/NCEPDEV/global/Jiarui.Dong/JEDI/task/T2B/bufr2ioda4/Data3/202103/adpsfc_snow_2021032318.nc4`

AND, please replace the snow observation data on orion as well. 

Partially resolves https://github.com/NOAA-EMC/GDASApp/issues/705