### PR TITLE
Optional binning of ghrsst

### DIFF
--- a/utils/obsproc/Ghrsst2Ioda.h
+++ b/utils/obsproc/Ghrsst2Ioda.h
@@ -149,16 +149,24 @@ namespace gdasapp {
 
       // TODO(Guillaume): check periodic BC, use sampling std dev of sst as a proxi for obs error
       //                  should the sst mean be weighted by the provided obs error?
-      std::vector<std::vector<float>> lon2d_s =
-        gdasapp::superobutils::subsample2D(lon2d, mask, fullConfig_);
-      std::vector<std::vector<float>> lat2d_s =
-        gdasapp::superobutils::subsample2D(lat2d, mask, fullConfig_);
-      std::vector<std::vector<float>> sst_s =
-        gdasapp::superobutils::subsample2D(sst, mask, fullConfig_);
-      std::vector<std::vector<float>> obserror_s =
-        gdasapp::superobutils::subsample2D(obserror, mask, fullConfig_);
-      std::vector<std::vector<float>> seconds_s =
-        gdasapp::superobutils::subsample2D(seconds, mask, fullConfig_);
+      std::vector<std::vector<float>> sst_s;
+      std::vector<std::vector<float>> lon2d_s;
+      std::vector<std::vector<float>> lat2d_s;
+      std::vector<std::vector<float>> obserror_s;
+      std::vector<std::vector<float>> seconds_s;
+      if ( fullConfig_.has("binning") ) {
+        sst_s = gdasapp::superobutils::subsample2D(sst, mask, fullConfig_);
+        lon2d_s = gdasapp::superobutils::subsample2D(lon2d, mask, fullConfig_);
+        lat2d_s = gdasapp::superobutils::subsample2D(lat2d, mask, fullConfig_);
+        obserror_s = gdasapp::superobutils::subsample2D(obserror, mask, fullConfig_);
+        seconds_s = gdasapp::superobutils::subsample2D(seconds, mask, fullConfig_);
+      } else {
+        sst_s = sst;
+        lon2d_s = lon2d;
+        lat2d_s = lat2d;
+        obserror_s = obserror;
+        seconds_s = seconds;
+      }
 
       // number of obs after subsampling
       int nobs = sst_s.size() * sst_s[0].size();

--- a/utils/obsproc/superob.h
+++ b/utils/obsproc/superob.h
@@ -35,6 +35,7 @@ namespace gdasapp {
         for (int j = 0; j < subsampledCols; ++j) {
           count = 0;
           sum = static_cast<T>(0);
+
           // Compute the average within the stride
           for (int si = 0; si < stride; ++si) {
             for (int sj = 0; sj < stride; ++sj) {
@@ -48,7 +49,7 @@ namespace gdasapp {
           }
 
           // Calculate the average and store it in the subsampled array
-          if ( count < 1 ) {
+          if ( count < minNumObs ) {
             subsampled[i][j] = static_cast<T>(-9999);
           } else {
             subsampled[i][j] = sum / static_cast<T>(count);


### PR DESCRIPTION
We can now remove the binning section in the `yaml`. This will skip the binning and just output the original file converted to ioda, which should help testing the code for correctness.

I'm also passing the ```min number of obs``` `yaml` key to the binning function, which I had forgotten to do!  

