### PR TITLE
Update nc suffix and bufr file path for atmospheric observation yamls and bufr2ioda converters

### DIFF
--- a/parm/atm/obs/config/aircraft.yaml
+++ b/parm/atm/obs/config/aircraft.yaml
@@ -3,7 +3,7 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(DATA)/obs/$(OPREFIX)aircraft.${{ current_cycle | to_YMDH }}.nc4
+      obsfile: $(DATA)/obs/$(OPREFIX)aircraft.${{ current_cycle | to_YMDH }}.nc
     obsgrouping:
       group variables: ["stationIdentification"]
       sort variable: "pressure"
@@ -11,7 +11,7 @@ obs space:
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(DATA)/diags/diag_aircraft_${{ current_cycle | to_YMDH }}.nc4
+      obsfile: $(DATA)/diags/diag_aircraft_${{ current_cycle | to_YMDH }}.nc
   io pool:
     max pool size: 1
   simulated variables: [windEastward, windNorthward, airTemperature, specificHumidity]

--- a/parm/atm/obs/config/amsua_n19.yaml
+++ b/parm/atm/obs/config/amsua_n19.yaml
@@ -3,11 +3,11 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(DATA)/obs/$(OPREFIX)amsua_n19.{{ current_cycle | to_YMDH }}.nc4
+      obsfile: $(DATA)/obs/$(OPREFIX)amsua_n19.{{ current_cycle | to_YMDH }}.nc
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(DATA)/diags/diag_amsua_n19_{{ current_cycle | to_YMDH }}.nc4
+      obsfile: $(DATA)/diags/diag_amsua_n19_{{ current_cycle | to_YMDH }}.nc
   io pool:
     max pool size: 1
   simulated variables: [brightnessTemperature]
@@ -22,8 +22,8 @@ obs operator:
     EndianType: little_endian
     CoefficientPath: $(DATA)/crtm/
 obs bias:
-  input file: $(DATA)/obs/$(GPREFIX)amsua_n19.satbias.nc4
-  output file: $(DATA)/bc/$(APREFIX)amsua_n19.satbias.nc4
+  input file: $(DATA)/obs/$(GPREFIX)amsua_n19.satbias.nc
+  output file: $(DATA)/bc/$(APREFIX)amsua_n19.satbias.nc
   variational bc:
     predictors:
     - name: constant
@@ -46,11 +46,11 @@ obs bias:
     step size: 1.0e-4
     largest analysis variance: 10000.0
     prior:
-      input file: $(DATA)/obs/$(GPREFIX)amsua_n19.satbias_cov.nc4
+      input file: $(DATA)/obs/$(GPREFIX)amsua_n19.satbias_cov.nc
       inflation:
         ratio: 1.1
         ratio for small dataset: 2.0
-    output file: $(DATA)/bc/$(APREFIX)amsua_n19.satbias_cov.nc4
+    output file: $(DATA)/bc/$(APREFIX)amsua_n19.satbias_cov.nc
 obs filters:
 - filter: BlackList
   filter variables:

--- a/parm/atm/obs/config/atms_n20.yaml
+++ b/parm/atm/obs/config/atms_n20.yaml
@@ -27,8 +27,8 @@ obs operator:
     Absorbers: [H2O, O3]
 
 obs bias:
-  input file: $(DATA)/obs/$(GPREFIX)atms_n20.satbias.nc4
-  output file: $(DATA)/bc/$(APREFIX)atms_n20.satbias.nc4
+  input file: $(DATA)/obs/$(GPREFIX)atms_n20.satbias.nc
+  output file: $(DATA)/bc/$(APREFIX)atms_n20.satbias.nc
   variational bc:
     predictors:
     - name: constant
@@ -51,11 +51,11 @@ obs bias:
     step size: 1.0e-4
     largest analysis variance: 10000.0
     prior:
-      input file: $(DATA)/obs/$(GPREFIX)atms_n20.satbias_cov.nc4
+      input file: $(DATA)/obs/$(GPREFIX)atms_n20.satbias_cov.nc
       inflation:
         ratio: 1.1
         ratio for small dataset: 2.0
