### PR TITLE
Adapted the recent changes in the assimilation window

### DIFF
--- a/test/land/letkfoi_land.yaml
+++ b/test/land/letkfoi_land.yaml
@@ -164,6 +164,5 @@ observations:
 output increment:
   filename_sfcd: xainc.sfc_data.nc
   filetype: fms restart
-time window:
-  begin: '2021-03-23T15:00:00Z'
-  length: PT6H
+window begin: '2021-03-23T15:00:00Z'
+window length: PT6H


### PR DESCRIPTION
The recent changes below in **JEDI UFO/OOPS/IODA** cause the failure of `test_gdasapp_land_letkfoi_snowda`

Use `window begin` and `window length` for adapting the recent changes in defining the assimilation window. 

https://github.com/JCSDA-internal/ufo/pull/3056
https://github.com/JCSDA-internal/oops/pull/2386
https://github.com/JCSDA-internal/ioda/pull/1121
