### PR TITLE
A few updates for ATMS end-to-end testing

### DIFF
--- a/parm/atm/obs/config/atms_n20.yaml
+++ b/parm/atm/obs/config/atms_n20.yaml
@@ -83,6 +83,9 @@ obs pre filters:
   - name: InterChannelConsistency
     initial value: false
     force reinitialization: false 
+  - name: UseflagCheck 
+    initial value: false
+    force reinitialization: false 
 
 obs post filters:
 # Step 0-B: Calculate derived variables
@@ -519,7 +522,7 @@ obs post filters:
       sensor: *Sensor_ID
       use_flag: [ 1,  1,  1,  1,  1,
                   1,  1,  1,  1,  1,
-                  1,  1,  1,  1,  1,
+                  1,  1,  1,  1,  4,
                   1,  1,  1,  1,  1,
                   1,  1]
   maxvalue: 1.0e-12
@@ -529,3 +532,24 @@ obs post filters:
       ignore: rejected observations
     - name: reject
 
+# Step 12: Useflag Check
+- filter: Bounds Check
+  filter variables:
+  - name: brightnessTemperature
+    channels: *atms_n20_channels
+  test variables:
+  - name: ObsFunction/ChannelUseflagCheckRad
+    channels: *atms_n20_channels
+    options:
+      channels: *atms_n20_channels
+      use_flag: [ 1,  1,  1,  1,  1,
+                  1,  1,  1,  1,  1,
+                  1,  1,  1,  1,  4,
+                  1,  1,  1,  1,  1,
+                  1,  1]
+  minvalue: 1.0e-12
+  actions:
+    - name: set
+      flag: UseflagCheck 
+      ignore: rejected observations
+    - name: reject

--- a/parm/atm/obs/config/atms_n20.yaml
+++ b/parm/atm/obs/config/atms_n20.yaml
@@ -18,6 +18,7 @@ obs operator:
   Absorbers: [H2O,O3]
   Clouds: [Water, Ice]
   Cloud_Fraction: 1.0
+  Cloud_Seeding: true 
   obs options:
     Sensor_ID: &Sensor_ID atms_n20
     EndianType: little_endian
@@ -56,7 +57,10 @@ obs bias:
 
 obs pre filters:
 # Step 0-A: Create Diagnostic Flags
+<<<<<<< Updated upstream
 # Diagnostic flag for CLW retrieval
+=======
+>>>>>>> Stashed changes
 - filter: Create Diagnostic Flags
   filter variables:
   - name: brightnessTemperature
@@ -224,7 +228,11 @@ obs post filters:
           channels: *atms_n20_channels
         coefs: [1, -1]
 
+<<<<<<< Updated upstream
 # Step 0-C: Assign initial all-sky observation error
+=======
+# Step 0-C: Assign Initial All-Sky Observation Error
+>>>>>>> Stashed changes
 - filter: Perform Action
   filter variables:
   - name: brightnessTemperature
@@ -235,7 +243,11 @@ obs post filters:
       name: InitialObsError@DerivedMetaData
       channels: *atms_n20_channels
 
+<<<<<<< Updated upstream
 # Step 1: Remove observations from the edge of the scan
+=======
+# Step 1: Remove Observations from the Edge of the Scan
+>>>>>>> Stashed changes
 - filter: Domain Check
   filter variables:
   - name: brightnessTemperature
@@ -250,6 +262,7 @@ obs post filters:
     - name: reject
 
 # Step 2: Data Thinning
+<<<<<<< Updated upstream
 #- filter: Gaussian Thinning
 #  horizontal_mesh: 145 
 #  use_reduced_horizontal_grid: true
@@ -259,6 +272,18 @@ obs post filters:
 #    - name: set
 #      flag: Thinning 
 #    - name: reject
+=======
+- filter: Gaussian Thinning
+  horizontal_mesh: 145 
+  use_reduced_horizontal_grid: true
+  distance_norm: geodesic
+#  round_horizontal_bin_count_to_nearest: true
+#  partition_longitude_bins_using_mesh: true
+  actions:
+    - name: set
+      flag: Thinning 
+    - name: reject
+>>>>>>> Stashed changes
 
 # Step 3A: CLW Retrieval Check (observation_based)
 - filter: Bounds Check
@@ -286,7 +311,11 @@ obs post filters:
       flag: CLWRetrievalCheck
     - name: reject
 
+<<<<<<< Updated upstream
 # Step 4: Window channel sanity check
+=======
+# Step 4: Window Channel Sanity Check
+>>>>>>> Stashed changes
 - filter: Bounds Check
   filter variables:
   - name: brightnessTemperature
@@ -338,7 +367,11 @@ obs post filters:
       ignore: rejected observations
     - name: reject
 
+<<<<<<< Updated upstream
 # Step 6: Observation error inflation based on topography check
+=======
+# Step 6: Observation Error Inflation based on Topography Check
+>>>>>>> Stashed changes
 - filter: Variable Assignment
   assignments:
   - name: ObsErrorFactorTopo@DerivedMetaData
