### PR TITLE
Absolute threshold for the bkg check

### DIFF
--- a/parm/soca/obs/config/sst_abi_g16_l3c.yaml
+++ b/parm/soca/obs/config/sst_abi_g16_l3c.yaml
@@ -27,7 +27,7 @@ obs filters:
   minvalue: 1.0
   maxvalue: 41.0
 - filter: Background Check
-  threshold: 5.0
+  absolute threshold: 5.0
 - filter: Domain Check
   where:
   - variable: {name: ObsError/seaSurfaceTemperature}

--- a/parm/soca/obs/config/sst_abi_g17_l3c.yaml
+++ b/parm/soca/obs/config/sst_abi_g17_l3c.yaml
@@ -27,7 +27,7 @@ obs filters:
   minvalue: 1.0
   maxvalue: 41.0
 - filter: Background Check
-  threshold: 5.0
+  absolute threshold: 5.0
 - filter: Domain Check
   where:
   - variable: {name: ObsError/seaSurfaceTemperature}

--- a/parm/soca/obs/config/sst_ahi_h08_l3c.yaml
+++ b/parm/soca/obs/config/sst_ahi_h08_l3c.yaml
@@ -27,7 +27,7 @@ obs filters:
   minvalue: 1.0
   maxvalue: 41.0
 - filter: Background Check
-  threshold: 5.0
+  absolute threshold: 5.0
 - filter: Domain Check
   where:
   - variable: {name: ObsError/seaSurfaceTemperature}

--- a/parm/soca/obs/config/sst_avhrr_ma_l3u.yaml
+++ b/parm/soca/obs/config/sst_avhrr_ma_l3u.yaml
@@ -27,7 +27,7 @@ obs filters:
   minvalue: 1.0
   maxvalue: 41.0
 - filter: Background Check
-  threshold: 5.0
+  absolute threshold: 5.0
 - filter: Domain Check
   where:
   - variable: {name: ObsError/seaSurfaceTemperature}

--- a/parm/soca/obs/config/sst_avhrr_mb_l3u.yaml
+++ b/parm/soca/obs/config/sst_avhrr_mb_l3u.yaml
@@ -27,7 +27,7 @@ obs filters:
   minvalue: 1.0
   maxvalue: 41.0
 - filter: Background Check
-  threshold: 5.0
+  absolute threshold: 5.0
 - filter: Domain Check
   where:
   - variable: {name: ObsError/seaSurfaceTemperature}

--- a/parm/soca/obs/config/sst_avhrr_mc_l3u.yaml
+++ b/parm/soca/obs/config/sst_avhrr_mc_l3u.yaml
@@ -27,7 +27,7 @@ obs filters:
   minvalue: 1.0
   maxvalue: 41.0
 - filter: Background Check
-  threshold: 5.0
+  absolute threshold: 5.0
 - filter: Domain Check
   where:
   - variable: {name: ObsError/seaSurfaceTemperature}

--- a/parm/soca/obs/config/sst_viirs_n20_l3u.yaml
+++ b/parm/soca/obs/config/sst_viirs_n20_l3u.yaml
@@ -27,7 +27,7 @@ obs filters:
   minvalue: 1.0
   maxvalue: 41.0
 - filter: Background Check
-  threshold: 5.0
+  absolute threshold: 5.0
 - filter: Domain Check
   where:
   - variable: {name: ObsError/seaSurfaceTemperature}

--- a/parm/soca/obs/config/sst_viirs_npp_l3u.yaml
+++ b/parm/soca/obs/config/sst_viirs_npp_l3u.yaml
@@ -27,7 +27,7 @@ obs filters:
   minvalue: 1.0
   maxvalue: 41.0
 - filter: Background Check
-  threshold: 5.0
+  absolute threshold: 5.0
 - filter: Domain Check
   where:
   - variable: {name: ObsError/seaSurfaceTemperature}


### PR DESCRIPTION
While working on the background error, and alternatively on the obs error, I noticed that we were still using a background check based on the obs error. This is a mistake, switching back to `absolute threshold`.