### PR TITLE
make ctest dmpdir more like real life

### DIFF
--- a/parm/soca/obsproc/obsproc_config_test.yaml
+++ b/parm/soca/obsproc/obsproc_config_test.yaml
@@ -1,25 +1,25 @@
 observations:
 - obs space:
     name: sss_smap
-    obsproc subdir: '' 
+    obsproc subdir: 'SSS'
     obsproc regex: sss_smap_?.nc4
     provider: SMAP
     output file: sss_smap.ioda.nc
 - obs space:
     name: sss_smos
     provider: SMOS
-    obsproc subdir: ''
+    obsproc subdir: 'SSS'
     output file: sss_smos.ioda.nc
     obsproc regex: sss_smos_?.nc4
 - obs space:
     name: adt_3b_egm2008
-    obsproc subdir: ''
+    obsproc subdir: 'ADT'
     obsproc regex: rads_adt_??_???????.nc4
     provider: RADS
     output file: adt_all.nc4
 - obs space:
     name: icec_amsr2_north
     provider: AMSR2
-    obsproc subdir: ''
+    obsproc subdir: 'ice'
     output file: icec_amsr2_north.ioda.nc
     obsproc regex: icec_amsr2_north_?.nc4

--- a/test/soca/gw/setup_obsproc.sh
+++ b/test/soca/gw/setup_obsproc.sh
@@ -11,6 +11,8 @@ mkdir -p ${test_dmpdir}
 
 cd ${test_dmpdir}
 
+mkdir SSS ADT icec sst
+
 ${project_source_dir}/utils/test/prepdata.sh ${project_source_dir}/utils/test/
 
 

--- a/utils/test/prepdata.sh
+++ b/utils/test/prepdata.sh
@@ -17,17 +17,17 @@ cdl2nc4() {
 project_source_dir=$1
 
 
-cdl2nc4 rads_adt_3a_2021181.nc4 ${project_source_dir}/testdata/rads_adt_3a_2021181.cdl
-cdl2nc4 rads_adt_3b_2021181.nc4 ${project_source_dir}/testdata/rads_adt_3b_2021181.cdl
-cdl2nc4 icec_amsr2_north_1.nc4 ${project_source_dir}/testdata/icec_amsr2_north_1.cdl
-cdl2nc4 icec_amsr2_north_2.nc4 ${project_source_dir}/testdata/icec_amsr2_north_2.cdl
-cdl2nc4 icec_amsr2_south_1.nc4 ${project_source_dir}/testdata/icec_amsr2_south_1.cdl
-cdl2nc4 icec_amsr2_south_2.nc4 ${project_source_dir}/testdata/icec_amsr2_south_2.cdl
-cdl2nc4 sss_smap_1.nc4 ${project_source_dir}/testdata/sss_smap_1.cdl
-cdl2nc4 sss_smap_2.nc4 ${project_source_dir}/testdata/sss_smap_2.cdl
-cdl2nc4 sss_smos_1.nc4 ${project_source_dir}/testdata/sss_smos_1.cdl
-cdl2nc4 sss_smos_2.nc4 ${project_source_dir}/testdata/sss_smos_2.cdl
-cdl2nc4 ghrsst_sst_mb_202107010000.nc4 ${project_source_dir}/testdata/ghrsst_sst_mb_202107010000.cdl
-cdl2nc4 ghrsst_sst_mb_202107010100.nc4 ${project_source_dir}/testdata/ghrsst_sst_mb_202107010100.cdl
-cdl2nc4 viirs_aod_1.nc4 ${project_source_dir}/testdata/viirs_aod_1.cdl
-cdl2nc4 viirs_aod_2.nc4 ${project_source_dir}/testdata/viirs_aod_2.cdl
+cdl2nc4 ADT/rads_adt_3a_2021181.nc4 ${project_source_dir}/testdata/rads_adt_3a_2021181.cdl
+cdl2nc4 ADT/rads_adt_3b_2021181.nc4 ${project_source_dir}/testdata/rads_adt_3b_2021181.cdl
+cdl2nc4 icec/icec_amsr2_north_1.nc4 ${project_source_dir}/testdata/icec_amsr2_north_1.cdl
+cdl2nc4 icec/icec_amsr2_north_2.nc4 ${project_source_dir}/testdata/icec_amsr2_north_2.cdl
+cdl2nc4 icec/icec_amsr2_south_1.nc4 ${project_source_dir}/testdata/icec_amsr2_south_1.cdl
+cdl2nc4 icec/icec_amsr2_south_2.nc4 ${project_source_dir}/testdata/icec_amsr2_south_2.cdl
+cdl2nc4 SSS/sss_smap_1.nc4 ${project_source_dir}/testdata/sss_smap_1.cdl
+cdl2nc4 SSS/sss_smap_2.nc4 ${project_source_dir}/testdata/sss_smap_2.cdl
+cdl2nc4 SSS/sss_smos_1.nc4 ${project_source_dir}/testdata/sss_smos_1.cdl
+cdl2nc4 SSS/sss_smos_2.nc4 ${project_source_dir}/testdata/sss_smos_2.cdl
+cdl2nc4 sst/ghrsst_sst_mb_202107010000.nc4 ${project_source_dir}/testdata/ghrsst_sst_mb_202107010000.cdl
+cdl2nc4 sst/ghrsst_sst_mb_202107010100.nc4 ${project_source_dir}/testdata/ghrsst_sst_mb_202107010100.cdl
+cdl2nc4 sst/viirs_aod_1.nc4 ${project_source_dir}/testdata/viirs_aod_1.cdl
+cdl2nc4 sst/viirs_aod_2.nc4 ${project_source_dir}/testdata/viirs_aod_2.cdl


### PR DESCRIPTION
This makes the ctest DMPDIR for observation files more like the DMPDIR used in model runs, in order to provide for closer-to-life ctests, and in anticipation of the R2D2-ectomy.