@@ -361,7 +394,11 @@ obs post filters:
       name: ObsErrorFactorTopo@DerivedMetaData
       channels: *atms_n20_channels
 
+<<<<<<< Updated upstream
 # Step 7: Obs error inflation based on TOA transmittancec check
+=======
+# Step 7: Obs Error Inflation based on TOA Transmittancec Check
+>>>>>>> Stashed changes
 - filter: Variable Assignment
   assignments:
   - name: ObsErrorFactorTransmitTop@DerivedMetaData
@@ -383,7 +420,11 @@ obs post filters:
       name: ObsErrorFactorTransmitTop@DerivedMetaData
       channels: *atms_n20_channels
 
+<<<<<<< Updated upstream
 # Step 8: Observation error inflation based on surface jacobian check
+=======
+# Step 8: Observation Error Inflation based on Surface Jacobian Check
+>>>>>>> Stashed changes
 - filter: Variable Assignment
   assignments:
   - name: ObsErrorFactorSurfJacobian@DerivedMetaData
@@ -409,7 +450,11 @@ obs post filters:
       name: ObsErrorFactorSurfJacobian@DerivedMetaData
       channels: *atms_n20_channels
 
+<<<<<<< Updated upstream
 # Step 9: Situation dependent check
+=======
+# Step 9: Situation Dependent Check
+>>>>>>> Stashed changes
 - filter: Variable Assignment
   assignments:
   - name: ObsErrorFactorSituDepend@DerivedMetaData
@@ -504,7 +549,11 @@ obs post filters:
       ignore: rejected observations
     - name: reject
 
+<<<<<<< Updated upstream
 # Step 11: Inter-channel check
+=======
+# Step 11: Inter-Channel Check
+>>>>>>> Stashed changes
 - filter: Bounds Check
   filter variables:
   - name: brightnessTemperature

--- a/parm/atm/obs/config/atms_n20.yaml
+++ b/parm/atm/obs/config/atms_n20.yaml
@@ -57,10 +57,6 @@ obs bias:
 
 obs pre filters:
 # Step 0-A: Create Diagnostic Flags
-<<<<<<< Updated upstream
-# Diagnostic flag for CLW retrieval
-=======
->>>>>>> Stashed changes
 - filter: Create Diagnostic Flags
   filter variables:
   - name: brightnessTemperature
@@ -228,11 +224,7 @@ obs post filters:
           channels: *atms_n20_channels
         coefs: [1, -1]
 
-<<<<<<< Updated upstream
-# Step 0-C: Assign initial all-sky observation error
-=======
 # Step 0-C: Assign Initial All-Sky Observation Error
->>>>>>> Stashed changes
 - filter: Perform Action
   filter variables:
   - name: brightnessTemperature
@@ -243,11 +235,7 @@ obs post filters:
       name: InitialObsError@DerivedMetaData
       channels: *atms_n20_channels
 
-<<<<<<< Updated upstream
-# Step 1: Remove observations from the edge of the scan
-=======
 # Step 1: Remove Observations from the Edge of the Scan
->>>>>>> Stashed changes
 - filter: Domain Check
   filter variables:
   - name: brightnessTemperature
@@ -262,17 +250,6 @@ obs post filters:
     - name: reject
 
 # Step 2: Data Thinning
-<<<<<<< Updated upstream
-#- filter: Gaussian Thinning
-#  horizontal_mesh: 145 
-#  use_reduced_horizontal_grid: true
-##  round_horizontal_bin_count_to_nearest: true
-##  partition_longitude_bins_using_mesh: true
-#  actions:
-#    - name: set
-#      flag: Thinning 
-#    - name: reject
-=======
 - filter: Gaussian Thinning
   horizontal_mesh: 145 
   use_reduced_horizontal_grid: true
@@ -283,7 +260,6 @@ obs post filters:
     - name: set
       flag: Thinning 
     - name: reject
->>>>>>> Stashed changes
 
 # Step 3A: CLW Retrieval Check (observation_based)
 - filter: Bounds Check
@@ -311,11 +287,7 @@ obs post filters:
       flag: CLWRetrievalCheck
     - name: reject
 
-<<<<<<< Updated upstream
-# Step 4: Window channel sanity check
-=======
 # Step 4: Window Channel Sanity Check
->>>>>>> Stashed changes
 - filter: Bounds Check
   filter variables:
   - name: brightnessTemperature
@@ -367,11 +339,7 @@ obs post filters:
       ignore: rejected observations
     - name: reject
 
-<<<<<<< Updated upstream
-# Step 6: Observation error inflation based on topography check
-=======
 # Step 6: Observation Error Inflation based on Topography Check
->>>>>>> Stashed changes
 - filter: Variable Assignment
   assignments:
   - name: ObsErrorFactorTopo@DerivedMetaData
@@ -394,11 +362,7 @@ obs post filters:
       name: ObsErrorFactorTopo@DerivedMetaData
       channels: *atms_n20_channels
 
