### PR TITLE
Modify BUFR converter and filter yamls for MetoOp Scatwind

### DIFF
--- a/parm/atm/obs/config/satwind_goes-16.yaml
+++ b/parm/atm/obs/config/satwind_goes-16.yaml
@@ -7,7 +7,7 @@ obs space:
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(DATA)/diags/diag_satwind_abi_goes-16_{{ current_cycle | to_YMDH }}.nc4
+      obsfile: $(DATA)/diags/diag_satwind_abi_goes-16_{{ current_cycle | to_YMDH }}.nc
   io pool:
     max pool size: 1
   simulated variables: [windEastward, windNorthward]

--- a/parm/atm/obs/config/satwind_goes-17.yaml
+++ b/parm/atm/obs/config/satwind_goes-17.yaml
@@ -7,7 +7,7 @@ obs space:
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(DATA)/diags/diag_satwind_abi_goes-17_{{ current_cycle | to_YMDH }}.nc4
+      obsfile: $(DATA)/diags/diag_satwind_abi_goes-17_{{ current_cycle | to_YMDH }}.nc
   io pool:
     max pool size: 1
   simulated variables: [windEastward, windNorthward]

--- a/parm/atm/obs/config/scatwind_metop-a.yaml
+++ b/parm/atm/obs/config/scatwind_metop-a.yaml
@@ -3,11 +3,11 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(DATA)/obs/$(OPREFIX)ascatw.ascat_metop-a.{{ current_cycle | to_YMDH }}.nc4
+      obsfile: $(DATA)/obs/$(OPREFIX)ascatw.ascat_metop-a.tm00.nc
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(DATA)/diags/diag_ascatw_ascat_metop-a_{{ current_cycle | to_YMDH }}.nc4
+      obsfile: $(DATA)/diags/diag_ascatw_ascat_metop-a_{{ current_cycle | to_YMDH }}.nc
   io pool:
     max pool size: 1
   simulated variables: [windEastward, windNorthward]
@@ -22,6 +22,20 @@ obs operator:
   interpolation method: linear
   hofx scaling field: SurfaceWindScalingHeight
   hofx scaling field group: DerivedVariables
+
+linear obs operator:
+  name: VertInterp
+  vertical coordinate: geopotential_height
+  observation vertical coordinate group: DerivedVariables
+  observation vertical coordinate: adjustedHeight
+  interpolation method: linear
+
+obs pre filters:
+- filter: Gaussian Thinning
+  horizontal_mesh: 75
+  use_reduced_horizontal_grid: true 
+  round_horizontal_bin_count_to_nearest: true
+  partition_longitude_bins_using_mesh: true
 
 obs prior filters:
 # Apply variable changes needed for rescaled height coordinate

--- a/parm/atm/obs/config/scatwind_metop-b.yaml
+++ b/parm/atm/obs/config/scatwind_metop-b.yaml
@@ -23,6 +23,20 @@ obs operator:
   hofx scaling field: SurfaceWindScalingHeight
   hofx scaling field group: DerivedVariables
 
+linear obs operator:
+  name: VertInterp
+  vertical coordinate: geopotential_height
+  observation vertical coordinate group: DerivedVariables
+  observation vertical coordinate: adjustedHeight
+  interpolation method: linear
+
+obs pre filters:
+- filter: Gaussian Thinning
+  horizontal_mesh: 75
+  use_reduced_horizontal_grid: true
+  round_horizontal_bin_count_to_nearest: true
+  partition_longitude_bins_using_mesh: true
+
 obs prior filters:
 # Apply variable changes needed for rescaled height coordinate
 - filter: Variable Transforms

--- a/parm/atm/obs/config/scatwind_metop-b.yaml
+++ b/parm/atm/obs/config/scatwind_metop-b.yaml
@@ -3,11 +3,11 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(DATA)/obs/$(OPREFIX)ascatw.ascat_metop-b.{{ current_cycle | to_YMDH }}.nc4
+      obsfile: $(DATA)/obs/$(OPREFIX)ascatw.ascat_metop-b.tm00.nc
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(DATA)/diags/diag_ascatw_ascat_metop-b_{{ current_cycle | to_YMDH }}.nc4
+      obsfile: $(DATA)/diags/diag_ascatw_ascat_metop-b_{{ current_cycle | to_YMDH }}.nc
   io pool:
     max pool size: 1
   simulated variables: [windEastward, windNorthward]

--- a/ush/ioda/bufr2ioda/bufr2ioda_satwind_scat.py
+++ b/ush/ioda/bufr2ioda/bufr2ioda_satwind_scat.py
@@ -169,6 +169,9 @@ def bufr_to_ioda(config, logger):
     logger.debug('Creating derived variables - observation height')
     height = np.full_like(lat, 10.)
 
+    logger.debug('Creating derived variables - station elevation')
+    stnelv = np.full_like(lat, 0.)
+
     end_time = time.time()
     running_time = end_time - start_time
     logger.debug(f'Processing time for creating derived variables : {running_time} seconds')
