### PR TITLE
Fix GW jjob tests for upcoming GW PR #2420

### DIFF
--- a/test/atm/global-workflow/CMakeLists.txt
+++ b/test/atm/global-workflow/CMakeLists.txt
@@ -16,6 +16,11 @@ add_test(NAME test_gdasapp_atm_jjob_var_run
           ${PROJECT_BINARY_DIR} ${PROJECT_SOURCE_DIR}
   WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/atm/global-workflow/testrun)
 
+add_test(NAME test_gdasapp_atm_jjob_var_inc
+  COMMAND ${PROJECT_SOURCE_DIR}/test/atm/global-workflow/jjob_var_inc.sh
+          ${PROJECT_BINARY_DIR} ${PROJECT_SOURCE_DIR}
+  WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/test/atm/global-workflow/testrun)
+
 add_test(NAME test_gdasapp_atm_jjob_var_final
   COMMAND ${PROJECT_SOURCE_DIR}/test/atm/global-workflow/jjob_var_final.sh
           ${PROJECT_BINARY_DIR} ${PROJECT_SOURCE_DIR}

--- a/test/atm/global-workflow/jjob_var_inc.sh
+++ b/test/atm/global-workflow/jjob_var_inc.sh
@@ -14,9 +14,6 @@ export EXPDIR=$bindir/test/atm/global-workflow/testrun/experiments/$PSLOT
 export PDY=20210323
 export cyc=18
 export CDATE=${PDY}${cyc}
-export gPDY=20210323
-export gcyc=12
-export GDATE=${gPDY}${gcyc}
 export ROTDIR=$bindir/test/atm/global-workflow/testrun/ROTDIRS/$PSLOT
 export RUN=gdas
 export CDUMP=gdas
@@ -50,9 +47,9 @@ fi
 
 # Execute j-job
 if [[ $machine = 'HERA' ]]; then
-    sbatch --ntasks=6 --account=$ACCOUNT --qos=batch --time=00:10:00 --export=ALL --wait ${HOMEgfs}/jobs/JGLOBAL_ATM_ANALYSIS_VARIATIONAL
+    sbatch --ntasks=6 --account=$ACCOUNT --qos=batch --time=00:10:00 --export=ALL --wait ${HOMEgfs}/jobs/JGLOBAL_ATM_ANALYSIS_FV3_INCREMENT
 elif [[ $machine = 'ORION' || $machine = 'HERCULES' ]]; then
-    sbatch --ntasks=6 --account=$ACCOUNT --qos=batch --time=00:10:00 --export=ALL --wait ${HOMEgfs}/jobs/JGLOBAL_ATM_ANALYSIS_VARIATIONAL
+    sbatch --ntasks=6 --account=$ACCOUNT --qos=batch --time=00:10:00 --export=ALL --wait ${HOMEgfs}/jobs/JGLOBAL_ATM_ANALYSIS_FV3_INCREMENT
 else
-    ${HOMEgfs}/jobs/JGLOBAL_ATM_ANALYSIS_VARIATIONAL
+    ${HOMEgfs}/jobs/JGLOBAL_ATM_ANALYSIS_FV3_INCREMENT
 fi

--- a/utils/fv3jedi/fv3jedi_fv3inc.h
+++ b/utils/fv3jedi/fv3jedi_fv3inc.h
@@ -148,7 +148,7 @@ namespace gdasapp {
 
             size_t gridSize = viewFV3.shape(0);
             int nLevels = viewFV3.shape(1);
-            for (int iLevel = 0; iLevel < nLevels + 1; ++iLevel) {
+            for (int iLevel = 0; iLevel < nLevels; ++iLevel) {
               for ( size_t jNode = 0; jNode < gridSize ; ++jNode ) {
                 viewFV3(jNode, iLevel) = viewJEDI(jNode, iLevel);
               }


### PR DESCRIPTION
This PR addresses issue [#1011](https://github.com/NOAA-EMC/GDASApp/issues/1011), related to the failure of the "gdasatmanlvar" jjob test due to a change in the name of the "gdasatmanlvar" run script, and, with the upcoming Global Workflow PR [#2420](https://github.com/NOAA-EMC/global-workflow/pull/2420), the impending failure of the "gdasatmanlfinal" jjob. This fixes the script name in the "gdasatmanlvar" test and adds a new test for "gdasatmanlfv3inc" which will fix the issure with "gdasatmanlfinal".

The "gdasatmanlfv3inc"  and "gdasatmanlfinal" won't pass yes in GW develop, but will after [#2420](https://github.com/NOAA-EMC/global-workflow/pull/2420) merges GW feature/jediinc2fv3.

This PR is just a verbatim copy of @RussTreadon-NOAA 's work, taken from his comment [here](https://github.com/NOAA-EMC/GDASApp/issues/1011#issuecomment-2052249333). I re-ran the new tests, and they also passed for me in GW feature/jediinc2fv3.