-<<<<<<< Updated upstream
-# Step 7: Obs error inflation based on TOA transmittancec check
-=======
 # Step 7: Obs Error Inflation based on TOA Transmittancec Check
->>>>>>> Stashed changes
 - filter: Variable Assignment
   assignments:
   - name: ObsErrorFactorTransmitTop@DerivedMetaData
@@ -420,11 +384,7 @@ obs post filters:
       name: ObsErrorFactorTransmitTop@DerivedMetaData
       channels: *atms_n20_channels
 
-<<<<<<< Updated upstream
-# Step 8: Observation error inflation based on surface jacobian check
-=======
 # Step 8: Observation Error Inflation based on Surface Jacobian Check
->>>>>>> Stashed changes
 - filter: Variable Assignment
   assignments:
   - name: ObsErrorFactorSurfJacobian@DerivedMetaData
@@ -450,11 +410,7 @@ obs post filters:
       name: ObsErrorFactorSurfJacobian@DerivedMetaData
       channels: *atms_n20_channels
 
-<<<<<<< Updated upstream
-# Step 9: Situation dependent check
-=======
 # Step 9: Situation Dependent Check
->>>>>>> Stashed changes
 - filter: Variable Assignment
   assignments:
   - name: ObsErrorFactorSituDepend@DerivedMetaData
@@ -549,11 +505,7 @@ obs post filters:
       ignore: rejected observations
     - name: reject
 
-<<<<<<< Updated upstream
-# Step 11: Inter-channel check
-=======
 # Step 11: Inter-Channel Check
->>>>>>> Stashed changes
 - filter: Bounds Check
   filter variables:
   - name: brightnessTemperature

--- a/parm/atm/obs/config/atms_npp.yaml
+++ b/parm/atm/obs/config/atms_npp.yaml
@@ -83,6 +83,9 @@ obs pre filters:
   - name: InterChannelConsistency
     initial value: false
     force reinitialization: false 
+  - name: UseflagCheck 
+    initial value: false
+    force reinitialization: false 
 
 obs post filters:
 # Step 0-B: Calculate derived variables
@@ -519,7 +522,7 @@ obs post filters:
       sensor: *Sensor_ID
       use_flag: [ 1,  1,  1,  1,  1,
                   1,  1,  1,  1,  1,
-                  1,  1,  1,  1,  1,
+                  1,  1,  1,  1,  4,
                   1,  1,  1,  1,  1,
                   1,  1]
   maxvalue: 1.0e-12
@@ -529,3 +532,24 @@ obs post filters:
       ignore: rejected observations
     - name: reject
 
+# Step 12: Useflag Check
+- filter: Bounds Check
+  filter variables:
+  - name: brightnessTemperature
+    channels: *atms_npp_channels
+  test variables:
+  - name: ObsFunction/ChannelUseflagCheckRad
+    channels: *atms_npp_channels
+    options:
+      channels: *atms_npp_channels
+      use_flag: [ 1,  1,  1,  1,  1,
+                  1,  1,  1,  1,  1,
+                  1,  1,  1,  1,  4,
+                  1,  1,  1,  1,  1,
+                  1,  1]
+  minvalue: 1.0e-12
+  actions:
+    - name: set
+      flag: UseflagCheck 
+      ignore: rejected observations
+    - name: reject

--- a/parm/atm/obs/config/atms_npp.yaml
+++ b/parm/atm/obs/config/atms_npp.yaml
@@ -18,6 +18,10 @@ obs operator:
   Absorbers: [H2O,O3]
   Clouds: [Water, Ice]
   Cloud_Fraction: 1.0
+<<<<<<< Updated upstream
+=======
+  Cloud_Seeding: true 
+>>>>>>> Stashed changes
   obs options:
     Sensor_ID: &Sensor_ID atms_npp
     EndianType: little_endian
@@ -56,7 +60,10 @@ obs bias:
 
 obs pre filters:
 # Step 0-A: Create Diagnostic Flags
+<<<<<<< Updated upstream
 # Diagnostic flag for CLW retrieval
+=======
+>>>>>>> Stashed changes
 - filter: Create Diagnostic Flags
   filter variables:
   - name: brightnessTemperature
@@ -224,7 +231,11 @@ obs post filters:
           channels: *atms_npp_channels
         coefs: [1, -1]
 
+<<<<<<< Updated upstream
 # Step 0-C: Assign initial all-sky observation error
+=======
+# Step 0-C: Assign Initial All-Sky Observation Error
+>>>>>>> Stashed changes
 - filter: Perform Action
   filter variables:
   - name: brightnessTemperature
@@ -235,7 +246,11 @@ obs post filters:
       name: InitialObsError@DerivedMetaData
       channels: *atms_npp_channels
 
+<<<<<<< Updated upstream
 # Step 1: Remove observations from the edge of the scan
+=======
+# Step 1: Remove Observations from the Edge of the Scan
+>>>>>>> Stashed changes
 - filter: Domain Check
   filter variables:
   - name: brightnessTemperature
@@ -250,6 +265,7 @@ obs post filters:
     - name: reject
 
 # Step 2: Data Thinning
