### PR TITLE
Change FIXgdas to FIXgfs/gdas

### DIFF
--- a/parm/snow/prep/prep_ims.yaml
+++ b/parm/snow/prep/prep_ims.yaml
@@ -3,7 +3,7 @@ calcfims:
     - {{ DATA }}/obs
   copy:
     - [{{ COM_OBS }}/{{ OPREFIX }}ims{{ current_cycle | to_julian }}_4km_v1.3.nc, {{ DATA }}/obs/ims{{ current_cycle | to_julian }}_4km_v1.3.nc]
-    - [{{ FIXgdas }}/obs/ims/IMS_4km_to_{{ CASE }}.mx{{ OCNRES }}.nc, {{ DATA }}/obs/IMS4km_to_FV3_mapping.{{ CASE }}_oro_data.nc]
+    - [{{ FIXgfs }}/gdas/obs/ims/IMS_4km_to_{{ CASE }}.mx{{ OCNRES }}.nc, {{ DATA }}/obs/IMS4km_to_FV3_mapping.{{ CASE }}_oro_data.nc]
 ims2ioda:
   copy:
     - [{{ DATA }}/ims_snow_{{ current_cycle | to_YMDH }}.nc4, {{ COM_OBS }}/{{ OPREFIX }}ims_snow.nc4]


### PR DESCRIPTION
Related to https://github.com/NOAA-EMC/global-workflow/issues/2184

Needs to be merged in coordination with the workflow changes.

Removes the usage of FIXgdas and instead uses FIXgfs/gdas as the global-workflow is removing all FIX* variables except for FIXgfs