### PR TITLE
Modify BUFR converter and filter yamls for GOES AMV

### DIFF
--- a/parm/atm/obs/config/satwind_goes-16.yaml
+++ b/parm/atm/obs/config/satwind_goes-16.yaml
@@ -17,6 +17,9 @@ obs operator:
   hofx scaling field: SurfaceWindScalingPressure
   hofx scaling field group: DerivedVariables
 
+linear obs operator:
+  name: VertInterp
+
 obs prior filters:
 # Apply variable changes needed for wind scaling
 # For wind observations with pressure provided

--- a/parm/atm/obs/config/satwind_goes-16.yaml
+++ b/parm/atm/obs/config/satwind_goes-16.yaml
@@ -184,7 +184,7 @@ obs post filters:
   - name: windEastward
   - name: windNorthward
   test variables:
-  - name: MetaData/sensorZenithAngle
+  - name: MetaData/satelliteZenithAngle
   maxvalue: 68.
   action:
     name: reject

--- a/parm/atm/obs/config/satwind_goes-17.yaml
+++ b/parm/atm/obs/config/satwind_goes-17.yaml
@@ -184,7 +184,7 @@ obs post filters:
   - name: windEastward
   - name: windNorthward
   test variables:
-  - name: MetaData/sensorZenithAngle
+  - name: MetaData/satelliteZenithAngle
   maxvalue: 68.
   action:
     name: reject

--- a/parm/atm/obs/config/satwind_goes-17.yaml
+++ b/parm/atm/obs/config/satwind_goes-17.yaml
@@ -17,6 +17,9 @@ obs operator:
   hofx scaling field: SurfaceWindScalingPressure
   hofx scaling field group: DerivedVariables
 
+obs linear operator:
+  name: VertInterp
+
 obs prior filters:
 # Apply variable changes needed for wind scaling
 # For wind observations with pressure provided

--- a/ush/ioda/bufr2ioda/bufr2ioda_satwind_amv_goes.py
+++ b/ush/ioda/bufr2ioda/bufr2ioda_satwind_amv_goes.py
@@ -124,7 +124,7 @@ def bufr_to_ioda(config, logger):
     q.add('hour', '*/HOUR')
     q.add('minute', '*/MINU')
     q.add('second', '*/SECO')
-    q.add('sensorZenithAngle', '*/SAZA')
+    q.add('satelliteZenithAngle', '*/SAZA')
     q.add('sensorCentralFrequency', '*/SCCF')
     q.add('pressure', '*/PRLC[1]')
 
@@ -173,7 +173,7 @@ def bufr_to_ioda(config, logger):
     second = r.get('second')
     lat = r.get('latitude')
     lon = r.get('longitude')
-    satzenang = r.get('sensorZenithAngle')
+    satzenang = r.get('satelliteZenithAngle')
     pressure = r.get('pressure', type='float')
     chanfreq = r.get('sensorCentralFrequency', type='float')
 
@@ -357,10 +357,10 @@ def bufr_to_ioda(config, logger):
                 .write_data(satid2)
 
             # Sensor Zenith Angle
-            obsspace.create_var('MetaData/sensorZenithAngle', dtype=satzenang2.dtype, fillval=satzenang2.fill_value) \
+            obsspace.create_var('MetaData/satelliteZenithAngle', dtype=satzenang2.dtype, fillval=satzenang2.fill_value) \
                 .write_attr('units', 'degree') \
                 .write_attr('valid_range', np.array([0, 90], dtype=np.float32)) \
-                .write_attr('long_name', 'Sensor Zenith Angle') \
+                .write_attr('long_name', 'Satellite Zenith Angle') \
                 .write_data(satzenang2)
 
             # Sensor Centrall Frequency
@@ -427,18 +427,6 @@ def bufr_to_ioda(config, logger):
                 .write_attr('units', 'm') \
                 .write_attr('long_name', 'Station Elevation') \
                 .write_data(stnelev2)
-
-            # Wind Speed
-            obsspace.create_var('ObsValue/windSpeed', dtype=wspd2.dtype, fillval=wspd2.fill_value) \
-                .write_attr('units', 'm s-1') \
-                .write_attr('long_name', 'Wind Speed') \
-                .write_data(wspd2)
-
-            # Wind Direction
-            obsspace.create_var('ObsValue/windDirection', dtype=wdir2.dtype, fillval=wdir2.fill_value) \
-                .write_attr('units', 'degrees') \
-                .write_attr('long_name', 'Wind Direction') \
-                .write_data(wdir2)
 
             # U-Wind Component
             obsspace.create_var('ObsValue/windEastward', dtype=uob2.dtype, fillval=wspd2.fill_value) \


### PR DESCRIPTION
Two updates for GOES AMV

1. BUFR Converter:
- remove wind direction and speed
- change sensorZenithAngle to satelliteZenithAngle
2. UFO Filters:
- change `sensorZenithAngle` to `satelliteZenithAngle`
- add `linear obs operator` section
The declaration of `linear obs operator" is necessary for GOES AMV since there is no linearized component for applying the 10-meter factor.

The increments look reasonable:
```
0: ----------------------------------------------------------------------------------------------------
  0: Increment print | number of fields = 8 | cube sphere face size: C768
  0: eastward_wind                                | Min:-1.642335e-01 Max:+1.660654e-01 RMS:+2.746685e-04
  0: northward_wind                               | Min:-2.120068e-01 Max:+1.663539e-01 RMS:+2.631295e-04
  0: air_temperature                              | Min:+0.000000e+00 Max:+0.000000e+00 RMS:+0.000000e+00
  0: surface_pressure                             | Min:+0.000000e+00 Max:+0.000000e+00 RMS:+0.000000e+00
  0: specific_humidity                            | Min:+0.000000e+00 Max:+0.000000e+00 RMS:+0.000000e+00
  0: cloud_liquid_ice                             | Min:+0.000000e+00 Max:+0.000000e+00 RMS:+0.000000e+00
  0: cloud_liquid_water                           | Min:+0.000000e+00 Max:+0.000000e+00 RMS:+0.000000e+00
  0: ozone_mass_mixing_ratio                      | Min:+0.000000e+00 Max:+0.000000e+00 RMS:+0.000000e+00
  0: ----------------------------------------------------------------------------------------------------
```

The UFO filter results vs. GSI  -- looks good

![ufo_abi_goes-16_omf_windEastward_qc_time1](https://github.com/NOAA-EMC/GDASApp/assets/36091766/017aeabc-d6ca-4643-b037-16f46dde76a0)

![gsi_abi_goes-16_omf_windEastward_qc_time1](https://github.com/NOAA-EMC/GDASApp/assets/36091766/d99599a2-3f36-4ef6-aa2e-4611500b8c43)