+<<<<<<< Updated upstream
 #- filter: Gaussian Thinning
 #  horizontal_mesh: 145 
 #  use_reduced_horizontal_grid: true
@@ -259,6 +275,18 @@ obs post filters:
 #    - name: set
 #      flag: Thinning 
 #    - name: reject
+=======
+- filter: Gaussian Thinning
+  horizontal_mesh: 145 
+  use_reduced_horizontal_grid: true
+  distance_norm: geodesic
+#  round_horizontal_bin_count_to_nearest: true
+#  partition_longitude_bins_using_mesh: true
+  actions:
+    - name: set
+      flag: Thinning 
+    - name: reject
+>>>>>>> Stashed changes
 
 # Step 3A: CLW Retrieval Check (observation_based)
 - filter: Bounds Check
@@ -286,7 +314,11 @@ obs post filters:
       flag: CLWRetrievalCheck
     - name: reject
 
+<<<<<<< Updated upstream
 # Step 4: Window channel sanity check
+=======
+# Step 4: Window Channel Sanity Check
+>>>>>>> Stashed changes
 - filter: Bounds Check
   filter variables:
   - name: brightnessTemperature
@@ -338,7 +370,11 @@ obs post filters:
       ignore: rejected observations
     - name: reject
 
+<<<<<<< Updated upstream
 # Step 6: Observation error inflation based on topography check
+=======
+# Step 6: Observation Error Inflation based on Topography Check
+>>>>>>> Stashed changes
 - filter: Variable Assignment
   assignments:
   - name: ObsErrorFactorTopo@DerivedMetaData
@@ -361,7 +397,11 @@ obs post filters:
       name: ObsErrorFactorTopo@DerivedMetaData
       channels: *atms_npp_channels
 
+<<<<<<< Updated upstream
 # Step 7: Obs error inflation based on TOA transmittancec check
+=======
+# Step 7: Obs Error Inflation based on TOA Transmittancec Check
+>>>>>>> Stashed changes
 - filter: Variable Assignment
   assignments:
   - name: ObsErrorFactorTransmitTop@DerivedMetaData
@@ -383,7 +423,11 @@ obs post filters:
       name: ObsErrorFactorTransmitTop@DerivedMetaData
       channels: *atms_npp_channels
 
+<<<<<<< Updated upstream
 # Step 8: Observation error inflation based on surface jacobian check
+=======
+# Step 8: Observation Error Inflation based on Surface Jacobian Check
+>>>>>>> Stashed changes
 - filter: Variable Assignment
   assignments:
   - name: ObsErrorFactorSurfJacobian@DerivedMetaData
@@ -409,7 +453,11 @@ obs post filters:
       name: ObsErrorFactorSurfJacobian@DerivedMetaData
       channels: *atms_npp_channels
 
+<<<<<<< Updated upstream
 # Step 9: Situation dependent check
+=======
+# Step 9: Situation Dependent Check
+>>>>>>> Stashed changes
 - filter: Variable Assignment
   assignments:
   - name: ObsErrorFactorSituDepend@DerivedMetaData
@@ -504,7 +552,11 @@ obs post filters:
       ignore: rejected observations
     - name: reject
 
+<<<<<<< Updated upstream
 # Step 11: Inter-channel check
+=======
+# Step 11: Inter-Channel Check
+>>>>>>> Stashed changes
 - filter: Bounds Check
   filter variables:
   - name: brightnessTemperature

--- a/parm/atm/obs/config/atms_npp.yaml
+++ b/parm/atm/obs/config/atms_npp.yaml
@@ -18,10 +18,7 @@ obs operator:
   Absorbers: [H2O,O3]
   Clouds: [Water, Ice]
   Cloud_Fraction: 1.0
-<<<<<<< Updated upstream
-=======
   Cloud_Seeding: true 
->>>>>>> Stashed changes
   obs options:
     Sensor_ID: &Sensor_ID atms_npp
     EndianType: little_endian
@@ -60,10 +57,6 @@ obs bias:
 
 obs pre filters:
 # Step 0-A: Create Diagnostic Flags
-<<<<<<< Updated upstream
-# Diagnostic flag for CLW retrieval
-=======
->>>>>>> Stashed changes
 - filter: Create Diagnostic Flags
   filter variables:
   - name: brightnessTemperature
@@ -231,11 +224,7 @@ obs post filters:
           channels: *atms_npp_channels
         coefs: [1, -1]
 
-<<<<<<< Updated upstream
-# Step 0-C: Assign initial all-sky observation error
-=======
 # Step 0-C: Assign Initial All-Sky Observation Error
->>>>>>> Stashed changes
 - filter: Perform Action
   filter variables:
   - name: brightnessTemperature
@@ -246,11 +235,7 @@ obs post filters:
       name: InitialObsError@DerivedMetaData
       channels: *atms_npp_channels
 
-<<<<<<< Updated upstream
-# Step 1: Remove observations from the edge of the scan
-=======
 # Step 1: Remove Observations from the Edge of the Scan
