### PR TITLE
update resdet and resens keywords in prototypes

### DIFF
--- a/prototypes/configs/cp0.sh
+++ b/prototypes/configs/cp0.sh
@@ -14,8 +14,8 @@ edate=2021080118
 app="ATM"
 starttype="cold"
 gfscyc=0
-resdet=96
-resens=96
+resdetatmos=96
+resensatmos=96
 nens=0
 # config.* options
 DO_JEDIATMVAR="YES"

--- a/prototypes/gen_prototype.sh
+++ b/prototypes/gen_prototype.sh
@@ -89,8 +89,8 @@ cd $GWDIR/global-workflow/workflow
                            --app $app \
                            --start $starttype \
                            --gfs_cyc $gfscyc \
-                           --resdet $resdet \
-                           --resens $resens \
+                           --resdetatmos $resdetatmos \
+                           --resensatmos $resensatmos \
                            --nens $nens \
                            --pslot $PSLOT \
                            --configdir $GWDIR/global-workflow/parm/config/gfs \


### PR DESCRIPTION
This PR replaces `--resdet` and `--resens` with `--resdetatmos` and `--resensatmos`, respectively, in order to restore the functionality of automated GDASApp tests which exercise g-w.

Resolves #866