### PR TITLE
Update aerosol YAMLs to support increment write updates

### DIFF
--- a/parm/aero/variational/3dvar_fgat_gfs_aero.yaml
+++ b/parm/aero/variational/3dvar_fgat_gfs_aero.yaml
@@ -102,12 +102,13 @@ final:
       npz: $(npz_ges)
       field metadata override: ./fv3jedi/fv3jedi_fieldmetadata_restart.yaml
     output:
-      datapath: ./anl
-      prefix: aeroinc
-      filetype: fms restart
-      filename_core: '{{ current_cycle | to_fv3time }}.fv_core.res.nc'
-      filename_trcr: '{{ current_cycle | to_fv3time }}.fv_tracer.res.nc'
-      filename_cplr: '{{ current_cycle | to_fv3time }}.coupler.res'
-      state variables: [t,delp,sphum,so4,bc1,bc2,oc1,oc2,
-                        dust1,dust2,dust3,dust4,dust5,
-                        seas1,seas2,seas3,seas4]
+      state component:
+        datapath: ./anl
+        prefix: aeroinc
+        filetype: fms restart
+        filename_core: '{{ current_cycle | to_fv3time }}.fv_core.res.nc'
+        filename_trcr: '{{ current_cycle | to_fv3time }}.fv_tracer.res.nc'
+        filename_cplr: '{{ current_cycle | to_fv3time }}.coupler.res'
+        state variables: [t,delp,sphum,so4,bc1,bc2,oc1,oc2,
+                          dust1,dust2,dust3,dust4,dust5,
+                          seas1,seas2,seas3,seas4]

--- a/parm/aero/variational/3dvar_gfs_aero.yaml
+++ b/parm/aero/variational/3dvar_gfs_aero.yaml
@@ -93,12 +93,13 @@ final:
       npz: $(npz_ges)
       field metadata override: ./fv3jedi/fv3jedi_fieldmetadata_restart.yaml
     output:
-      datapath: ./anl
-      prefix: aeroinc
-      filetype: fms restart
-      filename_core: '{{ current_cycle | to_fv3time }}.fv_core.res.nc'
-      filename_trcr: '{{ current_cycle | to_fv3time }}.fv_tracer.res.nc'
-      filename_cplr: '{{ current_cycle | to_fv3time }}.coupler.res'
-      state variables: [t,delp,sphum,so4,bc1,bc2,oc1,oc2,
-                        dust1,dust2,dust3,dust4,dust5,
-                        seas1,seas2,seas3,seas4]
+      state component:
+        datapath: ./anl
+        prefix: aeroinc
+        filetype: fms restart
+        filename_core: '{{ current_cycle | to_fv3time }}.fv_core.res.nc'
+        filename_trcr: '{{ current_cycle | to_fv3time }}.fv_tracer.res.nc'
+        filename_cplr: '{{ current_cycle | to_fv3time }}.coupler.res'
+        state variables: [t,delp,sphum,so4,bc1,bc2,oc1,oc2,
+                          dust1,dust2,dust3,dust4,dust5,
+                          seas1,seas2,seas3,seas4]


### PR DESCRIPTION
JEDI recently changed the YAML format for the increment write to require a `state component` subsection. Without this, the code will lead to a vague segmentation fault.