### PR TITLE
replace existing and remove obsolete references to solo

### DIFF
--- a/ush/ufsda/misc_utils.py
+++ b/ush/ufsda/misc_utils.py
@@ -2,7 +2,6 @@ import datetime as dt
 import logging
 import os
 import re
-import solo.date
 import stat
 import subprocess
 
@@ -11,27 +10,6 @@ scheduler = {
     'orion': 'slurm',
     'hera': 'slurm',
 }
-
-
-def calc_fcst_steps(fcst_step, win_length):
-    """
-    function to return a list of forecast steps
-    for a given fcst_step (forecast step)
-    and win_length (window length)
-    """
-    # need to get +- half of the window length
-    # assumes only hours for now, probably bad...
-    # also assumes the window is symmetric, probably also bad
-    h = int(re.findall('PT(\\d+)H', win_length)[0])
-    h2 = int(re.findall('PT(\\d+)H', fcst_step)[0])
-    assert h % h2 == 0, "win_length must be divisible by fcst_step"
-    if h2 > h//2:
-        return [fcst_step]
-    start = f'PT{h-h//2}H'
-    end = f'PT{h+h//2}H'
-    # solo has a nice utility for this
-    fcst_steps = solo.date.step_sequence(start, end, fcst_step)
-    return fcst_steps
 
 
 def isTrue(str_in):

--- a/ush/ufsda/ufs_yaml.py
+++ b/ush/ufsda/ufs_yaml.py
@@ -1,7 +1,6 @@
 import datetime
 import os
-from solo.yaml_file import YAMLFile
-from solo.template import TemplateConstants, Template
+from wxflow import YAMLFile, TemplateConstants, Template
 
 
 def gen_yaml(outyaml, templateyaml):
@@ -121,7 +120,7 @@ def get_exp_vars():
 
 
 def replace_vars(config):
-    # use SOLO to replace variables in the configuration dictionary
+    # use wxflow to replace variables in the configuration dictionary
     # as appropriate with either other dictionary key/value pairs
     # or environment variables
     config = Template.substitute_structure_from_environment(config)

--- a/ush/ufsda/yamltools.py
+++ b/ush/ufsda/yamltools.py
@@ -2,8 +2,6 @@ import datetime
 import os
 import re
 import logging
-from solo.yaml_file import YAMLFile
-from solo.template import TemplateConstants, Template
 from ufsda.misc_utils import isTrue
 import wxflow
 
@@ -307,7 +305,7 @@ def include_yaml(config):
 
 
 def replace_vars(config):
-    # use SOLO to replace variables in the configuration dictionary
+    # use wxflow to replace variables in the configuration dictionary
     # as appropriate with either other dictionary key/value pairs
     # or environment variables
     config = Template.substitute_structure_from_environment(config)

--- a/ush/ufsda/yamltools.py
+++ b/ush/ufsda/yamltools.py
@@ -3,7 +3,7 @@ import os
 import re
 import logging
 from ufsda.misc_utils import isTrue
-import wxflow
+from wxflow import YAMLFile, TemplateConstants, Template
 
 logging.basicConfig(format='%(asctime)s:%(levelname)s:%(message)s',
                     level=logging.INFO, datefmt='%Y-%m-%d %H:%M:%S')


### PR DESCRIPTION
This PR incudes the following changes
1. Replace `solo` with `wxflow` in `ush/ufsda/ufs_yaml.py` and `ush/ufsda/yamltools.py`.
2. Remove method `calc_fcst_steps` from `ush/ufsda/misc_utils.py` since it is not used

These changes are necessary for 30 GDASApp ctests to pass when using [`feature/rocky8`](https://github.com/NOAA-EMC/GDASApp/tree/feature/rocky8).  See GDASApp issue #958 for additional details.