### PR TITLE
Fix YAML so minimization works for satwind G17

### DIFF
--- a/parm/atm/obs/config/satwind_goes-17.yaml
+++ b/parm/atm/obs/config/satwind_goes-17.yaml
@@ -17,7 +17,7 @@ obs operator:
   hofx scaling field: SurfaceWindScalingPressure
   hofx scaling field group: DerivedVariables
 
-obs linear operator:
+linear obs operator:
   name: VertInterp
 
 obs prior filters:


### PR DESCRIPTION
@RussTreadon-NOAA noted that `obs linear operator` should be `linear obs operator` in the GOES-17 satwind YAML. This fixes that.