### PR TITLE
Adjust absolute float tolerance for variational and ensemble DA jjob tests

### DIFF
--- a/test/atm/global-workflow/jcb-prototype_3dvar.yaml.j2
+++ b/test/atm/global-workflow/jcb-prototype_3dvar.yaml.j2
@@ -20,4 +20,4 @@ atm_obsdatain_suffix: ".{{ current_cycle | to_YMDH }}.nc"
 test_reference_filename: {{ HOMEgfs }}/sorc/gdas.cd/test/atm/global-workflow/3dvar.ref
 test_output_filename: ./3dvar.out
 float_relative_tolerance: 1.0e-3
-float_absolute_tolerance: 1.0e-6
+float_absolute_tolerance: 1.0e-5

--- a/test/atm/global-workflow/jcb-prototype_lgetkf.yaml.j2
+++ b/test/atm/global-workflow/jcb-prototype_lgetkf.yaml.j2
@@ -25,4 +25,4 @@ atm_obsdatain_suffix: ".{{ current_cycle | to_YMDH }}.nc"
 test_reference_filename: {{ HOMEgfs }}/sorc/gdas.cd/test/atm/global-workflow/lgetkf.ref
 test_output_filename: ./lgetkf.out
 float_relative_tolerance: 1.0e-3
-float_absolute_tolerance: 1.0e-7
+float_absolute_tolerance: 1.0e-5


### PR DESCRIPTION
This PR adjusts the absolute float tolerance for both variational and ensemble DA jjob tests to 10e-5 from 10e-6 and 10e-7 respectively. The old tolerances came from CTests in FV3-JEDI that involve very low resolution experiments. @danholdaway , suggested 10e-5 - 10e-4, since simple machine error could even cause the test to pass on one machine but fail on another.

Reviewers please let me know if the relative float tolerance (10e-3) makes sense as well.