### PR TITLE
Remove N21 from the aero obs list 

### DIFF
--- a/parm/aero/obs/lists/gdas_aero.yaml.j2
+++ b/parm/aero/obs/lists/gdas_aero.yaml.j2
@@ -2,5 +2,4 @@ observers:
 {% filter indent(width=2) %}
 {% include 'aero/obs/config/viirs_n20_aod.yaml.j2' %}
 {% include 'aero/obs/config/viirs_npp_aod.yaml.j2' %}
-{% include 'aero/obs/config/viirs_n21_aod.yaml.j2' %}
 {% endfilter %}


### PR DESCRIPTION
Remove N21 from the aero obs list until JCB can determine if the cycle we are running should have N21 data available.