### PR TITLE
Adding a feature Metadata/ocean-basin-flag to all ioda converters

### DIFF
--- a/utils/obsproc/Ghrsst2Ioda.h
+++ b/utils/obsproc/Ghrsst2Ioda.h
@@ -181,8 +181,14 @@ namespace gdasapp {
       // number of obs after subsampling
       int nobs = sst_s.size() * sst_s[0].size();
 
+      // Set the int metadata names
+      std::vector<std::string> intMetadataNames = {"oceanBasin"};
+
+      // Set the float metadata name
+      std::vector<std::string> floatMetadataNames = {};
+
       // Create instance of iodaVars object
-      gdasapp::obsproc::iodavars::IodaVars iodaVars(nobs, {}, {});
+      gdasapp::obsproc::iodavars::IodaVars iodaVars(nobs, floatMetadataNames, intMetadataNames);
 
       // Reference time is Jan 01 1981 00:00:00 GMT+0000
       iodaVars.referenceDate_ = refDate;
@@ -197,6 +203,8 @@ namespace gdasapp {
           iodaVars.obsError_(loc)  = obserror_s[i][j];
           iodaVars.preQc_(loc)     = 0;
           iodaVars.datetime_(loc)  = seconds_s[i][j];
+          // Store optional metadata, set ocean basins to -999 for now
+          iodaVars.intMetadata_.row(loc) << -999;
           loc += 1;
         }
       }

