### PR TITLE
Change IMS prep path to point to GDAS fix directory

### DIFF
--- a/parm/land/prep/prep_ims.yaml
+++ b/parm/land/prep/prep_ims.yaml
@@ -3,7 +3,7 @@ calcfims:
     - {{ DATA }}/obs
   copy:
     - [{{ COM_OBS }}/{{ OPREFIX }}ims{{ current_cycle | to_julian }}_4km_v1.3.nc, {{ DATA }}/obs/ims{{ current_cycle | to_julian }}_4km_v1.3.nc]
-    - [{{ COM_OBS }}/{{ OPREFIX }}IMS4km_to_FV3_mapping.{{ CASE }}_oro_data.nc, {{ DATA }}/obs/IMS4km_to_FV3_mapping.{{ CASE }}_oro_data.nc]
+    - [{{ fixGDAS }}/obs/IMS_4km_to_{{ CASE }}.mx{{ OCNRES }}.nc, {{ DATA }}/obs/IMS4km_to_FV3_mapping.{{ CASE }}_oro_data.nc]
 ims2ioda:
   copy:
     - [{{ DATA }}/ims_snow_{{ current_cycle | to_YMDH }}.nc4, {{ COM_OBS }}/{{ OPREFIX }}ims_snow.nc4]

--- a/parm/land/prep/prep_ims.yaml
+++ b/parm/land/prep/prep_ims.yaml
@@ -3,7 +3,7 @@ calcfims:
     - {{ DATA }}/obs
   copy:
     - [{{ COM_OBS }}/{{ OPREFIX }}ims{{ current_cycle | to_julian }}_4km_v1.3.nc, {{ DATA }}/obs/ims{{ current_cycle | to_julian }}_4km_v1.3.nc]
-    - [{{ fixGDAS }}/obs/IMS_4km_to_{{ CASE }}.mx{{ OCNRES }}.nc, {{ DATA }}/obs/IMS4km_to_FV3_mapping.{{ CASE }}_oro_data.nc]
+    - [{{ FIXgdas }}/obs/ims/IMS_4km_to_{{ CASE }}.mx{{ OCNRES }}.nc, {{ DATA }}/obs/IMS4km_to_FV3_mapping.{{ CASE }}_oro_data.nc]
 ims2ioda:
   copy:
     - [{{ DATA }}/ims_snow_{{ current_cycle | to_YMDH }}.nc4, {{ COM_OBS }}/{{ OPREFIX }}ims_snow.nc4]


### PR DESCRIPTION
The IMS remapping files should not be in COM_OBS but in FIXgdas, now that they are stored there and maintained by the global-workflow team. This PR has the workflow copy these files from that place now instead. 

Note, this is one in many PRs in the next few weeks to refactor the snow/land DA.