-    output file: $(DATA)/bc/$(APREFIX)atms_n20.satbias_cov.nc4
+    output file: $(DATA)/bc/$(APREFIX)atms_n20.satbias_cov.nc
 
 obs pre filters:
 # Step 0-A: Create Diagnostic Flags

--- a/parm/atm/obs/config/atms_npp.yaml
+++ b/parm/atm/obs/config/atms_npp.yaml
@@ -27,8 +27,8 @@ obs operator:
     Absorbers: [H2O, O3]
 
 obs bias:
-  input file: $(DATA)/obs/$(GPREFIX)atms_npp.satbias.nc4
-  output file: $(DATA)/bc/$(APREFIX)atms_npp.satbias.nc4
+  input file: $(DATA)/obs/$(GPREFIX)atms_npp.satbias.nc
+  output file: $(DATA)/bc/$(APREFIX)atms_npp.satbias.nc
   variational bc:
     predictors:
     - name: constant
@@ -51,11 +51,11 @@ obs bias:
     step size: 1.0e-4
     largest analysis variance: 10000.0
     prior:
-      input file: $(DATA)/obs/$(GPREFIX)atms_npp.satbias_cov.nc4
+      input file: $(DATA)/obs/$(GPREFIX)atms_npp.satbias_cov.nc
       inflation:
         ratio: 1.1
         ratio for small dataset: 2.0
-    output file: $(DATA)/bc/$(APREFIX)atms_npp.satbias_cov.nc4
+    output file: $(DATA)/bc/$(APREFIX)atms_npp.satbias_cov.nc
 
 obs pre filters:
 # Step 0-A: Create Diagnostic Flags

--- a/parm/atm/obs/config/cris-fsr_n20.yaml
+++ b/parm/atm/obs/config/cris-fsr_n20.yaml
@@ -3,11 +3,11 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(DATA)/obs/$(OPREFIX)cris-fsr_n20.${{ current_cycle | to_YMDH }}.nc4
+      obsfile: $(DATA)/obs/$(OPREFIX)cris-fsr_n20.${{ current_cycle | to_YMDH }}.nc
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(DATA)/diags/diag_cris-fsr_n20_${{ current_cycle | to_YMDH }}.nc4
+      obsfile: $(DATA)/diags/diag_cris-fsr_n20_${{ current_cycle | to_YMDH }}.nc
   io pool:
     max pool size: 1
   simulated variables: [brightness_temperature]
@@ -53,8 +53,8 @@ obs operator:
     EndianType: little_endian
     CoefficientPath: $(DATA)/crtm/
 obs bias:
-  input file: $(DATA)/obs/$(GPREFIX)cris-fsr_n20.satbias.nc4
-  output file: $(DATA)/bc/$(APREFIX)cris-fsr_n20.satbias.nc4
+  input file: $(DATA)/obs/$(GPREFIX)cris-fsr_n20.satbias.nc
+  output file: $(DATA)/bc/$(APREFIX)cris-fsr_n20.satbias.nc
   variational bc:
     predictors:
     - name: constant
@@ -77,11 +77,11 @@ obs bias:
     step size: 1.0e-4
     largest analysis variance: 10000.0
     prior:
-      input file: $(DATA)/obs/$(GPREFIX)cris-fsr_n20.satbias_cov.nc4
+      input file: $(DATA)/obs/$(GPREFIX)cris-fsr_n20.satbias_cov.nc
       inflation:
         ratio: 1.1
         ratio for small dataset: 2.0
-    output file: $(DATA)/bc/$(APREFIX)cris-fsr_n20.satbias_cov.nc4
+    output file: $(DATA)/bc/$(APREFIX)cris-fsr_n20.satbias_cov.nc
 #
 #obs filters:
 ##  Wavenumber Check

--- a/parm/atm/obs/config/cris-fsr_npp.yaml
+++ b/parm/atm/obs/config/cris-fsr_npp.yaml
@@ -3,11 +3,11 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(DATA)/obs/$(OPREFIX)cris-fsr_npp.${{ current_cycle | to_YMDH }}.nc4
+      obsfile: $(DATA)/obs/$(OPREFIX)cris-fsr_npp.${{ current_cycle | to_YMDH }}.nc
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(DATA)/diags/diag_cris-fsr_npp_${{ current_cycle | to_YMDH }}.nc4
+      obsfile: $(DATA)/diags/diag_cris-fsr_npp_${{ current_cycle | to_YMDH }}.nc
   io pool:
     max pool size: 1
   simulated variables: [brightness_temperature]