--- a/utils/obsproc/IcecAmsr2Ioda.h
+++ b/utils/obsproc/IcecAmsr2Ioda.h
@@ -43,8 +43,14 @@ namespace gdasapp {
       int nobs = dimxSize * dimySize;
       int ntimes = dimxSize * dimySize * dimTimeSize;
 
+      // Set the int metadata names
+      std::vector<std::string> intMetadataNames = {"oceanBasin"};
+
+      // Set the float metadata name
+      std::vector<std::string> floatMetadataNames = {};
+
       // Create instance of iodaVars object
-      gdasapp::obsproc::iodavars::IodaVars iodaVars(nobs, {}, {});
+      gdasapp::obsproc::iodavars::IodaVars iodaVars(nobs, floatMetadataNames, intMetadataNames);
 
       oops::Log::debug() << "--- iodaVars.location_: " << iodaVars.location_ << std::endl;
 
@@ -103,6 +109,8 @@ namespace gdasapp {
         iodaVars.obsVal_(i) = static_cast<float>(oneDimObsVal[i]*0.01f);
         iodaVars.obsError_(i) = 0.1;  // Do something for obs error
         iodaVars.preQc_(i) = oneDimFlagsVal[i];
+        // Store optional metadata, set ocean basins to -999 for now
+        iodaVars.intMetadata_.row(i) << -999;
       }
 
       // basic test for iodaVars.trim

--- a/utils/obsproc/NetCDFToIodaConverter.h
+++ b/utils/obsproc/NetCDFToIodaConverter.h
@@ -153,6 +153,18 @@ namespace gdasapp {
         for (const std::string& strMeta : iodaVars.intMetadataName_) {
           tmpIntMeta = ogrp.vars.createWithScales<int>("MetaData/"+strMeta,
                                                          {ogrp.vars["Location"]}, int_params);
+          // get ocean basin masks if asked in the config
+          obsproc::oceanmask::OceanMask* oceanMask = nullptr;
+          if (fullConfig_.has("ocean basin")) {
+             std::string fileName;
+             fullConfig_.get("ocean basin", fileName);
+             oceanMask = new obsproc::oceanmask::OceanMask(fileName);
+
+             for (int i = 0; i < iodaVars.location_; i++) {
+               iodaVars.intMetadata_.coeffRef(i, size(iodaVars.intMetadataName_)-1) =
+                 oceanMask->getOceanMask(iodaVars.longitude_[i], iodaVars.latitude_[i]);
+             }
+          }
           tmpIntMeta.writeWithEigenRegular(iodaVars.intMetadata_.col(count));
           count++;
         }

--- a/utils/obsproc/Rads2Ioda.h
+++ b/utils/obsproc/Rads2Ioda.h
@@ -123,19 +123,6 @@ namespace gdasapp {
         (iodaVars.obsVal_ > -4.0 && iodaVars.obsVal_ < 4.0);
       iodaVars.trim(boundsCheck);
 
-      // get ocean basin masks if asked in the config
-      obsproc::oceanmask::OceanMask* oceanMask = nullptr;
-      if (fullConfig_.has("ocean basin")) {
-          std::string fileName;
-          fullConfig_.get("ocean basin", fileName);
-          oceanMask = new obsproc::oceanmask::OceanMask(fileName);
-
-          for (int i = 0; i < iodaVars.location_; i++) {
-            iodaVars.intMetadata_.coeffRef(i, 3) =
-              oceanMask->getOceanMask(iodaVars.longitude_[i], iodaVars.latitude_[i]);
-          }
-      }
-
       return iodaVars;
     };
   };  // class Rads2Ioda

--- a/utils/obsproc/Smap2Ioda.h
+++ b/utils/obsproc/Smap2Ioda.h
@@ -41,7 +41,14 @@ namespace gdasapp {
       int dim1  = ncFile.getDim("phony_dim_1").getSize();
       int nobs = dim0 * dim1;
 
-      gdasapp::obsproc::iodavars::IodaVars iodaVars(nobs, {}, {});
+      // Set the int metadata names
+      std::vector<std::string> intMetadataNames = {"oceanBasin"};
+
+      // Set the float metadata name
+      std::vector<std::string> floatMetadataNames = {};
+
+      // Create instance of iodaVars object
+      gdasapp::obsproc::iodavars::IodaVars iodaVars(nobs, floatMetadataNames, intMetadataNames);
 
       // TODO(AFE): these arrays can be done as 1D vectors, but those need proper ushorts in
       // the input files, at odd with the current ctests
@@ -102,6 +109,8 @@ namespace gdasapp {
           iodaVars.obsError_(loc) = sss_error[i][j];
           iodaVars.preQc_(loc) = sss_qc[i][j];
           iodaVars.datetime_(loc) =  static_cast<int64_t>(obsTime[j] + secondsSinceEpoch);
+          // Store optional metadata, set ocean basins to -999 for now
+          iodaVars.intMetadata_.row(loc) << -999;
         }
       }
 

--- a/utils/obsproc/Smos2Ioda.h
+++ b/utils/obsproc/Smos2Ioda.h
@@ -37,7 +37,7 @@ namespace gdasapp {
       // Set the int metadata names
       // TODO(AFE): add other metadata in form of
       // std::vector<std::string> intMetadataNames = {"pass", "cycle", "mission"};
-      std::vector<std::string> intMetadataNames = {};
+      std::vector<std::string> intMetadataNames = {"oceanBasin"};
 
       // Set the float metadata name
       // TODO(AFE): add other metadata in form of
@@ -81,6 +81,8 @@ namespace gdasapp {
         iodaVars.obsError_(i) = sss_error[i];
         iodaVars.preQc_(i) = sss_qc[i];
         iodaVars.datetime_(i) =  static_cast<int64_t>(datetime_[i]*86400.0f) + mjd2000;
+        // Store optional metadata, set ocean basins to -999 for now
+        iodaVars.intMetadata_.row(i) << -999;
       }
 
       // basic test for iodaVars.trim

--- a/utils/test/testinput/gdas_ghrsst2ioda.yaml
+++ b/utils/test/testinput/gdas_ghrsst2ioda.yaml
@@ -9,7 +9,7 @@ bounds:
   min: -3.0
   max: 50.0
 output file: ghrsst_sst_mb_20210701.ioda.nc
-ocean basin: RECCAP2_region_masks_all_v20221025.nc
+#ocean basin: RECCAP2_region_masks_all_v20221025.nc
 input files:
 - ghrsst_sst_mb_202107010000.nc4
 - ghrsst_sst_mb_202107010100.nc4

--- a/utils/test/testinput/gdas_ghrsst2ioda.yaml
+++ b/utils/test/testinput/gdas_ghrsst2ioda.yaml
@@ -9,6 +9,7 @@ bounds:
   min: -3.0
   max: 50.0
 output file: ghrsst_sst_mb_20210701.ioda.nc
+ocean basin: RECCAP2_region_masks_all_v20221025.nc
 input files:
 - ghrsst_sst_mb_202107010000.nc4
 - ghrsst_sst_mb_202107010100.nc4

--- a/utils/test/testinput/gdas_icecamsr2ioda.yaml
+++ b/utils/test/testinput/gdas_icecamsr2ioda.yaml
@@ -2,7 +2,7 @@ provider: AMSR2
 window begin: 2018-04-15T06:00:00Z
 window end: 2018-04-15T12:00:00Z
 output file: icec_amsr2_north.ioda.nc
-ocean basin: RECCAP2_region_masks_all_v20221025.nc
+#ocean basin: RECCAP2_region_masks_all_v20221025.nc
 input files:
 - icec_amsr2_north_1.nc4
 - icec_amsr2_north_2.nc4

--- a/utils/test/testinput/gdas_icecamsr2ioda.yaml
+++ b/utils/test/testinput/gdas_icecamsr2ioda.yaml
@@ -2,6 +2,7 @@ provider: AMSR2
 window begin: 2018-04-15T06:00:00Z
 window end: 2018-04-15T12:00:00Z
 output file: icec_amsr2_north.ioda.nc
+ocean basin: RECCAP2_region_masks_all_v20221025.nc
 input files:
 - icec_amsr2_north_1.nc4
 - icec_amsr2_north_2.nc4

--- a/utils/test/testinput/gdas_rads2ioda.yaml
+++ b/utils/test/testinput/gdas_rads2ioda.yaml
@@ -2,7 +2,7 @@ provider: RADS
 window begin: 2018-04-15T06:00:00Z
 window end: 2018-04-15T12:00:00Z
 output file: rads_adt_3ab_2021181.ioda.nc
-#ocean basin: RECCAP2_region_masks_all_v20221025.nc
+ocean basin: RECCAP2_region_masks_all_v20221025.nc
 input files:
 - rads_adt_3a_2021181.nc4
 - rads_adt_3b_2021181.nc4

--- a/utils/test/testinput/gdas_rads2ioda.yaml
+++ b/utils/test/testinput/gdas_rads2ioda.yaml
@@ -2,7 +2,7 @@ provider: RADS
 window begin: 2018-04-15T06:00:00Z
 window end: 2018-04-15T12:00:00Z
 output file: rads_adt_3ab_2021181.ioda.nc
-ocean basin: RECCAP2_region_masks_all_v20221025.nc
+#ocean basin: RECCAP2_region_masks_all_v20221025.nc
 input files:
 - rads_adt_3a_2021181.nc4
 - rads_adt_3b_2021181.nc4

--- a/utils/test/testinput/gdas_smap2ioda.yaml
+++ b/utils/test/testinput/gdas_smap2ioda.yaml
@@ -2,7 +2,7 @@ provider: SMAP
 window begin: 2018-04-15T06:00:00Z
 window end: 2018-04-15T12:00:00Z
 output file: sss_smap.ioda.nc
-ocean basin: RECCAP2_region_masks_all_v20221025.nc
+#ocean basin: RECCAP2_region_masks_all_v20221025.nc
 input files:
 - sss_smap_1.nc4
 - sss_smap_2.nc4

--- a/utils/test/testinput/gdas_smap2ioda.yaml
+++ b/utils/test/testinput/gdas_smap2ioda.yaml
@@ -2,6 +2,7 @@ provider: SMAP
 window begin: 2018-04-15T06:00:00Z
 window end: 2018-04-15T12:00:00Z
 output file: sss_smap.ioda.nc
+ocean basin: RECCAP2_region_masks_all_v20221025.nc
 input files:
 - sss_smap_1.nc4
 - sss_smap_2.nc4

--- a/utils/test/testinput/gdas_smos2ioda.yaml
+++ b/utils/test/testinput/gdas_smos2ioda.yaml
@@ -2,6 +2,7 @@ provider: SMOS
 window begin: 2018-04-15T06:00:00Z
 window end: 2018-04-15T12:00:00Z
 output file: sss_smos.ioda.nc
+ocean basin: RECCAP2_region_masks_all_v20221025.nc
 input files:
 - sss_smos_1.nc4
 - sss_smos_2.nc4

--- a/utils/test/testinput/gdas_smos2ioda.yaml
+++ b/utils/test/testinput/gdas_smos2ioda.yaml
@@ -2,7 +2,7 @@ provider: SMOS
 window begin: 2018-04-15T06:00:00Z
 window end: 2018-04-15T12:00:00Z
 output file: sss_smos.ioda.nc
-ocean basin: RECCAP2_region_masks_all_v20221025.nc
+#ocean basin: RECCAP2_region_masks_all_v20221025.nc
 input files:
 - sss_smos_1.nc4
 - sss_smos_2.nc4


### PR DESCRIPTION
- Moved a simple OceanMask struct that reads in regional ocean masks to base class
- Those are an implementation of the feature in all converters

Close https://github.com/NOAA-EMC/GDASApp/issues/775

- Tested with one full obs file for each converter:
![ocean_flag_combined](https://github.com/NOAA-EMC/GDASApp/assets/141867620/e114f1c4-f45a-420e-8336-26075cdfa301)
