### PR TITLE
Change yamls for goes amvs

### DIFF
--- a/parm/atm/obs/config/satwind_goes-16.yaml
+++ b/parm/atm/obs/config/satwind_goes-16.yaml
@@ -3,7 +3,7 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(DATA)/obs/$(OPREFIX)satwind.abi_goes-16.{{ current_cycle | to_YMDH }}.nc4
+      obsfile: $(DATA)/obs/$(OPREFIX)satwnd.abi_goes-16.tm00.nc
   obsdataout:
     engine:
       type: H5File

--- a/parm/atm/obs/config/satwind_goes-17.yaml
+++ b/parm/atm/obs/config/satwind_goes-17.yaml
@@ -3,7 +3,7 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(DATA)/obs/$(OPREFIX)satwind.abi_goes-17.{{ current_cycle | to_YMDH }}.nc4
+      obsfile: $(DATA)/obs/$(OPREFIX)satwnd.abi_goes-16.tm00.nc
   obsdataout:
     engine:
       type: H5File

--- a/parm/atm/obs/config/satwind_goes-17.yaml
+++ b/parm/atm/obs/config/satwind_goes-17.yaml
@@ -3,7 +3,7 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(DATA)/obs/$(OPREFIX)satwnd.abi_goes-16.tm00.nc
+      obsfile: $(DATA)/obs/$(OPREFIX)satwnd.abi_goes-17.tm00.nc
   obsdataout:
     engine:
       type: H5File


### PR DESCRIPTION
This PR makes the filenames that JEDI is looking for for GOES AMVs consistent with the files produced by the BUFR to IODA converter (hopefully)