### PR TITLE
Change generate_com to declare_from_tmpl

### DIFF
--- a/test/aero/global-workflow/jjob_var_init.sh
+++ b/test/aero/global-workflow/jjob_var_init.sh
@@ -60,8 +60,8 @@ gprefix=$GDUMP.t${gcyc}z
 oprefix=$CDUMP.t${cyc}z
 
 # Generate COM variables from templates
-YMD=${PDY} HH=${cyc} generate_com -rx COM_OBS
-RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} generate_com -rx \
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_OBS
+RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
     COM_CHEM_ANALYSIS_PREV:COM_CHEM_ANALYSIS_TMPL \
     COM_CHEM_HISTORY_PREV:COM_CHEM_HISTORY_TMPL \
     COM_ATMOS_RESTART_PREV:COM_ATMOS_RESTART_TMPL

--- a/test/atm/global-workflow/jjob_ens_init.sh
+++ b/test/atm/global-workflow/jjob_ens_init.sh
@@ -61,8 +61,8 @@ gprefix=$GDUMP.t${gcyc}z
 oprefix=$GDUMP.t${cyc}z
 
 # Generate COM variables from templates
-RUN=${GDUMP} YMD=${PDY} HH=${cyc} generate_com -rx COM_OBS
-RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} generate_com -rx \
+RUN=${GDUMP} YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_OBS
+RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
     COM_ATMOS_ANALYSIS_PREV:COM_ATMOS_ANALYSIS_TMPL \
 
 # Link observations
@@ -90,7 +90,7 @@ dpath=enkfgdas.$gPDY/$gcyc
 for imem in $(seq 1 $NMEM_ENS); do
     memchar="mem"$(printf %03i $imem)
 
-    MEMDIR=${memchar} RUN=${RUN} YMD=${gPDY} HH=${gcyc} generate_com -x \
+    MEMDIR=${memchar} RUN=${RUN} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -x \
 	COM_ATMOS_HISTORY_PREV_ENS:COM_ATMOS_HISTORY_TMPL \
 	COM_ATMOS_RESTART_PREV_ENS:COM_ATMOS_RESTART_TMPL
     COM_ATMOS_RESTART_PREV_DIRNAME_ENS=$(dirname $COM_ATMOS_RESTART_PREV_ENS)

--- a/test/atm/global-workflow/jjob_var_init.sh
+++ b/test/atm/global-workflow/jjob_var_init.sh
@@ -61,8 +61,8 @@ gprefix=$GDUMP.t${gcyc}z
 oprefix=$CDUMP.t${cyc}z
 
 # Generate COM variables from templates
-YMD=${PDY} HH=${cyc} generate_com -rx COM_OBS
-RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} generate_com -rx \
+YMD=${PDY} HH=${cyc} declare_from_tmpl -rx COM_OBS
+RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
     COM_ATMOS_ANALYSIS_PREV:COM_ATMOS_ANALYSIS_TMPL \
     COM_ATMOS_HISTORY_PREV:COM_ATMOS_HISTORY_TMPL \
     COM_ATMOS_RESTART_PREV:COM_ATMOS_RESTART_TMPL
@@ -110,7 +110,7 @@ dpath=enkfgdas.$gPDY/$gcyc
 for imem in $(seq 1 $NMEM_ENS); do
     memchar="mem"$(printf %03i $imem)
 
-    MEMDIR=${memchar} RUN=enkf${RUN} YMD=${gPDY} HH=${gcyc} generate_com -x \
+    MEMDIR=${memchar} RUN=enkf${RUN} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -x \
 	COM_ATMOS_HISTORY_PREV_ENS:COM_ATMOS_HISTORY_TMPL \
 	COM_ATMOS_RESTART_PREV_ENS:COM_ATMOS_RESTART_TMPL
     COM_ATMOS_RESTART_PREV_DIRNAME_ENS=$(dirname $COM_ATMOS_RESTART_PREV_ENS)

--- a/ush/soca/run_jjobs.py
+++ b/ush/soca/run_jjobs.py
@@ -158,7 +158,7 @@ class JobCard:
                 self.f.write(f"set -u \n")
 
     def precom(self, com, tmpl):
-        cmd = f"RUN={self.RUN} YMD={self.gPDY} HH={self.gcyc} generate_com -xr {com}:{tmpl}"
+        cmd = f"RUN={self.RUN} YMD={self.gPDY} HH={self.gcyc} declare_from_tmpl -xr {com}:{tmpl}"
         self.f.write(f"{cmd}\n")
 
     def copy_bkgs(self):


### PR DESCRIPTION
In global-workflow the script routine `generate_com` was changed to `declare_from_tmpl`, breaking a number of ctests in GDASApp. A number of these ctests, particularly non-SOCA, were apparently already broken, but this seems to eliminate an error from them.

Resolves https://github.com/NOAA-EMC/GDASApp/issues/1024