### PR TITLE
Fix inconsistent VIIRS preprocessing test

### DIFF
--- a/utils/test/testinput/gdas_viirsaod2ioda.yaml
+++ b/utils/test/testinput/gdas_viirsaod2ioda.yaml
@@ -9,6 +9,7 @@ input files:
 thinning:
   threshold: 0
 channel: 4
+preqc: 2
 
 test: 
   reference filename: testref/viirsaod2ioda.test


### PR DESCRIPTION
Closes #993 

The `preqc` key was missing from the test YAML and eckit just decided to place some integer in there. This PR should ensure tests pass on all platforms instead of just by chance.