### PR TITLE
Switch to std::vector in Rads2Ioda.h

### DIFF
--- a/utils/obsproc/Rads2Ioda.h
+++ b/utils/obsproc/Rads2Ioda.h
@@ -44,17 +44,17 @@ namespace gdasapp {
       gdasapp::obsproc::iodavars::IodaVars iodaVars(nobs, floatMetadataNames, intMetadataNames);
 
       // Read non-optional metadata: datetime, longitude and latitude
-      int lat[iodaVars.location_];  // NOLINT
-      ncFile.getVar("lat").getVar(lat);
+      std::vector<int> lat(iodaVars.location_);
+      ncFile.getVar("lat").getVar(lat.data());
 
-      int lon[iodaVars.location_];  // NOLINT
-      ncFile.getVar("lon").getVar(lon);
+      std::vector<int> lon(iodaVars.location_);
+      ncFile.getVar("lon").getVar(lon.data());
 
       float geoscaleFactor;
       ncFile.getVar("lon").getAtt("scale_factor").getValues(&geoscaleFactor);
 
-      float datetime[iodaVars.location_];  // NOLINT
-      ncFile.getVar("time_mjd").getVar(datetime);
+      std::vector<float> datetime(iodaVars.location_);
+      ncFile.getVar("time_mjd").getVar(datetime.data());
       iodaVars.referenceDate_ = "seconds since 1858-11-17T00:00:00Z";
 
       std::map<std::string, int> altimeterMap;
@@ -84,10 +84,10 @@ namespace gdasapp {
       iodaVars.strGlobalAttr_["references"] = references;
 
       // Read optional integer metadata "pass" and "cycle"
-      int pass[iodaVars.location_];  // NOLINT
-      ncFile.getVar("pass").getVar(pass);
-      int cycle[iodaVars.location_];  // NOLINT
-      ncFile.getVar("cycle").getVar(cycle);
+      std::vector<int> pass(iodaVars.location_);
+      ncFile.getVar("pass").getVar(pass.data());
+      std::vector<int> cycle(iodaVars.location_);
+      ncFile.getVar("cycle").getVar(cycle.data());
 
       // Store optional metadata, set ocean basins to -999 for now
       for (int i = 0; i < iodaVars.location_; i++) {
@@ -95,14 +95,14 @@ namespace gdasapp {
       }
 
       // Get adt_egm2008 obs values and attributes
-      int adt[iodaVars.location_];  // NOLINT
-      ncFile.getVar("adt_egm2008").getVar(adt);
+      std::vector<int> adt(iodaVars.location_);
+      ncFile.getVar("adt_egm2008").getVar(adt.data());
       float scaleFactor;
       ncFile.getVar("adt_egm2008").getAtt("scale_factor").getValues(&scaleFactor);
 
       // Read sla
-      short sla[iodaVars.location_];  // NOLINT
-      ncFile.getVar("sla").getVar(sla);
+      std::vector<int16_t> sla(iodaVars.location_);
+      ncFile.getVar("sla").getVar(sla.data());
 
       // Update non-optional Eigen arrays
       for (int i = 0; i < iodaVars.location_; i++) {


### PR DESCRIPTION
### Description
#### This PR includes what is done below
- Switch to ```std::vector``` in RadsToIoda.h for replacing the array
- Implement type of ```short sla``` to ```std::vector<int16_t> sla```

close https://github.com/NOAA-EMC/GDASApp/issues/664

#### ioda results are below
```
netcdf rads_adt_3b_2021181.ioda {
dimensions:
        Location = 11 ;
variables:
        int Location(Location) ;
                Location:suggested_chunk_dim = 11LL ;

// global attributes:
                string :_ioda_layout = "ObsGroup" ;
                :_ioda_layout_version = 0 ;
                string :obs_source_files = "rads_adt_3b_2021181.nc4" ;
                string :mission_index = "CRYOSAT2 = 6 JASON-1 = 3 JASON-2 = 4 JASON-3 = 5 SARAL = 7 SNTNL-3A = 1 SNTNL-3B = 2 " ;
                string :references = "RADS Data Manual, Version 4.2 or later" ;
data:

 Location = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ;

group: MetaData {
  variables:
        int cycle(Location) ;
                cycle:_FillValue = -2147483643 ;
        int64 dateTime(Location) ;
                dateTime:_FillValue = -9223372036854775801LL ;
                string dateTime:units = "seconds since 1858-11-17T00:00:00Z" ;
        float latitude(Location) ;
                latitude:_FillValue = -3.368795e+38f ;
        float longitude(Location) ;
                longitude:_FillValue = -3.368795e+38f ;
        float mdt(Location) ;
                mdt:_FillValue = -3.368795e+38f ;
        int mission(Location) ;
                mission:_FillValue = -2147483643 ;
        int oceanBasin(Location) ;
                oceanBasin:_FillValue = -2147483643 ;
        int pass(Location) ;
                pass:_FillValue = -2147483643 ;
  data:

   cycle = 54, 54, 54, 54, 54, 54, 54, 54, 54, 54, 54 ;

   dateTime = 5131728384, 5131728384, 5131728384, 5131728384, 5131728384,
      5131728384, 5131728384, 5131728384, 5131728384, 5131728384, 5131728384 ;

   latitude = 59.73273, 59.5059, 58.76763, 58.71078, 58.65391, 58.59704,
      58.54016, 58.48327, 58.42637, 58.36946, 58.31255 ;

   longitude = 163.4174, 163.2622, 162.7704, 162.7333, 162.6964, 162.6595,
      162.6228, 162.5861, 162.5496, 162.5132, 162.4768 ;

   mdt = 0.1927, 0.2235, 0.4589, 0.5115, 0.5307, 0.5154999, 0.4983, 0.4831,
      0.4875, 0.4722, 0.4527 ;

   mission = 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2 ;

   oceanBasin = -999, -999, -999, -999, -999, -999, -999, -999, -999, -999,
      -999 ;

   pass = 232, 232, 232, 232, 232, 232, 232, 232, 232, 232, 232 ;
  } // group MetaData

group: ObsError {
  variables:
        float absoluteDynamicTopography(Location) ;
                absoluteDynamicTopography:_FillValue = -3.368795e+38f ;
  data:

   absoluteDynamicTopography = 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1,
      0.1, 0.1 ;
  } // group ObsError

group: ObsValue {
  variables:
        float absoluteDynamicTopography(Location) ;
                absoluteDynamicTopography:_FillValue = -3.368795e+38f ;
  data:

   absoluteDynamicTopography = 0.6505, 0.7307, 0.6026, 0.5871, 0.5561,
      0.5246, 0.4981, 0.4661, 0.4391, 0.4409, 0.4283 ;
  } // group ObsValue

group: PreQC {
  variables:
        int absoluteDynamicTopography(Location) ;
                absoluteDynamicTopography:_FillValue = -2147483643 ;
  data:

   absoluteDynamicTopography = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ;
  } // group PreQC
}
```