### PR TITLE
Added ObsType group variables to the adpupa prepbufr api

### DIFF
--- a/ush/ioda/bufr2ioda/bufr2ioda_adpupa_prepbufr.py
+++ b/ush/ioda/bufr2ioda/bufr2ioda_adpupa_prepbufr.py
@@ -49,6 +49,16 @@ def Compute_dateTime(cycleTimeSinceEpoch, hrdr):
     return dateTime
 
 
+def Mask_typ_for_var(typ, var):
+
+    typ_var = copy.deepcopy(typ)
+    for i in range(len(typ_var)):
+        if ma.is_masked(var[i]):
+            typ_var[i] = typ.fill_value
+
+    return typ_var
+
+
 def bufr_to_ioda(config, logger):
 
     subsets = config["subsets"]
@@ -86,6 +96,9 @@ def bufr_to_ioda(config, logger):
 
     logger.info('Making QuerySet')
     q = bufr.QuerySet(subsets)
+
+    # ObsType
+    q.add('observationType', '*/TYP')
 
     # MetaData
     q.add('prepbufrDataLevelCategory', '*/PRSLEVEL/CAT')
@@ -136,7 +149,11 @@ def bufr_to_ioda(config, logger):
     with bufr.File(DATA_PATH) as f:
         r = f.execute(q)
 
+    # ObsType
+    logger.debug(" ... Executing QuerySet for ADPUPA: get ObsType ...")
+    obstyp = r.get('observationType', 'prepbufrDataLevelCategory', type='int32')
     logger.info('Executing QuerySet: get metadata')
+
     # MetaData
     cat = r.get('prepbufrDataLevelCategory', 'prepbufrDataLevelCategory')
     lat = r.get('latitude', 'prepbufrDataLevelCategory')
@@ -306,6 +323,23 @@ def bufr_to_ioda(config, logger):
     running_time = end_time - start_time
     logger.info(f"Running time for creating derived variables : {running_time} seconds")
 
+    # Mask Certain Variables
+    logger.debug(f"Mask typ for certain variables where data is available...")
+    typ_ps = Mask_typ_for_var(obstyp, ps)
+    typ_tsen = Mask_typ_for_var(obstyp, tsen)
+    typ_tvo = Mask_typ_for_var(obstyp, tvo)
+    typ_qob = Mask_typ_for_var(obstyp, qob)
+    typ_uob = Mask_typ_for_var(obstyp, uob)
+    typ_vob = Mask_typ_for_var(obstyp, vob)
+
+    logger.debug(f"     Check drived variables (typ*) shape & type ... ")
+    logger.debug(f"     typ_ps shape, type = {typ_ps.shape}, {typ_ps.dtype}")
+    logger.debug(f"     typ_tsen shape, type = {typ_tsen.shape}, {typ_tsen.dtype}")
+    logger.debug(f"     typ_tvo shape, type = {typ_tvo.shape}, {typ_tvo.dtype}")
+    logger.debug(f"     typ_qob shape, type = {typ_qob.shape}, {typ_qob.dtype}")
+    logger.debug(f"     typ_uob shape, type = {typ_uob.shape}, {typ_uob.dtype}")
+    logger.debug(f"     typ_vob shape, type = {typ_vob.shape}, {typ_vob.dtype}")
+
     # Create the dimensions
     dims = {'Location': np.arange(0, lat.shape[0])}
 
@@ -327,6 +361,36 @@ def bufr_to_ioda(config, logger):
         .write_attr('units', '1') \
         .write_attr('long_name', 'Prepbufr Data Level Category') \
         .write_data(cat)
+
+    # Observation Type: airTemperature
+    obsspace.create_var('ObsType/airTemperature', dtype=obstyp.dtype, fillval=obstyp.fill_value) \
+        .write_attr('long_name', 'Observation Type') \
+        .write_data(typ_tsen)
+
+    # Observation Type: virtualTemperature
+    obsspace.create_var('ObsType/virtualTemperature', dtype=obstyp.dtype, fillval=obstyp.fill_value) \
+        .write_attr('long_name', 'Observation Type') \
+        .write_data(typ_tvo)
+
+    # Observation Type: stationPressure
+    obsspace.create_var('ObsType/stationPressure', dtype=obstyp.dtype, fillval=obstyp.fill_value) \
+        .write_attr('long_name', 'Observation Type') \
+        .write_data(typ_ps)
+
+    # Observation Type: specificHumidity
+    obsspace.create_var('ObsType/specificHumidity', dtype=obstyp.dtype, fillval=obstyp.fill_value) \
+        .write_attr('long_name', 'Observation Type') \
+        .write_data(typ_qob)
+
+    # Observation Type: windEastward
+    obsspace.create_var('ObsType/windEastward', dtype=obstyp.dtype, fillval=obstyp.fill_value) \
+        .write_attr('long_name', 'Observation Type') \
+        .write_data(typ_uob)
+
+    # Observation Type: windNorthward
+    obsspace.create_var('ObsType/windNorthward', dtype=obstyp.dtype, fillval=obstyp.fill_value) \
+        .write_attr('long_name', 'Observation Type') \
+        .write_data(typ_vob)
 
     # Latitude
     obsspace.create_var('MetaData/latitude', dtype=lat.dtype, fillval=lat.fill_value) \


### PR DESCRIPTION
This PR adds ObsType group variables to the ADPUPA prepbufr Python api. 

The following file has been changed: 
- bufr2ioda/bufr2ioda_adpupa_prepbufr.py

Thank you @ADCollard for updating the Python api. The ObsSubType group variables are not required and hence removed from the code. 

 I performed the following tests: 
[X] Self-reviewed the code. 
[X] Ran end-to-end tests. 
[X] Created HofX plots, which agreed with the GSI plots.  