@@ -53,8 +53,8 @@ obs operator:
     EndianType: little_endian
     CoefficientPath: $(DATA)/crtm/
 obs bias:
-  input file: $(DATA)/obs/$(GPREFIX)cris-fsr_npp.satbias.nc4
-  output file: $(DATA)/bc/$(APREFIX)cris-fsr_npp.satbias.nc4
+  input file: $(DATA)/obs/$(GPREFIX)cris-fsr_npp.satbias.nc
+  output file: $(DATA)/bc/$(APREFIX)cris-fsr_npp.satbias.nc
   variational bc:
     predictors:
     - name: constant
@@ -77,11 +77,11 @@ obs bias:
     step size: 1.0e-4
     largest analysis variance: 10000.0
     prior:
-      input file: $(DATA)/obs/$(GPREFIX)cris-fsr_npp.satbias_cov.nc4
+      input file: $(DATA)/obs/$(GPREFIX)cris-fsr_npp.satbias_cov.nc
       inflation:
         ratio: 1.1
         ratio for small dataset: 2.0
-    output file: $(DATA)/bc/$(APREFIX)cris-fsr_npp.satbias_cov.nc4
+    output file: $(DATA)/bc/$(APREFIX)cris-fsr_npp.satbias_cov.nc
 #obs filters:
 ##  Wavenumber Check
 #- filter: BlackList

--- a/parm/atm/obs/config/gnssro.yaml
+++ b/parm/atm/obs/config/gnssro.yaml
@@ -18,7 +18,7 @@ obs space:
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(DATA)/diags/diag_gnssro_{{ current_cycle | to_YMDH }}.nc4
+      obsfile: $(DATA)/diags/diag_gnssro_{{ current_cycle | to_YMDH }}.nc
   simulated variables: [bendingAngle]
 
 obs filters:

--- a/parm/atm/obs/config/iasi_metop-a.yaml
+++ b/parm/atm/obs/config/iasi_metop-a.yaml
@@ -74,8 +74,8 @@ obs operator:
     Absorbers: [H2O,O3]
 
 obs bias:
-  input file: $(DATA)/obs/$(GPREFIX)iasi_metop-a.satbias.nc4
-  output file: $(DATA)/bc/$(APREFIX)iasi_metop-a.satbias.nc4
+  input file: $(DATA)/obs/$(GPREFIX)iasi_metop-a.satbias.nc
+  output file: $(DATA)/bc/$(APREFIX)iasi_metop-a.satbias.nc
   variational bc:
     predictors:
     - name: constant
@@ -98,11 +98,11 @@ obs bias:
     step size: 1.0e-4
     largest analysis variance: 10000.0
     prior:
-      input file: $(DATA)/obs/$(GPREFIX)iasi_metop-a.satbias_cov.nc4
+      input file: $(DATA)/obs/$(GPREFIX)iasi_metop-a.satbias_cov.nc
       inflation:
         ratio: 1.1
         ratio for small dataset: 2.0
-    output file: $(DATA)/bc/$(APREFIX)iasi_metop-a.satbias_cov.nc4
+    output file: $(DATA)/bc/$(APREFIX)iasi_metop-a.satbias_cov.nc
 
 obs pre filters:
 # Step 0-A: Create Diagnostic Flags

--- a/parm/atm/obs/config/iasi_metop-b.yaml
+++ b/parm/atm/obs/config/iasi_metop-b.yaml
@@ -74,8 +74,8 @@ obs operator:
     Absorbers: [H2O,O3]
 
 obs bias:
-  input file: $(DATA)/obs/$(GPREFIX)iasi_metop-b.satbias.nc4
-  output file: $(DATA)/bc/$(APREFIX)iasi_metop-b.satbias.nc4
+  input file: $(DATA)/obs/$(GPREFIX)iasi_metop-b.satbias.nc
+  output file: $(DATA)/bc/$(APREFIX)iasi_metop-b.satbias.nc
   variational bc:
     predictors:
     - name: constant
