### PR TITLE
remove seviri from gdas_prototype_3d yaml

### DIFF
--- a/parm/atm/obs/lists/gdas_prototype_3d.yaml.j2
+++ b/parm/atm/obs/lists/gdas_prototype_3d.yaml.j2
@@ -7,6 +7,4 @@ observers:
 {% include 'atm/obs/config/ompsnp_npp.yaml.j2' %}
 {% include 'atm/obs/config/ompstc_npp.yaml.j2' %}
 {% include 'atm/obs/config/omi_aura.yaml.j2' %}
-{% include 'atm/obs/config/seviri_m08.yaml.j2' %}
-{% include 'atm/obs/config/seviri_m11.yaml.j2' %}
 {% endfilter %}


### PR DESCRIPTION
This PR removes 
```
-{% include 'atm/obs/config/seviri_m08.yaml.j2' %}
-{% include 'atm/obs/config/seviri_m11.yaml.j2' %}
```
from `parm/atm/obs/lists/gdas_prototype_3d.yaml.j2`.   Doing so allows GDASApp ATM variational cycling to run for cases from 20221005 12Z to present.

Fixes #1008 