### PR TITLE
Add 'bound to include' to manipulate the DA window.

### DIFF
--- a/parm/land/letkfoi/letkfoi.yaml
+++ b/parm/land/letkfoi/letkfoi.yaml
@@ -22,6 +22,7 @@ geometry:
 time window:
   begin: '{{ LAND_WINDOW_BEGIN | to_isotime }}'
   length: $(LAND_WINDOW_LENGTH)
+  bound to include: begin
 
 background:
    datetime: '{{ current_cycle | to_isotime }}'


### PR DESCRIPTION
Add `bound to include` to manipulate the DA window following the recent upgrades in JEDI on the DA window manipulation (PRs [ufo #3056](https://github.com/JCSDA-internal/ufo/pull/3056); [oops #2386](https://github.com/JCSDA-internal/oops/pull/2386) and [ioda #1121](https://github.com/JCSDA-internal/ioda/pull/1121)) for handling the loss of the observations due to the difference in NCEP dump convention and IODA convention.