### PR TITLE
Catch error when trying to copy missing obs files from DATA to ROTDIR in prepoceanobs

### DIFF
--- a/scripts/exglobal_prep_ocean_obs.py
+++ b/scripts/exglobal_prep_ocean_obs.py
@@ -170,7 +170,16 @@ for obsspace_to_convert in obsspaces_to_convert:
     processes.append(process)
 
 # Wait for all processes to finish
+# TODO(AFE): add return value checking
 for process in processes:
     process.join()
 
-FileHandler({'copy': files_to_save}).sync()
+#TODO(AFE): Find a better way to do the "no file found" exception handling -
+# this way make individual calls to FileHandler for each file, instead of 
+# batching them.
+for file_to_save in files_to_save:
+    try:
+        FileHandler({'copy': [file_to_save]}).sync()
+    except OSError:
+        logger.warning(f"Obs file {file_to_save} not found, possible IODA converter failure)")
+        continue

--- a/scripts/exglobal_prep_ocean_obs.py
+++ b/scripts/exglobal_prep_ocean_obs.py
@@ -174,8 +174,8 @@ for obsspace_to_convert in obsspaces_to_convert:
 for process in processes:
     process.join()
 
-#TODO(AFE): Find a better way to do the "no file found" exception handling -
-# this way make individual calls to FileHandler for each file, instead of 
+# TODO(AFE): Find a better way to do the "no file found" exception handling -
+# this way make individual calls to FileHandler for each file, instead of
 # batching them.
 for file_to_save in files_to_save:
     try:

--- a/scripts/exglobal_prep_ocean_obs.py
+++ b/scripts/exglobal_prep_ocean_obs.py
@@ -176,7 +176,7 @@ for process in processes:
 
 # TODO(AFE): Find a better way to do the "no file found" exception handling -
 # this way make individual calls to FileHandler for each file, instead of
-# batching them.
+# batching them. See issue https://github.com/NOAA-EMC/GDASApp/issues/1031
 for file_to_save in files_to_save:
     try:
         FileHandler({'copy': [file_to_save]}).sync()


### PR DESCRIPTION
Catches error when `FileHandler` tries to copy a nonexistant obs file (usually due to a failing IODA converter) and prints a warning to the log.

Tested by including sst_avhrr_mb_l3u and then deleting file after conversion.

Partially addresses https://github.com/NOAA-EMC/GDASApp/issues/972