->>>>>>> Stashed changes
 - filter: Domain Check
   filter variables:
   - name: brightnessTemperature
@@ -265,17 +250,6 @@ obs post filters:
     - name: reject
 
 # Step 2: Data Thinning
-<<<<<<< Updated upstream
-#- filter: Gaussian Thinning
-#  horizontal_mesh: 145 
-#  use_reduced_horizontal_grid: true
-##  round_horizontal_bin_count_to_nearest: true
-##  partition_longitude_bins_using_mesh: true
-#  actions:
-#    - name: set
-#      flag: Thinning 
-#    - name: reject
-=======
 - filter: Gaussian Thinning
   horizontal_mesh: 145 
   use_reduced_horizontal_grid: true
@@ -286,7 +260,6 @@ obs post filters:
     - name: set
       flag: Thinning 
     - name: reject
->>>>>>> Stashed changes
 
 # Step 3A: CLW Retrieval Check (observation_based)
 - filter: Bounds Check
@@ -314,11 +287,7 @@ obs post filters:
       flag: CLWRetrievalCheck
     - name: reject
 
-<<<<<<< Updated upstream
-# Step 4: Window channel sanity check
-=======
 # Step 4: Window Channel Sanity Check
->>>>>>> Stashed changes
 - filter: Bounds Check
   filter variables:
   - name: brightnessTemperature
@@ -370,11 +339,7 @@ obs post filters:
       ignore: rejected observations
     - name: reject
 
-<<<<<<< Updated upstream
-# Step 6: Observation error inflation based on topography check
-=======
 # Step 6: Observation Error Inflation based on Topography Check
->>>>>>> Stashed changes
 - filter: Variable Assignment
   assignments:
   - name: ObsErrorFactorTopo@DerivedMetaData
@@ -397,11 +362,7 @@ obs post filters:
       name: ObsErrorFactorTopo@DerivedMetaData
       channels: *atms_npp_channels
 
-<<<<<<< Updated upstream
-# Step 7: Obs error inflation based on TOA transmittancec check
-=======
 # Step 7: Obs Error Inflation based on TOA Transmittancec Check
->>>>>>> Stashed changes
 - filter: Variable Assignment
   assignments:
   - name: ObsErrorFactorTransmitTop@DerivedMetaData
@@ -423,11 +384,7 @@ obs post filters:
       name: ObsErrorFactorTransmitTop@DerivedMetaData
       channels: *atms_npp_channels
 
-<<<<<<< Updated upstream
-# Step 8: Observation error inflation based on surface jacobian check
-=======
 # Step 8: Observation Error Inflation based on Surface Jacobian Check
->>>>>>> Stashed changes
 - filter: Variable Assignment
   assignments:
   - name: ObsErrorFactorSurfJacobian@DerivedMetaData
@@ -453,11 +410,7 @@ obs post filters:
       name: ObsErrorFactorSurfJacobian@DerivedMetaData
       channels: *atms_npp_channels
 
-<<<<<<< Updated upstream
-# Step 9: Situation dependent check
-=======
 # Step 9: Situation Dependent Check
->>>>>>> Stashed changes
 - filter: Variable Assignment
   assignments:
   - name: ObsErrorFactorSituDepend@DerivedMetaData
@@ -552,11 +505,7 @@ obs post filters:
       ignore: rejected observations
     - name: reject
 
-<<<<<<< Updated upstream
-# Step 11: Inter-channel check
-=======
 # Step 11: Inter-Channel Check
->>>>>>> Stashed changes
 - filter: Bounds Check
   filter variables:
   - name: brightnessTemperature

--- a/parm/atm/obs/testing/atms_n20.yaml
+++ b/parm/atm/obs/testing/atms_n20.yaml
@@ -45,45 +45,35 @@ obs bias:
 
 obs post filters:
 # Step 0-A: Create Diagnostic Flags
-# Diagnostic flag for CLW retrieval
 - filter: Create Diagnostic Flags
   filter variables:
   - name: brightnessTemperature
     channels: *atms_n20_channels
   flags:
-  - name: CLWRetrievalReject
+  - name: ScanEdgeRemoval
     initial value: false
-    force reinitialization: true
-
-# Diagnostic flag for hydrometeor check 
-- filter: Create Diagnostic Flags
-  filter variables:
-  - name: brightnessTemperature
-    channels: *atms_n20_channels
-  flags:
-  - name: HydrometeorCheckReject
+    force reinitialization: false
+  - name: Thinning
     initial value: false
-    force reinitialization: true
-
-# Diagnostic flag for gross check 
-- filter: Create Diagnostic Flags
-  filter variables:
-  - name: brightnessTemperature
-    channels: *atms_n20_channels
-  flags:
-  - name: GrossCheckReject
+    force reinitialization: false
+  - name: CLWRetrievalCheck
     initial value: false
-    force reinitialization: true
-
-# Diagnostic flag for inter-channel consistency check 
-- filter: Create Diagnostic Flags
-  filter variables:
-  - name: brightnessTemperature
-    channels: *atms_n20_channels
-  flags:
-  - name: InterChannelCheckReject
+    force reinitialization: false
+  - name: WindowChannelExtremeResidual
     initial value: false
