### PR TITLE
Addin a GFSv17 ctest

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -138,8 +138,8 @@ if (${BUILD_GDASBUNDLE})
   add_subdirectory(fv3jedi)   # fv3jedi tests
   add_subdirectory(soca)      # soca tests
   add_subdirectory(snow)      # snow da tests
-  option(RUNGWCI "Enable GWCI tests" OFF)
-  if (RUNGWCI)
+  option(RUN_GW_CI "Enable the global-workflow CI tests" OFF)
+  if (RUN_GW_CI)
     add_subdirectory(gw-ci)   # subset of the global-workflow ci tests
   endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -138,7 +138,11 @@ if (${BUILD_GDASBUNDLE})
   add_subdirectory(fv3jedi)   # fv3jedi tests
   add_subdirectory(soca)      # soca tests
   add_subdirectory(snow)      # snow da tests
-  add_subdirectory(gw-ci)     # replicate the creation of some of the gw-ci tests
+  option(RUNGWCI "Enable GWCI tests" OFF)
+  if (RUNGWCI)
+    add_subdirectory(gw-ci)   # subset of the global-workflow ci tests
+  endif()
+
 endif()
 
 # gdas atm tests

--- a/test/gw-ci/CMakeLists.txt
+++ b/test/gw-ci/CMakeLists.txt
@@ -1,41 +1,18 @@
-# Setup the environement
-set(HOMEgfs ${CMAKE_SOURCE_DIR}/../../..)
-set(RUNTESTS ${CMAKE_CURRENT_BINARY_DIR}/../../test/gw-ci)
-
-# List of g-w ci test to create
-# -----------------------------
-set(cycling_tests "C48mx500_3DVarAOWCDA" "C96_atmaerosnowDA" "C96C48_ufs_hybatmDA")
-
-# List of tasks to run for each test
-# ----------------------------------
-set(C48mx500_3DVarAOWCDA_tasks
-  "gdasprepoceanobs"
-  "gdasocnanalprep"
-  "gdasocnanalbmat"
-  "gdasocnanalrun"
-  "gdasocnanalchkpt"
-  "gdasocnanalpost")
-set(C96_atmaerosnowDA_tasks)     # empty list for now
-set(C96C48_ufs_hybatmDA_tasks)   # empty list for now
-
-# Iterate through the list of cycling test
-# ----------------------------------------
-foreach(pslot ${cycling_tests})
-  message(STATUS "preparing ${pslot} ctest")
+# Function that generates the 1/2 cycle forecast and DA tasks
+function(add_cycling_tests pslot YAML_PATH HOMEgfs RUNTESTS PROJECT_SOURCE_DIR TASK_LIST)
   # Prepare the COMROOT and EXPDIR for the cycling ctests
-  set(YAML ${HOMEgfs}/ci/cases/pr/${pslot}.yaml)
   add_test(NAME ${pslot}
-    COMMAND /bin/bash -c "${PROJECT_SOURCE_DIR}/test/gw-ci/create_exp.sh ${YAML} ${pslot} ${HOMEgfs} ${RUNTESTS}"
+    COMMAND /bin/bash -c "${PROJECT_SOURCE_DIR}/test/gw-ci/create_exp.sh ${YAML_PATH} ${pslot} ${HOMEgfs} ${RUNTESTS}"
     WORKING_DIRECTORY ${RUNTESTS})
   set_tests_properties(${pslot} PROPERTIES LABELS "manual")
 
   # Get the 1/2 cycle and full cycle's dates
   execute_process(
-    COMMAND ${CMAKE_COMMAND} -E env python ${PROJECT_SOURCE_DIR}/test/gw-ci/get_cycles.py ${YAML}
+    COMMAND ${CMAKE_COMMAND} -E env python ${PROJECT_SOURCE_DIR}/test/gw-ci/get_cycles.py ${YAML_PATH}
     OUTPUT_VARIABLE SCRIPT_OUTPUT
     RESULT_VARIABLE SCRIPT_RESULT
     OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
+  )
   string(REPLACE "," ";" DATES_LIST ${SCRIPT_OUTPUT})
   list(GET DATES_LIST 0 HALF_CYCLE)
   list(GET DATES_LIST 1 FULL_CYCLE)
@@ -48,9 +25,7 @@ foreach(pslot ${cycling_tests})
   set_tests_properties(${pslot}_gdasfcst_${HALF_CYCLE} PROPERTIES LABELS "manual")
 
   # Select the list of tasks to run for the full cycle
-  set(TASK_LIST_NAME "${pslot}_tasks")
-  set(TASK_LIST "${${TASK_LIST_NAME}}")
-  message(STATUS "Tasks for ${EXPERIMENT}: ${TASK_LIST}")
+  message(STATUS "Tasks ${TASK_LIST}")
 
   foreach(task ${TASK_LIST})
     message(STATUS "preparing the full cycle ${task} for ${pslot} ctest")
@@ -59,4 +34,53 @@ foreach(pslot ${cycling_tests})
              WORKING_DIRECTORY ${RUNTESTS})
     set_tests_properties(${pslot}_${task}_${FULL_CYCLE} PROPERTIES LABELS "manual")
   endforeach()