@@ -209,6 +212,7 @@ def bufr_to_ioda(config, logger):
             timestamp2 = timestamp[mask]
             pressure2 = pressure[mask]
             height2 = height[mask]
+            stnelv2 = stnelv[mask]
             obstype2 = obstype[mask]
 
             # QC Info
@@ -299,6 +303,12 @@ def bufr_to_ioda(config, logger):
                 .write_attr('long_name', 'Height of Observation') \
                 .write_data(height2)
 
+            # Station Elevation 
+            obsspace.create_var('MetaData/stationElevation', dtype=stnelv2.dtype, fillval=stnelv2.fill_value) \
+                .write_attr('units', 'm') \
+                .write_attr('long_name', 'Station Elevation') \
+                .write_data(stnelv2)
+
             # ObsType based on sensor type
             obsspace.create_var('ObsType/windEastward', dtype=obstype2.dtype, fillval=obstype2.fill_value) \
                 .write_attr('long_name', 'PrepBUFR Report Type') \
@@ -308,18 +318,6 @@ def bufr_to_ioda(config, logger):
             obsspace.create_var('ObsType/windNorthward', dtype=obstype2.dtype, fillval=obstype2.fill_value) \
                 .write_attr('long_name', 'PrepBUFR Report Type') \
                 .write_data(obstype2)
-
-            # Wind Speed
-            obsspace.create_var('ObsValue/windSpeed', dtype=wspd2.dtype, fillval=wspd2.fill_value) \
-                .write_attr('units', 'm s-1') \
-                .write_attr('long_name', 'Wind Speed at 10 Meters') \
-                .write_data(wspd2)
-
-            # Wind Direction
-            obsspace.create_var('ObsValue/windDirection', dtype=wdir2.dtype, fillval=wdir2.fill_value) \
-                .write_attr('units', 'degrees') \
-                .write_attr('long_name', 'Wind Direction at 10 Meters') \
-                .write_data(wdir2)
 
             # U-Wind Component
             obsspace.create_var('ObsValue/windEastward', dtype=uob2.dtype, fillval=uob2.fill_value) \

--- a/ush/ioda/bufr2ioda/bufr2ioda_satwind_scat.py
+++ b/ush/ioda/bufr2ioda/bufr2ioda_satwind_scat.py
@@ -303,7 +303,7 @@ def bufr_to_ioda(config, logger):
                 .write_attr('long_name', 'Height of Observation') \
                 .write_data(height2)
 
-            # Station Elevation 
+            # Station Elevation
             obsspace.create_var('MetaData/stationElevation', dtype=stnelv2.dtype, fillval=stnelv2.fill_value) \
                 .write_attr('units', 'm') \
                 .write_attr('long_name', 'Station Elevation') \


### PR DESCRIPTION
Two updates for MetOp SCATWIND; one minor updates for GOES AMV 

1. BUFR Converter:
    - remove wind direction and speed
    - add `stationElevation` as zero 

2. UFO Filters:
    - add linear obs operator section
      The declaration of `linear obs operator" is necessary for GOES AMV since there is no 
      linearized component for applying the 10-meter factor.
    - add `Gaussian Thinning` filter to thin data with 75 km box (equal box size, prefer data close to central of the box)

3. For GOES AMV YAML files, change output data extension from `nc4` to `nc`

UFO vs. GSI O-F and QC comparison: O-F and data count passed look close
![ufo_ascat_metop-b_omf_windEastward_qc (1)](https://github.com/NOAA-EMC/GDASApp/assets/36091766/f234543e-e0b5-4c6e-add9-3c7365c0c469)
![gsi_ascat_metop-b_omf_windEastward_qc](https://github.com/NOAA-EMC/GDASApp/assets/36091766/37f4fba8-bd2a-4a54-b45e-4055e3ef3142)

3Dvar increments are reasonable with MetOp-B SCATWIND alone.
```
0: ----------------------------------------------------------------------------------------------------
  0: Increment print | number of fields = 8 | cube sphere face size: C768
  0: eastward_wind                                | Min:-1.741092e+00 Max:+1.712287e+00 RMS:+2.282584e-03
  0: northward_wind                               | Min:-1.825957e+00 Max:+1.930385e+00 RMS:+2.496075e-03
  0: air_temperature                              | Min:+0.000000e+00 Max:+0.000000e+00 RMS:+0.000000e+00
  0: surface_pressure                             | Min:+0.000000e+00 Max:+0.000000e+00 RMS:+0.000000e+00
  0: specific_humidity                            | Min:+0.000000e+00 Max:+0.000000e+00 RMS:+0.000000e+00
  0: cloud_liquid_ice                             | Min:+0.000000e+00 Max:+0.000000e+00 RMS:+0.000000e+00
  0: cloud_liquid_water                           | Min:+0.000000e+00 Max:+0.000000e+00 RMS:+0.000000e+00
  0: ozone_mass_mixing_ratio                      | Min:+0.000000e+00 Max:+0.000000e+00 RMS:+0.000000e+00
  0: ----------------------------------------------------------------------------------------------------

```

3DVar increments are also reasonable with MetOp-B + MetOp-A assimilated 
