### PR TITLE
Fix a bug for dateTime in IcecAmsr2Ioda.h and switch to std::vector in Rads2Ioda.h

### DIFF
--- a/utils/obsproc/IcecAmsr2Ioda.h
+++ b/utils/obsproc/IcecAmsr2Ioda.h
@@ -64,10 +64,9 @@ namespace gdasapp {
       ncFile.getVar("Scan_Time").getVar(oneTmpdateTimeVal.data());
       iodaVars.referenceDate_ = "seconds since 1970-01-01T00:00:00Z";
 
+      size_t index = 0;
       std::tm timeinfo = {};
       for (int i = 0; i < ntimes; i += dimTimeSize) {
-        for (int j = 0; j < dimTimeSize && i + j < ntimes; j++) {
-        }
         timeinfo.tm_year = oneTmpdateTimeVal[i] - 1900;  // Year since 1900
         timeinfo.tm_mon = oneTmpdateTimeVal[i + 1] - 1;  // 0-based; 8 represents Sep
         timeinfo.tm_mday = oneTmpdateTimeVal[i + 2];
@@ -77,7 +76,8 @@ namespace gdasapp {
 
         // Calculate and store the seconds since the Unix epoch
         time_t epochtime = std::mktime(&timeinfo);
-        iodaVars.datetime_(i/6) = static_cast<int64_t>(epochtime);
+        iodaVars.datetime_(index) = static_cast<int64_t>(epochtime);
+        index++;
       }
 
       // Update non-optional Eigen arrays
@@ -90,7 +90,8 @@ namespace gdasapp {
       }
 
       // basic test for iodaVars.trim
-      Eigen::Array<bool, Eigen::Dynamic, 1> mask = (iodaVars.obsVal_ >= 0.0);
+      Eigen::Array<bool, Eigen::Dynamic, 1> mask = (iodaVars.obsVal_ >= 0.0
+        && iodaVars.datetime_ > 0.0);
       iodaVars.trim(mask);
 
       return iodaVars;

--- a/utils/obsproc/Rads2Ioda.h
+++ b/utils/obsproc/Rads2Ioda.h
@@ -101,7 +101,7 @@ namespace gdasapp {
       ncFile.getVar("adt_egm2008").getAtt("scale_factor").getValues(&scaleFactor);
 
       // Read sla
-      std::vector<int> sla(iodaVars.location_);
+      std::vector<short> sla(iodaVars.location_);
       ncFile.getVar("sla").getVar(sla.data());
 
       // Update non-optional Eigen arrays

--- a/utils/obsproc/Rads2Ioda.h
+++ b/utils/obsproc/Rads2Ioda.h
@@ -44,17 +44,17 @@ namespace gdasapp {
       gdasapp::IodaVars iodaVars(nobs, floatMetadataNames, intMetadataNames);
 
       // Read non-optional metadata: datetime, longitude and latitude
-      int lat[iodaVars.location_];  // NOLINT
-      ncFile.getVar("lat").getVar(lat);
+      std::vector<int> lat(iodaVars.location_);  // NOLINT
+      ncFile.getVar("lat").getVar(lat.data());
 
-      int lon[iodaVars.location_];  // NOLINT
-      ncFile.getVar("lon").getVar(lon);
+      std::vector<int> lon(iodaVars.location_);  // NOLINT
+      ncFile.getVar("lon").getVar(lon.data());
 
       float geoscaleFactor;
       ncFile.getVar("lon").getAtt("scale_factor").getValues(&geoscaleFactor);
 
-      float datetime[iodaVars.location_];  // NOLINT
-      ncFile.getVar("time_mjd").getVar(datetime);
+      std::vector<float> datetime(iodaVars.location_);  // NOLINT
+      ncFile.getVar("time_mjd").getVar(datetime.data());
       iodaVars.referenceDate_ = "seconds since 1858-11-17T00:00:00Z";
 
       std::map<std::string, int> altimeterMap;
@@ -84,24 +84,24 @@ namespace gdasapp {
       iodaVars.strGlobalAttr_["references"] = references;
 
       // Read optional integer metadata "pass" and "cycle"
-      int pass[iodaVars.location_];  // NOLINT
-      ncFile.getVar("pass").getVar(pass);
-      int cycle[iodaVars.location_];  // NOLINT
-      ncFile.getVar("cycle").getVar(cycle);
+      std::vector<int> pass(iodaVars.location_);  // NOLINT
+      ncFile.getVar("pass").getVar(pass.data());
+      std::vector<int> cycle(iodaVars.location_);  // NOLINT
+      ncFile.getVar("cycle").getVar(cycle.data());
 
       for (int i = 0; i < iodaVars.location_; i++) {
         iodaVars.intMetadata_.row(i) << pass[i], cycle[i], mission_index;
       }
 
       // Get adt_egm2008 obs values and attributes
-      int adt[iodaVars.location_];  // NOLINT
-      ncFile.getVar("adt_egm2008").getVar(adt);
+      std::vector<int> adt(iodaVars.location_);  // NOLINT
+      ncFile.getVar("adt_egm2008").getVar(adt.data());
       float scaleFactor;
       ncFile.getVar("adt_egm2008").getAtt("scale_factor").getValues(&scaleFactor);
 
       // Read sla
-      int sla[iodaVars.location_];  // NOLINT
-      ncFile.getVar("sla").getVar(sla);
+      std::vector<int> sla(iodaVars.location_);  // NOLINT
+      ncFile.getVar("sla").getVar(sla.data());
 
       // Update non-optional Eigen arrays
       for (int i = 0; i < iodaVars.location_; i++) {

--- a/utils/obsproc/Rads2Ioda.h
+++ b/utils/obsproc/Rads2Ioda.h
@@ -44,16 +44,16 @@ namespace gdasapp {
       gdasapp::obsproc::iodavars::IodaVars iodaVars(nobs, floatMetadataNames, intMetadataNames);
 
       // Read non-optional metadata: datetime, longitude and latitude
-      std::vector<int> lat(iodaVars.location_);  // NOLINT
+      std::vector<int> lat(iodaVars.location_);
       ncFile.getVar("lat").getVar(lat.data());
 
-      std::vector<int> lon(iodaVars.location_);  // NOLINT
+      std::vector<int> lon(iodaVars.location_);
       ncFile.getVar("lon").getVar(lon.data());
 
       float geoscaleFactor;
       ncFile.getVar("lon").getAtt("scale_factor").getValues(&geoscaleFactor);
 
-      std::vector<float> datetime(iodaVars.location_);  // NOLINT
+      std::vector<float> datetime(iodaVars.location_);
       ncFile.getVar("time_mjd").getVar(datetime.data());
       iodaVars.referenceDate_ = "seconds since 1858-11-17T00:00:00Z";
 
@@ -84,9 +84,9 @@ namespace gdasapp {
       iodaVars.strGlobalAttr_["references"] = references;
 
       // Read optional integer metadata "pass" and "cycle"
-      std::vector<int> pass(iodaVars.location_);  // NOLINT
+      std::vector<int> pass(iodaVars.location_);
       ncFile.getVar("pass").getVar(pass.data());
-      std::vector<int> cycle(iodaVars.location_);  // NOLINT
+      std::vector<int> cycle(iodaVars.location_);
       ncFile.getVar("cycle").getVar(cycle.data());
 
       // Store optional metadata, set ocean basins to -999 for now
@@ -95,13 +95,13 @@ namespace gdasapp {
       }
 
       // Get adt_egm2008 obs values and attributes
-      std::vector<int> adt(iodaVars.location_);  // NOLINT
+      std::vector<int> adt(iodaVars.location_);
       ncFile.getVar("adt_egm2008").getVar(adt.data());
       float scaleFactor;
       ncFile.getVar("adt_egm2008").getAtt("scale_factor").getValues(&scaleFactor);
 
       // Read sla
-      std::vector<int> sla(iodaVars.location_);  // NOLINT
+      std::vector<int> sla(iodaVars.location_);
       ncFile.getVar("sla").getVar(sla.data());
 
       // Update non-optional Eigen arrays


### PR DESCRIPTION
### Description
#### This PR includes two main are done below
- Implemented an additional trim function to ensure that the Obs.Values align with their respective dTime entries
- Switch to ```std::vector``` in RadsToIoda.h for replacing the array

close https://github.com/NOAA-EMC/GDASApp/issues/664