### PR TITLE
Correct sensor amsua_n19 typo

### DIFF
--- a/parm/atm/obs/config/amsua_n19.yaml
+++ b/parm/atm/obs/config/amsua_n19.yaml
@@ -357,7 +357,7 @@ obs filters:
   - name: ObsFunction/ChannelUseflagCheckRad
     channels: *amsua_n19_channels
     options:
-      sensor: amaua_n19
+      sensor: amsua_n19
       channels: *amsua_n19_channels
       use_flag: [ 1,  1,  1,  1,  1,
                   1, -1, -1,  1,  1,


### PR DESCRIPTION
The `Useflag check` in `amsua_n19.yaml` specified the wrong sensor.  The string `amaua_n19` was used instead of `amsua_n19`.   The typo is corrected in [`feature/amsua_n19`](https://github.com/NOAA-EMC/GDASApp/tree/feature/amsua_n19).

Fixes #726