### PR TITLE
Remove R2D2 and SOLO from the GitHub Actions workflow CI

### DIFF
--- a/.github/workflows/unittests_g-w.yaml
+++ b/.github/workflows/unittests_g-w.yaml
@@ -17,12 +17,6 @@ jobs:
 
     - name: Install other dependencies
       run: |
-        wget https://ftp.emc.ncep.noaa.gov/static_files/public/GDASApp/r2d2-bb361c2.tar.gz
-        wget https://ftp.emc.ncep.noaa.gov/static_files/public/GDASApp/solo-877b414.tar.gz
-        tar -xvf r2d2-bb361c2.tar.gz
-        tar -xvf solo-877b414.tar.gz
-        cd solo && pip install . && cd ..
-        cd r2d2 && pip install . && cd ..
         sudo mkdir -p /work/noaa # to trick workflow into thinking this is RDHPCS Orion
 
     - name: Checkout wxflow


### PR DESCRIPTION
We removed these from the unit tests in #836 but missed this one. This is failing because of our RZDM issues, but it exposed that these need to be removed.