### PR TITLE
Fix test output for fv3jedi_fv3inc.h

### DIFF
--- a/utils/fv3jedi/fv3jedi_fv3inc.h
+++ b/utils/fv3jedi/fv3jedi_fv3inc.h
@@ -160,7 +160,6 @@ namespace gdasapp {
 
         // Write FV3 increment
         dxFV3.write(fv3IncrOuputConfig);
-
       }
 
       return 0;

--- a/utils/fv3jedi/fv3jedi_fv3inc.h
+++ b/utils/fv3jedi/fv3jedi_fv3inc.h
@@ -110,10 +110,12 @@ namespace gdasapp {
 
         // Read background state
         fv3jedi::State xxBkg(stateGeom, stateInputConfig);
+        oops::Log::test() << "Background State: " << std::endl << xxBkg << std::endl;
 
         // Read JEDI increment
         fv3jedi::Increment dxJEDI(jediIncrGeom, jediIncrVars, xxBkg.validTime());
         dxJEDI.read(jediIncrInputConfig);
+        oops::Log::test() << "JEDI Increment: " << std::endl << dxJEDI << std::endl;
 
         // Increment conversion
         // ---------------------------------------------------------------------------------
@@ -154,14 +156,11 @@ namespace gdasapp {
           }
         }
         dxFV3.fromFieldSet(dxFsFV3);
+        oops::Log::test() << "FV3 Increment: " << std::endl << dxFV3 << std::endl;
 
         // Write FV3 increment
         dxFV3.write(fv3IncrOuputConfig);
 
-        // Output for testing
-        oops::Log::test() << "Background State: " << std::endl << xxBkg << std::endl;
-        oops::Log::test() << "JEDI Increment: " << std::endl << dxJEDI << std::endl;
-        oops::Log::test() << "FV3 Increment: " << std::endl << dxFV3 << std::endl;
       }
 
       return 0;


### PR DESCRIPTION
I foolishly moved the test output print statements in fv3jedi_fv3inc.h around for aesthetic reasons AFTER I had ran test_gdasapp_fv3jedi_fv3inc to confirm that it still passed. It broke the test but I moved the print statements back to where they belong.

The test now passes.