### PR TITLE
Fix keyword for float tolerances in jjob tests

### DIFF
--- a/test/atm/global-workflow/jcb-prototype_3dvar.yaml.j2
+++ b/test/atm/global-workflow/jcb-prototype_3dvar.yaml.j2
@@ -19,5 +19,5 @@ atm_obsdatain_suffix: ".{{ current_cycle | to_YMDH }}.nc"
 # --------------
 test_reference_filename: {{ HOMEgfs }}/sorc/gdas.cd/test/atm/global-workflow/3dvar.ref
 test_output_filename: ./3dvar.out
-float_relative_tolerance: 1.0e-3
-float_absolute_tolerance: 1.0e-5
+test_float_relative_tolerance: 1.0e-3
+test_float_absolute_tolerance: 1.0e-5

--- a/test/atm/global-workflow/jcb-prototype_lgetkf.yaml.j2
+++ b/test/atm/global-workflow/jcb-prototype_lgetkf.yaml.j2
@@ -24,5 +24,5 @@ atm_obsdatain_suffix: ".{{ current_cycle | to_YMDH }}.nc"
 # --------------
 test_reference_filename: {{ HOMEgfs }}/sorc/gdas.cd/test/atm/global-workflow/lgetkf.ref
 test_output_filename: ./lgetkf.out
-float_relative_tolerance: 1.0e-3
-float_absolute_tolerance: 1.0e-5
+test_float_relative_tolerance: 1.0e-3
+test_float_absolute_tolerance: 1.0e-5


### PR DESCRIPTION
@RussTreadon-NOAA caught a bug in the JCB prototype files for the the jjob tests. They are missing "test_" in the keywords for the float tolerances, so that the jjob tests are just using the defaults. 

https://github.com/NOAA-EMC/GDASApp/issues/1148#issuecomment-2153252171