@@ -98,11 +98,11 @@ obs bias:
     step size: 1.0e-4
     largest analysis variance: 10000.0
     prior:
-      input file: $(DATA)/obs/$(GPREFIX)iasi_metop-b.satbias_cov.nc4
+      input file: $(DATA)/obs/$(GPREFIX)iasi_metop-b.satbias_cov.nc
       inflation:
         ratio: 1.1
         ratio for small dataset: 2.0
-    output file: $(DATA)/bc/$(APREFIX)iasi_metop-b.satbias_cov.nc4
+    output file: $(DATA)/bc/$(APREFIX)iasi_metop-b.satbias_cov.nc
 
 obs pre filters:
 # Step 0-A: Create Diagnostic Flags

--- a/parm/atm/obs/config/lgetkf_amsua_n19.yaml
+++ b/parm/atm/obs/config/lgetkf_amsua_n19.yaml
@@ -6,11 +6,11 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: ./obs/$(OPREFIX)amsua_n19.{{ current_cycle | to_YMDH }}.nc4
+      obsfile: ./obs/$(OPREFIX)amsua_n19.{{ current_cycle | to_YMDH }}.nc
   obsdataout:
     engine:
       type: H5File
-      obsfile: ./diags/diag_amsua_n19_{{ current_cycle | to_YMDH }}.nc4
+      obsfile: ./diags/diag_amsua_n19_{{ current_cycle | to_YMDH }}.nc
   io pool:
     max pool size: 1
   simulated variables: [brightnessTemperature]
@@ -27,8 +27,8 @@ obs operator:
 obs error:
   covariance model: diagonal
 obs bias:
-  input file: $(DATA)/obs/$(GPREFIX)amsua_n19.satbias.nc4
-  output file: $(DATA)/bc/$(APREFIX)amsua_n19.satbias.nc4
+  input file: $(DATA)/obs/$(GPREFIX)amsua_n19.satbias.nc
+  output file: $(DATA)/bc/$(APREFIX)amsua_n19.satbias.nc
   variational bc:
     predictors:
     - name: constant
@@ -51,11 +51,11 @@ obs bias:
     step size: 1.0e-4
     largest analysis variance: 10000.0
     prior:
-      input file: $(DATA)/obs/$(GPREFIX)amsua_n19.satbias_cov.nc4
+      input file: $(DATA)/obs/$(GPREFIX)amsua_n19.satbias_cov.nc
       inflation:
         ratio: 1.1
         ratio for small dataset: 2.0
-    output file: $(DATA)/bc/$(APREFIX)amsua_n19.satbias_cov.nc4
+    output file: $(DATA)/bc/$(APREFIX)amsua_n19.satbias_cov.nc
 obs filters:
 - filter: Bounds Check
   filter variables:

--- a/parm/atm/obs/config/lgetkf_sondes.yaml
+++ b/parm/atm/obs/config/lgetkf_sondes.yaml
@@ -6,11 +6,11 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: ./obs/$(OPREFIX)sondes.{{ current_cycle | to_YMDH }}.nc4
+      obsfile: ./obs/$(OPREFIX)sondes.{{ current_cycle | to_YMDH }}.nc
   obsdataout:
     engine:
       type: H5File
-      obsfile: ./diags/diag_sondes_lgetkf_{{ current_cycle | to_YMDH }}.nc4
+      obsfile: ./diags/diag_sondes_lgetkf_{{ current_cycle | to_YMDH }}.nc
   io pool:
     max pool size: 1
   simulated variables: [windEastward, windNorthward, airTemperature]

--- a/parm/atm/obs/config/omi_aura.yaml
+++ b/parm/atm/obs/config/omi_aura.yaml
@@ -3,11 +3,11 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(DATA)/obs/$(OPREFIX)omi_aura.${{ current_cycle | to_YMDH }}.nc4
+      obsfile: $(DATA)/obs/$(OPREFIX)omi_aura.${{ current_cycle | to_YMDH }}.nc
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(DATA)/diags/diag_omi_aura_${{ current_cycle | to_YMDH }}.nc4
+      obsfile: $(DATA)/diags/diag_omi_aura_${{ current_cycle | to_YMDH }}.nc
   io pool:
     max pool size: 1
   simulated variables: [ozoneTotal]

