### PR TITLE
remove gdas_ prefix from executable filename in test_gdasapp_fv3jedi_fv3inc (#1009)

### DIFF
--- a/test/fv3jedi/CMakeLists.txt
+++ b/test/fv3jedi/CMakeLists.txt
@@ -18,6 +18,6 @@ file(CREATE_LINK ${PROJECT_SOURCE_DIR}/sorc/fv3-jedi/test/Data/fv3files/field_ta
 
 # Tests
 add_test(NAME test_gdasapp_fv3jedi_fv3inc
-         COMMAND srun -n6 ${CMAKE_BINARY_DIR}/bin/gdas_fv3jedi_fv3inc.x ${PROJECT_BINARY_DIR}/test/fv3jedi/testinput/gdasapp_fv3jedi_fv3inc.yaml
+         COMMAND srun -n6 ${CMAKE_BINARY_DIR}/bin/fv3jedi_fv3inc.x ${PROJECT_BINARY_DIR}/test/fv3jedi/testinput/gdasapp_fv3jedi_fv3inc.yaml
          WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/fv3jedi)
 


### PR DESCRIPTION
There is a typo in the executable filename referenced by `test_gdasapp_fv3jedi_fv3inc`.   The prefix `gdas_` is not needed.  This PR removes `gdas_`

Fixes #1009