### PR TITLE
Use <filesystem> on a non c++17 supported machine (WCOSS ACORN)

### DIFF
--- a/utils/fv3jedi/fv3jedi_fv3inc.h
+++ b/utils/fv3jedi/fv3jedi_fv3inc.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <filesystem>
 #include <iostream>
 #include <memory>
 #include <string>

--- a/utils/soca/CMakeLists.txt
+++ b/utils/soca/CMakeLists.txt
@@ -1,14 +1,16 @@
 # Increment post processing
 ecbuild_add_executable( TARGET gdas_incr_handler.x
                         SOURCES gdas_incr_handler.cc gdas_postprocincr.h)
-target_compile_features( gdas_incr_handler.x PUBLIC cxx_std_17)
+target_compile_features( gdas_incr_handler.x PUBLIC cxx_std_11)
 target_link_libraries( gdas_incr_handler.x PUBLIC NetCDF::NetCDF_CXX oops atlas soca)
+target_link_libraries( gdas_incr_handler.x PRIVATE stdc++fs)
 
 # Ensemble members post processing
 ecbuild_add_executable( TARGET gdas_ens_handler.x
                         SOURCES gdas_ens_handler.cc gdas_postprocincr.h)
-target_compile_features( gdas_ens_handler.x PUBLIC cxx_std_17)
+target_compile_features( gdas_ens_handler.x PUBLIC cxx_std_11)
 target_link_libraries( gdas_ens_handler.x PUBLIC NetCDF::NetCDF_CXX oops atlas soca)
+target_link_libraries( gdas_ens_handler.x PRIVATE stdc++fs)
 
 # Hybrid-Weight
 ecbuild_add_executable( TARGET gdas_socahybridweights.x

--- a/utils/soca/gdas_ens_handler.h
+++ b/utils/soca/gdas_ens_handler.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <filesystem>
 #include <iostream>
 #include <string>
 #include <vector>

--- a/utils/soca/gdas_incr_handler.h
+++ b/utils/soca/gdas_incr_handler.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <filesystem>
 #include <iostream>
 #include <string>
 

--- a/utils/soca/gdas_postprocincr.h
+++ b/utils/soca/gdas_postprocincr.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <filesystem>
+#include <experimental/filesystem>
 
 #include <iostream>
 #include <string>
@@ -260,12 +260,12 @@ class PostProcIncr {
   std::string socaFname() {
     std::string datadir;
     outputIncrConfig_.get("datadir", datadir);
-    std::filesystem::path pathToResolve = datadir;
+    std::experimental::filesystem::path pathToResolve(datadir);
     std::string exp;
     outputIncrConfig_.get("exp", exp);
     std::string outputType;
     outputIncrConfig_.get("type", outputType);
-    std::string incrFname = std::filesystem::canonical(pathToResolve);
+    std::string incrFname = std::experimental::filesystem::canonical(pathToResolve);
     incrFname += "/ocn." + exp + "." + outputType + "." + dt_.toString() + ".nc";
 
     return incrFname;

--- a/utils/soca/gdas_socahybridweights.h
+++ b/utils/soca/gdas_socahybridweights.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <filesystem>
 #include <iostream>
 #include <string>
 #include <vector>


### PR DESCRIPTION
- Downgrade one of the gdasapp marine application from c++17 to c++11
- Fixes #812 and #841 