### PR TITLE
Add GitHub CLI to path for CI

### DIFF
--- a/ci/hera.sh
+++ b/ci/hera.sh
@@ -5,3 +5,4 @@ export SLURM_ACCOUNT=da-cpu
 export SALLOC_ACCOUNT=$SLURM_ACCOUNT
 export SBATCH_ACCOUNT=$SLURM_ACCOUNT
 export SLURM_QOS=debug
+export PATH=$PATH:/scratch1/NCEPDEV/da/Cory.R.Martin/CI/gh/gh_2.46.0_linux_amd64/bin


### PR DESCRIPTION
When switching to Rocky8, the GitHub CLI tools disappeared on Hera. I think I had them installed in the python conda env? But now they are installed in a new place. The CI source script manually adds this to `$PATH`.