--- a/parm/atm/obs/config/ompsnp_npp.yaml
+++ b/parm/atm/obs/config/ompsnp_npp.yaml
@@ -3,7 +3,7 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(DATA)/obs/$(OPREFIX)ompsnp_npp.${{ current_cycle | to_YMDH }}.nc4
+      obsfile: $(DATA)/obs/$(OPREFIX)ompsnp_npp.${{ current_cycle | to_YMDH }}.nc
     obsgrouping:
       group variables: ["latitude"]
       sort variable: "pressure"
@@ -11,7 +11,7 @@ obs space:
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(DATA)/diags/diag_ompsnp_npp_${{ current_cycle | to_YMDH }}.nc4
+      obsfile: $(DATA)/diags/diag_ompsnp_npp_${{ current_cycle | to_YMDH }}.nc
   io pool:
     max pool size: 1
   simulated variables: [ozoneLayer]

--- a/parm/atm/obs/config/ompstc8_npp.yaml
+++ b/parm/atm/obs/config/ompstc8_npp.yaml
@@ -3,11 +3,11 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(DATA)/obs/$(OPREFIX)ompstc8_npp.${{ current_cycle | to_YMDH }}.nc4
+      obsfile: $(DATA)/obs/$(OPREFIX)ompstc8_npp.${{ current_cycle | to_YMDH }}.nc
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(DATA)/diags/diag_ompstc8_npp_${{ current_cycle | to_YMDH }}.nc4
+      obsfile: $(DATA)/diags/diag_ompstc8_npp_${{ current_cycle | to_YMDH }}.nc
   io pool:
     max pool size: 1
   simulated variables: [ozoneTotal]

--- a/parm/atm/obs/config/satwind.yaml
+++ b/parm/atm/obs/config/satwind.yaml
@@ -3,11 +3,11 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(DATA)/obs/$(OPREFIX)satwind.${{ current_cycle | to_YMDH }}.nc4
+      obsfile: $(DATA)/obs/$(OPREFIX)satwind.${{ current_cycle | to_YMDH }}.nc
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(DATA)/diags/diag_satwind_${{ current_cycle | to_YMDH }}.nc4
+      obsfile: $(DATA)/diags/diag_satwind_${{ current_cycle | to_YMDH }}.nc
   io pool:
     max pool size: 1
   simulated variables: [windEastward, windNorthward]

--- a/parm/atm/obs/config/satwind_ahi_h8.yaml
+++ b/parm/atm/obs/config/satwind_ahi_h8.yaml
@@ -7,7 +7,7 @@ obs space:
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(DATA)/diags/diag_satwind_ahi_h8_{{ current_cycle | to_YMDH }}.nc4
+      obsfile: $(DATA)/diags/diag_satwind_ahi_h8_{{ current_cycle | to_YMDH }}.nc
   io pool:
     max pool size: 1
   simulated variables: [windEastward, windNorthward]

--- a/parm/atm/obs/config/sfc.yaml
+++ b/parm/atm/obs/config/sfc.yaml
@@ -3,11 +3,11 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(DATA)/obs/$(OPREFIX)sfc.${{ current_cycle | to_YMDH }}.nc4
+      obsfile: $(DATA)/obs/$(OPREFIX)sfc.${{ current_cycle | to_YMDH }}.nc
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(DATA)/diags/diag_sfc_${{ current_cycle | to_YMDH }}.nc4
+      obsfile: $(DATA)/diags/diag_sfc_${{ current_cycle | to_YMDH }}.nc
   io pool:
     max pool size: 1
   simulated variables: [stationPressure]

