### PR TITLE
make driver consistent with workflow driver

### DIFF
--- a/ci/driver.sh
+++ b/ci/driver.sh
@@ -70,6 +70,7 @@ for pr in $open_pr_list; do
   # checkout pull request
   git pull
   gh pr checkout $pr
+  git submodule update --init --recursive
 
   # get commit hash
   commit=$(git log --pretty=format:'%h' -n 1)


### PR DESCRIPTION
The non workflow CI driver would not update submodules. This fixes this (hopefully)