### PR TITLE
Add modules needed on Hera Rocky 8

### DIFF
--- a/modulefiles/GDAS/hera.intel.lua
+++ b/modulefiles/GDAS/hera.intel.lua
@@ -72,6 +72,7 @@ load("py-pyyaml/6.0")
 load("py-scipy/1.11.3")
 load("py-xarray/2023.7.0")
 load("py-f90nml/1.4.3")
+load("py-pip/23.1.2")
 
 -- hack for wxflow
 prepend_path("PYTHONPATH", "/scratch1/NCEPDEV/da/python/gdasapp/wxflow/20240307/src")

--- a/modulefiles/GDAS/hera.intel.lua
+++ b/modulefiles/GDAS/hera.intel.lua
@@ -71,6 +71,7 @@ load("py-pycodestyle/2.11.0")
 load("py-pyyaml/6.0")
 load("py-scipy/1.11.3")
 load("py-xarray/2023.7.0")
+load("py-f90nml/1.4.3")
 
 -- hack for wxflow
 prepend_path("PYTHONPATH", "/scratch1/NCEPDEV/da/python/gdasapp/wxflow/20240307/src")


### PR DESCRIPTION
Testing of GDASApp on Rocky-8 nodes identified two missing modules:  pip and f90nml.  This PR adds these modules to `hera.intel.lua`.

Fixes #984
Fixes #990