--- a/parm/atm/obs/config/sfcship.yaml
+++ b/parm/atm/obs/config/sfcship.yaml
@@ -3,12 +3,12 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(DATA)/obs/$(OPREFIX)sfcship.${{ current_cycle | to_YMDH }}.nc4
+      obsfile: $(DATA)/obs/$(OPREFIX)sfcship.${{ current_cycle | to_YMDH }}.nc
   obsdataout:
     engine:
       type: H5File
       overwrite: true
-      obsfile: $(DATA)/diags/diag_sfcship_${{ current_cycle | to_YMDH }}.nc4
+      obsfile: $(DATA)/diags/diag_sfcship_${{ current_cycle | to_YMDH }}.nc
   io pool:
     max pool size: 1
   simulated variables: [stationPressure, airTemperature, specificHumidity]

--- a/parm/atm/obs/config/sondes.yaml
+++ b/parm/atm/obs/config/sondes.yaml
@@ -3,7 +3,7 @@ obs space:
   obsdatain:
     engine: 
       type: H5File
-      obsfile: $(DATA)/obs/$(OPREFIX)sondes.{{ current_cycle | to_YMDH }}.nc4
+      obsfile: $(DATA)/obs/$(OPREFIX)sondes.{{ current_cycle | to_YMDH }}.nc
     obsgrouping:
       group variables: ["stationIdentification"]
       sort variable: "pressure"
@@ -11,7 +11,7 @@ obs space:
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(DATA)/diags/diag_sondes_{{ current_cycle | to_YMDH }}.nc4
+      obsfile: $(DATA)/diags/diag_sondes_{{ current_cycle | to_YMDH }}.nc
   io pool:
     max pool size: 1
   simulated variables: [stationPressure, airTemperature, windEastward, windNorthward, specificHumidity]

--- a/parm/atm/obs/config/ssmis_f17.yaml
+++ b/parm/atm/obs/config/ssmis_f17.yaml
@@ -10,16 +10,16 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(DATA)/obs/$(OPREFIX)ssmis_f17.${{ current_cycle | to_YMDH }}.nc4
+      obsfile: $(DATA)/obs/$(OPREFIX)ssmis_f17.${{ current_cycle | to_YMDH }}.nc
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(DATA)/diags/diag_ssmis_f17_${{ current_cycle | to_YMDH }}.nc4
+      obsfile: $(DATA)/diags/diag_ssmis_f17_${{ current_cycle | to_YMDH }}.nc
   simulated variables: [brightness_temperature]
   channels: 1-24
 obs bias:
-  input file: $(DATA)/obs/$(GPREFIX)ssmis_f17.satbias.nc4
-  output file: $(DATA)/bc/$(APREFIX)ssmis_f17.satbias.nc4
+  input file: $(DATA)/obs/$(GPREFIX)ssmis_f17.satbias.nc
+  output file: $(DATA)/bc/$(APREFIX)ssmis_f17.satbias.nc
   variational bc:
     predictors:
     - name: constant

--- a/parm/atm/obs/config/ssmis_f18.yaml
+++ b/parm/atm/obs/config/ssmis_f18.yaml
@@ -10,16 +10,16 @@ obs space:
   obsdatain:
     engine:
       type: H5File
-      obsfile: $(DATA)/obs/$(OPREFIX)ssmis_f18.${{ current_cycle | to_YMDH }}.nc4
+      obsfile: $(DATA)/obs/$(OPREFIX)ssmis_f18.${{ current_cycle | to_YMDH }}.nc
   obsdataout:
     engine:
       type: H5File
-      obsfile: $(DATA)/diags/diag_ssmis_f18_${{ current_cycle | to_YMDH }}.nc4
+      obsfile: $(DATA)/diags/diag_ssmis_f18_${{ current_cycle | to_YMDH }}.nc
   simulated variables: [brightness_temperature]
   channels: 1-24
 obs bias:
-  input file: $(DATA)/obs/$(GPREFIX)ssmis_f18.satbias.nc4
-  output file: $(DATA)/bc/$(APREFIX)ssmis_f18.satbias.nc4
+  input file: $(DATA)/obs/$(GPREFIX)ssmis_f18.satbias.nc
+  output file: $(DATA)/bc/$(APREFIX)ssmis_f18.satbias.nc
   variational bc:
     predictors:
     - name: constant

