### PR TITLE
Make changes to include 'OCNRES' in the orography filenames.

### DIFF
--- a/parm/land/letkfoi/apply_incr_nml.j2
+++ b/parm/land/letkfoi/apply_incr_nml.j2
@@ -6,5 +6,5 @@
   rst_path = "{{ DATA }}/anl",
   inc_path = "{{ DATA }}/anl",
   orog_path = "{{ HOMEgfs }}/fix/orog/{{ CASE }}",
-  otype = "{{ CASE }}_oro_data"
+  otype = "{{ CASE }}.mx{{ OCNRES }}_oro_data"
 /

--- a/parm/land/letkfoi/letkfoi.yaml
+++ b/parm/land/letkfoi/letkfoi.yaml
@@ -17,7 +17,7 @@ geometry:
       skip coupler file: true
       state variables: [orog_filt]
       datapath: $(FIXgfs)/orog/${CASE}/
-      filename_orog: $(CASE)_oro_data.nc
+      filename_orog: $(CASE).mx$(OCNRES)_oro_data.nc
 
 time window:
   begin: '{{ LAND_WINDOW_BEGIN | to_isotime }}'


### PR DESCRIPTION
This PR is to address the recent filename changes of the orography data from `$(CASE)_oro_data.nc` to `$(CASE).mx$(OCNRES)_oro_data.nc` in the global-workflow. 

This PR is a prerequisite to support https://github.com/NOAA-EMC/global-workflow/pull/2232. 