-endforeach()
+endfunction()
+
+# Setup the environement
+set(HOMEgfs ${CMAKE_SOURCE_DIR}/../../..)
+set(RUNTESTS ${CMAKE_CURRENT_BINARY_DIR}/../../test/gw-ci)
+
+# WCDA, low-res
+# -------------
+set(pslot "WCDA-3DVAR-C48mx500")
+set(YAML_PATH ${HOMEgfs}/ci/cases/pr/C48mx500_3DVarAOWCDA.yaml)
+set(TASK_LIST
+  "gdasprepoceanobs"
+  "gdasocnanalprep"
+  "gdasocnanalbmat"
+  "gdasocnanalrun"
+  "gdasocnanalchkpt"
+  "gdasocnanalpost"
+  )
+add_cycling_tests(${pslot} ${YAML_PATH} ${HOMEgfs} ${RUNTESTS} ${PROJECT_SOURCE_DIR} "${TASK_LIST}")
+
+# Aero-Land DA, C96
+# -----------------
+set(pslot "Aero-Snow-3DVAR-C96")
+set(YAML_PATH ${HOMEgfs}/ci/cases/pr/C96_atmaerosnowDA.yaml)
+set(TASK_LIST)  # empty list for now
+add_cycling_tests(${pslot} ${YAML_PATH} ${HOMEgfs} ${RUNTESTS} ${PROJECT_SOURCE_DIR} "${TASK_LIST}")
+
+# Atm DA, C96/C48
+# ---------------
+set(pslot "Atm-hyb-C96C48")
+set(YAML_PATH ${HOMEgfs}/ci/cases/pr/C96C48_ufs_hybatmDA.yaml)
+set(TASK_LIST)  # empty list for now
+add_cycling_tests(${pslot} ${YAML_PATH} ${HOMEgfs} ${RUNTESTS} ${PROJECT_SOURCE_DIR} "${TASK_LIST}")
+
+# GFSv17, 3DVAR prototype
+# -----------------------
+set(pslot "GFSv17-3DVAR-C384mx025")
+set(YAML_PATH ${HOMEgfs}/ci/cases/gfsv17/C384mx025_3DVarAOWCDA.yaml)
+set(TASK_LIST
+  "gdasprepoceanobs"
+  "gdasocnanalprep"
+  "gdasocnanalbmat"
+  "gdasocnanalrun"
+  "gdasocnanalchkpt"
+  "gdasocnanalpost"
+  "gdasocnanalvrfy"
+  "gdasprep"
+  "gdasanal"
+  )
+add_cycling_tests(${pslot} ${YAML_PATH} ${HOMEgfs} ${RUNTESTS} ${PROJECT_SOURCE_DIR} "${TASK_LIST}")


### PR DESCRIPTION
**What was done:**
- reorganization/code tidy to facilitate the addition of a GFSv17 prototype ctest
- exclude the new ctest by default, the user will have to run ```cmake -DRUN_GW_CI=ON .``` on an old build to configure the new ctest

He're the current list:

```
 Test project /scratch1/NCEPDEV/stmp2/Guillaume.Vernieres/runs/prs/global-workflow/sorc/gdas.cd/build/gdas/test/gw-ci
  Test  #1: WCDA-3DVAR-C48mx500
  Test  #2: WCDA-3DVAR-C48mx500_gdasfcst_202103241200
  Test  #3: WCDA-3DVAR-C48mx500_gdasprepoceanobs_202103241800
  Test  #4: WCDA-3DVAR-C48mx500_gdasocnanalprep_202103241800
  Test  #5: WCDA-3DVAR-C48mx500_gdasocnanalbmat_202103241800
  Test  #6: WCDA-3DVAR-C48mx500_gdasocnanalrun_202103241800
  Test  #7: WCDA-3DVAR-C48mx500_gdasocnanalchkpt_202103241800
  Test  #8: WCDA-3DVAR-C48mx500_gdasocnanalpost_202103241800
  Test  #9: Aero-Snow-3DVAR-C96
  Test #10: Aero-Snow-3DVAR-C96_gdasfcst_202112201200
  Test #11: Atm-hyb-C96C48
  Test #12: Atm-hyb-C96C48_gdasfcst_202402231800
  Test #13: GFSv17-3DVAR-C384mx025
  Test #14: GFSv17-3DVAR-C384mx025_gdasfcst_202106300000
  Test #15: GFSv17-3DVAR-C384mx025_gdasprepoceanobs_202106300600
  Test #16: GFSv17-3DVAR-C384mx025_gdasocnanalprep_202106300600
  Test #17: GFSv17-3DVAR-C384mx025_gdasocnanalbmat_202106300600
  Test #18: GFSv17-3DVAR-C384mx025_gdasocnanalrun_202106300600
  Test #19: GFSv17-3DVAR-C384mx025_gdasocnanalchkpt_202106300600
  Test #20: GFSv17-3DVAR-C384mx025_gdasocnanalpost_202106300600
  Test #21: GFSv17-3DVAR-C384mx025_gdasocnanalvrfy_202106300600
  Test #22: GFSv17-3DVAR-C384mx025_gdasprep_202106300600
  Test #23: GFSv17-3DVAR-C384mx025_gdasanal_202106300600

Total Tests: 23
```