--- a/test/atm/global-workflow/config.atmanl
+++ b/test/atm/global-workflow/config.atmanl
@@ -13,11 +13,11 @@ export STATICB_TYPE="identity"
 export BERROR_YAML=${HOMEgfs}/sorc/gdas.cd/parm/atm/berror/staticb_${STATICB_TYPE}.yaml
 export INTERP_METHOD='barycentric'
 
-export layout_x=1
-export layout_y=1
+export layout_x_atmanl=@LAYOUT_X_ATMANL@
+export layout_y_atmanl=@LAYOUT_Y_ATMANL@
 
-export io_layout_x=1
-export io_layout_y=1
+export io_layout_x=@IO_LAYOUT_X@
+export io_layout_y=@IO_LAYOUT_Y@
 
 export JEDIEXE=${HOMEgfs}/exec/fv3jedi_var.x
 export crtm_VERSION="2.4.0"

--- a/test/atm/global-workflow/config.yaml
+++ b/test/atm/global-workflow/config.yaml
@@ -9,3 +9,13 @@ base:
 atmanl:
   OBS_LIST: "@srcdir@/test/atm/global-workflow/gdas_prototype.yaml"
   ATMRES_ANL: "C48"
+  LAYOUT_X_ATMANL: 1
+  LAYOUT_Y_ATMANL: 1
+  IO_LAYOUT_X: 1
+  IO_LAYOUT_Y: 1
+
+atmensanl:
+  LAYOUT_X_ATMENSANL: 1
+  LAYOUT_Y_ATMENSANL: 1
+  IO_LAYOUT_X: 1
+  IO_LAYOUT_Y: 1

--- a/test/atm/global-workflow/jjob_ens_init.sh
+++ b/test/atm/global-workflow/jjob_ens_init.sh
@@ -68,15 +68,19 @@ RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} generate_com -rx \
 # Link observations
 dpath=gdas.$PDY/$cyc/obs
 mkdir -p $COM_OBS
-flist="amsua_n19.$CDATE.nc4 sondes.$CDATE.nc4"
+flist="amsua_n19.$CDATE sondes.$CDATE"
 for file in $flist; do
-   ln -fs $GDASAPP_TESTDATA/lowres/$dpath/${oprefix}.$file $COM_OBS/${oprefix}.$file
+   ln -fs $GDASAPP_TESTDATA/lowres/$dpath/${oprefix}.${file}.nc4 $COM_OBS/${oprefix}.${file}.nc
 done
 
 # Link radiance bias correction files
 dpath=gdas.$gPDY/$gcyc/analysis/atmos
 mkdir -p $COM_ATMOS_ANALYSIS_PREV
-flist="amsua_n19.satbias.nc4 amsua_n19.satbias_cov.nc4 amsua_n19.tlapse.txt"
+flist="amsua_n19.satbias amsua_n19.satbias_cov"
+for file in $flist; do
+   ln -fs $GDASAPP_TESTDATA/lowres/$dpath/$gprefix.${file}.nc4 $COM_ATMOS_ANALYSIS_PREV/$gprefix.${file}.nc
+done
+flist="amsua_n19.tlapse.txt"
 for file in $flist; do
    ln -fs $GDASAPP_TESTDATA/lowres/$dpath/$gprefix.$file $COM_ATMOS_ANALYSIS_PREV/$gprefix.$file
 done

--- a/test/atm/global-workflow/jjob_var_init.sh
+++ b/test/atm/global-workflow/jjob_var_init.sh
@@ -70,17 +70,21 @@ RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} generate_com -rx \
 # Link observations
 dpath=gdas.$PDY/$cyc/obs
 mkdir -p $COM_OBS
-flist="amsua_n19.$CDATE.nc4 sondes.$CDATE.nc4"
+flist="amsua_n19.$CDATE sondes.$CDATE"
 for file in $flist; do
-   ln -fs $GDASAPP_TESTDATA/lowres/$dpath/${oprefix}.$file $COM_OBS/${oprefix}.$file
+   ln -fs $GDASAPP_TESTDATA/lowres/$dpath/${oprefix}.${file}.nc4 $COM_OBS/${oprefix}.${file}.nc
 done
 
 # Link radiance bias correction files
 dpath=gdas.$gPDY/$gcyc/analysis/atmos
 mkdir -p $COM_ATMOS_ANALYSIS_PREV