-    force reinitialization: true
+    force reinitialization: false
+  - name: HydrometeorCheck
+    initial value: false
+    force reinitialization: false
+  - name: GrossCheck
+    initial value: false
+    force reinitialization: false
+  - name: InterChannelConsistency
+    initial value: false
+    force reinitialization: false
+  - name: UseflagCheck
+    initial value: false
+    force reinitialization: false
 
 # Step 0-B: Calculate derived variables
 # Calculate CLW retrieved from observation 
@@ -245,7 +235,7 @@ obs post filters:
   maxvalue: 999.0
   actions:
     - name: set
-      flag: CLWRetrievalReject
+      flag: CLWRetrievalCheck
     - name: reject
 
 # Step 3: CLW Retrieval Check (background_based)
@@ -258,7 +248,7 @@ obs post filters:
   maxvalue: 999.0
   actions:
     - name: set
-      flag: CLWRetrievalReject
+      flag: CLWRetrievalCheck
     - name: reject
 
 # Step 4: Window channel sanity check
@@ -272,6 +262,10 @@ obs post filters:
   maxvalue: 200.0
   minvalue: -200.0
   flag all filter variables if any test variable is out of bounds: true
+  actions:
+    - name: set
+      flag: WindowChannelExtremeResidual
+    - name: reject
 
 # Step 5: Hydrometeor Check (cloud/precipitation affected chanels)
 - filter: Variable Assignment
@@ -305,7 +299,7 @@ obs post filters:
   maxvalue: 0.0
   actions:
     - name: set
-      flag: HydrometeorCheckReject
+      flag: HydrometeorCheck
       ignore: rejected observations
     - name: reject
 
@@ -461,7 +455,6 @@ obs post filters:
                            1.0, 1.0, 1.0, 2.0, 4.5,
                            4.5, 2.0, 2.0, 2.0, 2.0,
                            2.0, 2.0]
-
 - filter: Background Check
   filter variables:
   - name: brightnessTemperature
@@ -471,7 +464,7 @@ obs post filters:
     channels: *atms_n20_channels
   actions:
     - name: set
-      flag: GrossCheckReject
+      flag: GrossCheck
       ignore: rejected observations
     - name: reject
 
@@ -489,14 +482,37 @@ obs post filters:
       sensor: *Sensor_ID
       use_flag: [ 1,  1,  1,  1,  1,
                   1,  1,  1,  1,  1,
-                  1,  1,  1,  1,  1,
+                  1,  1,  1,  1,  4,
                   1,  1,  1,  1,  1,
                   1,  1]
   maxvalue: 1.0e-12
   actions:
     - name: set
-      flag: InterChannelCheckReject
+      flag: InterChannelConsistency
       ignore: rejected observations
     - name: reject
+
+# Step 12: Useflag Check
+- filter: Bounds Check
+  filter variables:
+  - name: brightnessTemperature
+    channels: *atms_n20_channels
+  test variables:
+  - name: ObsFunction/ChannelUseflagCheckRad
+    channels: *atms_n20_channels
+    options:
+      channels: *atms_n20_channels
+      use_flag: [ 1,  1,  1,  1,  1,
+                  1,  1,  1,  1,  1,
+                  1,  1,  1,  1,  4,
+                  1,  1,  1,  1,  1,
+                  1,  1]
+  minvalue: 1.0e-12
+  actions:
+    - name: set
+      flag: UseflagCheck
+      ignore: rejected observations
+    - name: reject
+
 passedBenchmark: 181401 # GSI: 181403 (difference is in channel 7)
 

--- a/parm/atm/obs/testing/atms_n20.yaml
+++ b/parm/atm/obs/testing/atms_n20.yaml
@@ -1,12 +1,3 @@
-obs operator:
-  name: CRTM
-  Absorbers: [H2O,O3]
-  Clouds: [Water, Ice]
-  Cloud_Fraction: 1.0
-  obs options:
-    Sensor_ID: &Sensor_ID atms_n20 
-    EndianType: little_endian
-    CoefficientPath: crtm/
 obs space:
   name: atms_n20 
   obsdatain:
@@ -19,8 +10,20 @@ obs space:
         obsfile: !ENV atms_n20_diag_${CDATE}.nc4
   simulated variables: [brightnessTemperature]
   channels: &atms_n20_channels 1-22
+
 geovals:
   filename: !ENV atms_n20_geoval_${CDATE}.nc4
+
+obs operator:
+  name: CRTM
+  Absorbers: [H2O,O3]
+  Clouds: [Water, Ice]
+  Cloud_Fraction: 1.0
+  obs options:
+    Sensor_ID: &Sensor_ID atms_n20
+    EndianType: little_endian
+    CoefficientPath: crtm/
+
 obs bias:
   input file: !ENV atms_n20_satbias_${GDATE}.nc4
   variational bc:

--- a/parm/atm/obs/testing/atms_n20_noqc.yaml
+++ b/parm/atm/obs/testing/atms_n20_noqc.yaml
@@ -1,12 +1,3 @@
-obs operator:
-  name: CRTM
-  Absorbers: [H2O,O3]
-  Clouds: [Water, Ice]
-  Cloud_Fraction: 1.0
-  obs options:
-    Sensor_ID: &Sensor_ID atms_n20 
-    EndianType: little_endian
-    CoefficientPath: crtm/
 obs space:
   name: atms_n20 
   obsdatain:
@@ -19,8 +10,20 @@ obs space:
         obsfile: !ENV atms_n20_diag_${CDATE}.nc4
   simulated variables: [brightnessTemperature]
   channels: &atms_n20_channels 1-22
+
 geovals:
   filename: !ENV atms_n20_geoval_${CDATE}.nc4
+
+obs operator:
+  name: CRTM
+  Absorbers: [H2O,O3]
+  Clouds: [Water, Ice]
+  Cloud_Fraction: 1.0
+  obs options:
+    Sensor_ID: &Sensor_ID atms_n20
+    EndianType: little_endian
+    CoefficientPath: crtm/
+
 obs bias:
   input file: !ENV atms_n20_satbias_${GDATE}.nc4
   variational bc:

--- a/parm/atm/obs/testing/atms_npp.yaml
+++ b/parm/atm/obs/testing/atms_npp.yaml
@@ -1,12 +1,3 @@
-obs operator:
-  name: CRTM
-  Absorbers: [H2O,O3]
-  Clouds: [Water, Ice]
-  Cloud_Fraction: 1.0
-  obs options:
-    Sensor_ID: &Sensor_ID atms_npp 
-    EndianType: little_endian
-    CoefficientPath: crtm/
 obs space:
   name: atms_npp 
   obsdatain:
@@ -19,8 +10,20 @@ obs space:
         obsfile: !ENV atms_npp_diag_${CDATE}.nc4
   simulated variables: [brightnessTemperature]
   channels: &atms_npp_channels 1-22
+
 geovals:
   filename: !ENV atms_npp_geoval_${CDATE}.nc4
+
+obs operator:
+  name: CRTM
+  Absorbers: [H2O,O3]
+  Clouds: [Water, Ice]
+  Cloud_Fraction: 1.0
+  obs options:
+    Sensor_ID: &Sensor_ID atms_npp
+    EndianType: little_endian
+    CoefficientPath: crtm/
+
 obs bias:
   input file: !ENV atms_npp_satbias_${GDATE}.nc4
   variational bc:

--- a/parm/atm/obs/testing/atms_npp.yaml
+++ b/parm/atm/obs/testing/atms_npp.yaml
@@ -45,45 +45,35 @@ obs bias:
 
 obs post filters:
 # Step 0-A: Create Diagnostic Flags
-# Diagnostic flag for CLW retrieval
 - filter: Create Diagnostic Flags
   filter variables:
   - name: brightnessTemperature
     channels: *atms_npp_channels
   flags:
-  - name: CLWRetrievalReject
+  - name: ScanEdgeRemoval
     initial value: false
-    force reinitialization: true
-
-# Diagnostic flag for hydrometeor check 
-- filter: Create Diagnostic Flags
-  filter variables:
-  - name: brightnessTemperature
-    channels: *atms_npp_channels
-  flags:
-  - name: HydrometeorCheckReject
+    force reinitialization: false
+  - name: Thinning
     initial value: false
-    force reinitialization: true
-
-# Diagnostic flag for gross check 
-- filter: Create Diagnostic Flags
-  filter variables:
-  - name: brightnessTemperature
-    channels: *atms_npp_channels
-  flags:
-  - name: GrossCheckReject
+    force reinitialization: false
+  - name: CLWRetrievalCheck
     initial value: false
-    force reinitialization: true
-
-# Diagnostic flag for inter-channel consistency check 
-- filter: Create Diagnostic Flags
-  filter variables:
-  - name: brightnessTemperature
-    channels: *atms_npp_channels
-  flags:
-  - name: InterChannelCheckReject
+    force reinitialization: false
+  - name: WindowChannelExtremeResidual
     initial value: false
-    force reinitialization: true
+    force reinitialization: false
+  - name: HydrometeorCheck
+    initial value: false
+    force reinitialization: false
+  - name: GrossCheck
+    initial value: false
+    force reinitialization: false
+  - name: InterChannelConsistency
+    initial value: false
+    force reinitialization: false
+  - name: UseflagCheck
+    initial value: false
+    force reinitialization: false
 
 # Step 0-B: Calculate derived variables
 # Calculate CLW retrieved from observation 
@@ -245,7 +235,7 @@ obs post filters:
   maxvalue: 999.0
   actions:
     - name: set
-      flag: CLWRetrievalReject
+      flag: CLWRetrievalCheck
     - name: reject
 
 # Step 3: CLW Retrieval Check (background_based)
@@ -258,7 +248,7 @@ obs post filters:
   maxvalue: 999.0
   actions:
     - name: set
