### PR TITLE
Use _anl rather than _ges dimensions for increments in FV3 increment converter YAML

### DIFF
--- a/parm/atm/utils/fv3jedi_fv3inc.yaml.j2
+++ b/parm/atm/utils/fv3jedi_fv3inc.yaml.j2
@@ -35,9 +35,9 @@ jedi increment:
     layout:
     - {{ layout_x }}
     - {{ layout_y }}
-    npx: {{ npx_ges }}
-    npy: {{ npy_ges }}
-    npz: {{ npz_ges }}
+    npx: {{ npx_anl }}
+    npy: {{ npy_anl }}
+    npz: {{ npz_anl }}
     field metadata override: ./fv3jedi/fv3jedi_fieldmetadata_history.yaml
   input:
     filetype: cube sphere history
@@ -52,9 +52,9 @@ fv3 increment:
     layout:
     - {{ layout_x }}
     - {{ layout_y }}
-    npx: {{ npx_ges }}
-    npy: {{ npy_ges }}
-    npz: {{ npz_ges }}
+    npx: {{ npx_anl }}
+    npy: {{ npy_anl }}
+    npz: {{ npz_anl }}
     field metadata override: ./fv3jedi/fv3jedi_fieldmetadata_fv3inc.yaml
   output:
     filetype: auxgrid


### PR DESCRIPTION
npx_ges should be npx_anl for the JEDI and FV3 increments. Same for npy and npz.  See https://github.com/NOAA-EMC/global-workflow/pull/2420#issuecomment-2027575028