-flist="amsua_n19.satbias.nc4 amsua_n19.satbias_cov.nc4 amsua_n19.tlapse.txt"
+flist="amsua_n19.satbias amsua_n19.satbias_cov"
 for file in $flist; do
-   ln -fs $GDASAPP_TESTDATA/lowres/$dpath/$gprefix.$file $COM_ATMOS_ANALYSIS_PREV/$gprefix.$file
+   ln -fs $GDASAPP_TESTDATA/lowres/$dpath/$gprefix.${file}.nc4 $COM_ATMOS_ANALYSIS_PREV/$gprefix.${file}.nc
+done
+flist="amsua_n19.tlapse.txt"
+for file in $flist; do
+   ln -fs $GDASAPP_TESTDATA/lowres/$dpath/$gprefix.${file} $COM_ATMOS_ANALYSIS_PREV/$gprefix.${file}
 done
 
 # Link atmospheric background on gaussian grid

--- a/ush/ioda/bufr2ioda/bufr2ioda_acft_profiles_prepbufr.py
+++ b/ush/ioda/bufr2ioda/bufr2ioda_acft_profiles_prepbufr.py
@@ -98,7 +98,7 @@ def bufr_to_ioda(config, logger):
 
     bufrfile = f"{cycle_type}.t{hh}z.{data_format}.acft_profiles"
     DATA_PATH = os.path.join(dump_dir, f"{cycle_type}.{yyyymmdd}", str(hh),
-                             bufrfile)
+                             'atmos', bufrfile)
 
     # ============================================
     # Make the QuerySet for all the data we want

--- a/ush/ioda/bufr2ioda/bufr2ioda_adpsfc_prepbufr.py
+++ b/ush/ioda/bufr2ioda/bufr2ioda_adpsfc_prepbufr.py
@@ -70,7 +70,7 @@ def bufr_to_ioda(config, logger):
 
     bufrfile = f"{cycle_type}.t{hh}z.{data_format}"
     DATA_PATH = os.path.join(dump_dir, f"{cycle_type}.{yyyymmdd}",
-                             str(hh), bufrfile)
+                             str(hh), 'atmos', bufrfile)
 
     logger.debug(f"The DATA_PATH is: {DATA_PATH}")
 

--- a/ush/ioda/bufr2ioda/bufr2ioda_conventional_prepbufr_ps.py
+++ b/ush/ioda/bufr2ioda/bufr2ioda_conventional_prepbufr_ps.py
@@ -101,7 +101,7 @@ def bufr_to_ioda(config, logger):
 
     bufrfile = f"{cycle_type}.t{hh}z.{data_format}"
     DATA_PATH = os.path.join(dump_dir, f"{cycle_type}.{yyyymmdd}",
-                             str(hh), bufrfile)
+                             str(hh), 'atmos', bufrfile)
 
     logger.debug(f"The DATA_PATH is: {DATA_PATH}")
 

--- a/ush/ioda/bufr2ioda/bufr2ioda_sfcshp_prepbufr.py
+++ b/ush/ioda/bufr2ioda/bufr2ioda_sfcshp_prepbufr.py
@@ -60,7 +60,7 @@ def bufr_to_ioda(config, logger):
 
     bufrfile = f"{cycle_type}.t{hh}z.{data_format}"
     DATA_PATH = os.path.join(dump_dir, f"{cycle_type}.{yyyymmdd}",
-                             str(hh), bufrfile)
+                             str(hh), 'atmos', bufrfile)
 
     logger.debug(f"The DATA_PATH is: {DATA_PATH}")
 


### PR DESCRIPTION
This PR includes two sets of changes related to atmospheric observations:
1. replace `.nc4` with `.nc` in `parm/atm/obs/config`
2. add `atmos` to the path for bufr dump files in `ush/ioda/bufr2ioda` 

Resolves #911  (item 1)
Resolves #919  (item 2)

The above changes have been tested and are working in a Hera 3DEnVar JEDI parallel.