-      flag: CLWRetrievalReject
+      flag: CLWRetrievalCheck
     - name: reject
 
 # Step 4: Window channel sanity check
@@ -272,6 +262,10 @@ obs post filters:
   maxvalue: 200.0
   minvalue: -200.0
   flag all filter variables if any test variable is out of bounds: true
+  actions:
+    - name: set
+      flag: WindowChannelExtremeResidual
+    - name: reject
 
 # Step 5: Hydrometeor Check (cloud/precipitation affected chanels)
 - filter: Variable Assignment
@@ -305,7 +299,7 @@ obs post filters:
   maxvalue: 0.0
   actions:
     - name: set
-      flag: HydrometeorCheckReject
+      flag: HydrometeorCheck
       ignore: rejected observations
     - name: reject
 
@@ -470,7 +464,7 @@ obs post filters:
     channels: *atms_npp_channels
   actions:
     - name: set
-      flag: GrossCheckReject
+      flag: GrossCheck
       ignore: rejected observations
     - name: reject
 
@@ -487,15 +481,38 @@ obs post filters:
       use passive_bc: true
       sensor: *Sensor_ID
       use_flag: [ 1,  1,  1,  1,  1,
-                 1,  1,  1,  1,  1,
                   1,  1,  1,  1,  1,
+                  1,  1,  1,  1,  4,
                   1,  1,  1,  1,  1,
                   1,  1]
   maxvalue: 1.0e-12
   actions:
     - name: set
-      flag: InterChannelCheckReject
+      flag: InterChannelConsistency
       ignore: rejected observations
     - name: reject
+
+# Step 12: Useflag Check
+- filter: Bounds Check
+  filter variables:
+  - name: brightnessTemperature
+    channels: *atms_npp_channels
+  test variables:
+  - name: ObsFunction/ChannelUseflagCheckRad
+    channels: *atms_npp_channels
+    options:
+      channels: *atms_npp_channels
+      use_flag: [ 1,  1,  1,  1,  1,
+                  1,  1,  1,  1,  1,
+                  1,  1,  1,  1,  4,
+                  1,  1,  1,  1,  1,
+                  1,  1]
+  minvalue: 1.0e-12
+  actions:
+    - name: set
+      flag: UseflagCheck
+      ignore: rejected observations
+    - name: reject
+
 passedBenchmark: 182751 # GSI: 182751
 

--- a/parm/atm/obs/testing/atms_npp_noqc.yaml
+++ b/parm/atm/obs/testing/atms_npp_noqc.yaml
@@ -1,12 +1,3 @@
-obs operator:
-  name: CRTM
-  Absorbers: [H2O,O3]
-  Clouds: [Water, Ice]
-  Cloud_Fraction: 1.0
-  obs options:
-    Sensor_ID: &Sensor_ID atms_npp 
-    EndianType: little_endian
-    CoefficientPath: crtm/
 obs space:
   name: atms_npp 
   obsdatain:
@@ -19,8 +10,20 @@ obs space:
         obsfile: !ENV atms_npp_diag_${CDATE}.nc4
   simulated variables: [brightnessTemperature]
   channels: &atms_npp_channels 1-22
+
 geovals:
   filename: !ENV atms_npp_geoval_${CDATE}.nc4
+
+obs operator:
+  name: CRTM
+  Absorbers: [H2O,O3]
+  Clouds: [Water, Ice]
+  Cloud_Fraction: 1.0
+  obs options:
+    Sensor_ID: &Sensor_ID atms_npp
+    EndianType: little_endian
+    CoefficientPath: crtm/
+
 obs bias:
   input file: !ENV atms_npp_satbias_${GDATE}.nc4
   variational bc:


### PR DESCRIPTION
In [ previous PR](https://github.com/NOAA-EMC/GDASApp/pull/757) for ATMS, the end-to-end testing was done without data thinning.  And the excessive QC filtering in clear-sky areas, compared to GSI,  was found. (See [plots](https://github.com/NOAA-EMC/GDASApp/pull/757#issuecomment-1819753244))

This PR includes two fixes for ATMS in the end-to-end testing and one new feature:
1. fix the excess QC filtering in clear-sky areas.  ---> This has a paring [UFO PR #3122](https://github.com/JCSDA-internal/ufo/pull/3122)
2. add data thinning 
3. add the diagnostic flags (QC) --- **This can [reproduce QC flags](https://github.com/NOAA-EMC/GDASApp/pull/768#issuecomment-1828209921) from GSI in UFO** 

**To test updates in this PR, please check out the UFO branch: [feature/satrad](https://github.com/JCSDA-internal/ufo/tree/feature/satrad) from JCSDA-internal in gdas-validation.  This branch consolidates all proposed code changes to UFO for gdas validation:
UFO PR #https://github.com/JCSDA-internal/ufo/pull/3122
UFO PR #https://github.com/JCSDA-internal/ufo/pull/3121
UFO PR #https://github.com/JCSDA-internal/ufo/pull/3094

