### PR TITLE
Fix missing datetime "unit" and Ghrsst2ioda output "K" to "C"

### DIFF
--- a/utils/obsproc/Ghrsst2Ioda.h
+++ b/utils/obsproc/Ghrsst2Ioda.h
@@ -36,10 +36,6 @@ namespace gdasapp {
       fullConfig_.get("bounds.min", sstMin);
       float sstMax;
       fullConfig_.get("bounds.max", sstMax);
-      if ( sstUnits == "C" ) {
-        sstMin += 0.0;
-        sstMax += 0.0;
-      }
 
       // Open the NetCDF file in read-only mode
       netCDF::NcFile ncFile(fileName, netCDF::NcFile::read);

--- a/utils/obsproc/Ghrsst2Ioda.h
+++ b/utils/obsproc/Ghrsst2Ioda.h
@@ -37,8 +37,8 @@ namespace gdasapp {
       float sstMax;
       fullConfig_.get("bounds.max", sstMax);
       if ( sstUnits == "C" ) {
-        sstMin += 273.15;
-        sstMax += 273.15;
+        sstMin += 0.0;
+        sstMax += 0.0;
       }
 
       // Open the NetCDF file in read-only mode
@@ -135,9 +135,9 @@ namespace gdasapp {
           preqc[i][j] = 5 - static_cast<int>(sstPreQC[0][i][j]);
 
           // bias corrected sst, regressed to the drifter depth
-          sst[i][j] = static_cast<float>(sstObsVal[index]) * sstScaleFactor + sstOffSet
+          // Remove added sstOffSet for Celsius
+          sst[i][j] = static_cast<float>(sstObsVal[index]) * sstScaleFactor
                     - static_cast<float>(sstObsBias[index]) * biasScaleFactor;
-
           // mask
           if (sst[i][j] >= sstMin && sst[i][j] <= sstMax && preqc[i][j] ==0) {
             mask[i][j] = 1;

--- a/utils/obsproc/NetCDFToIodaConverter.h
+++ b/utils/obsproc/NetCDFToIodaConverter.h
@@ -120,7 +120,8 @@ namespace gdasapp {
         ioda::Variable iodaDatetime =
           ogrp.vars.createWithScales<int64_t>("MetaData/dateTime",
                                           {ogrp.vars["Location"]}, long_params);
-        iodaDatetime.atts.add<std::string>("units", {iodaVarsAll.referenceDate_}, {1});
+        // TODO(MD): Make sure units with iodaVarsAll when applying mpi
+        iodaDatetime.atts.add<std::string>("units", {iodaVars.referenceDate_}, {1});
         ioda::Variable iodaLat =
           ogrp.vars.createWithScales<float>("MetaData/latitude",
                                             {ogrp.vars["Location"]}, float_params);

--- a/utils/test/testinput/gdas_ghrsst2ioda.yaml
+++ b/utils/test/testinput/gdas_ghrsst2ioda.yaml
@@ -5,7 +5,6 @@ binning:
   stride: 2
   min number of obs: 1
 bounds:
-  units: C
   min: -3.0
   max: 50.0
 output file: ghrsst_sst_mb_20210701.ioda.nc

--- a/utils/test/testref/ghrsst2ioda.test
+++ b/utils/test/testref/ghrsst2ioda.test
@@ -1,9 +1,9 @@
 Reading: [ghrsst_sst_mb_202107010000.nc4,ghrsst_sst_mb_202107010100.nc4]
 seconds since 1981-01-01T00:00:00Z
 obsVal:
-    Min: 276.708
-    Max: 281.714
-    Sum: 10051.7
+    Min: 3.558
+    Max: 8.5635
+    Sum: 218.297
 obsError:
     Min: 0.32
     Max: 0.61


### PR DESCRIPTION
This PR fixes two bugs:

1. Missing datetime "units"
2. Ghrsst2ioda converter outputs sea surface temperature with unit "C"

All outputs are placed at each issue at https://github.com/NOAA-EMC/GDASApp/issues/831 and https://github.com/NOAA-EMC/GDASApp/issues/830

Close https://github.com/NOAA-EMC/GDASApp/issues/831 , Close https://github.com/NOAA-EMC/GDASApp/issues/830