### PR TITLE
Point the CI to the dev/gdasapp global workflow branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,17 @@ Global Data Assimilation System Application
 
 The one app to rule them all
 
+## Notes to developers
+
+1 - As a developer, you will have to build the GDASApp againt the `dev/gdasapp` branch of the `global-workflow`
+
+```bash
+git clone --recursive --jobs 8 --branch dev/gdasapp https://github.com/NOAA-EMC/global-workflow.git
+```
+
+2 - For the most part (boundaries of that terminology is stil TBD), changes to the `global-workflow` related to the `GDASApp` developement will be issed in the `dev/gdasapp` branch.
+
+
 [![Orion](https://github.com/NOAA-EMC/GDASApp/actions/workflows/orion.yaml/badge.svg)](https://github.com/NOAA-EMC/GDASApp/actions/workflows/orion.yaml)
 [![Hera](https://github.com/NOAA-EMC/GDASApp/actions/workflows/hera.yaml/badge.svg)](https://github.com/NOAA-EMC/GDASApp/actions/workflows/hera.yaml)
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,15 @@ The one app to rule them all
 git clone --recursive --jobs 8 --branch dev/gdasapp https://github.com/NOAA-EMC/global-workflow.git
 ```
 
-2 - For the most part (boundaries of that terminology is stil TBD), changes to the `global-workflow` related to the `GDASApp` developement will be issed in the `dev/gdasapp` branch.
+2 - For the most part (boundaries of that terminology is stil TBD), changes to the `global-workflow` related to the `GDASApp` developement will be issued in the `dev/gdasapp` branch.
+
+3 - If your feature development involves changes to the global-workflow and the GDASApp, you will have to issue a PR in each repository. The GDASApp PR will have to have the same name in order for the GDASApp CI to build and run the correct branches.
+
+4 - If your work is contained within the `global-workflow` only, you will have to submit a dummy PR in the `GDASApp` with the same branch name.
+To submit a dummy PR, just create a branch with an empty commit:
+```
+git commit --allow-empty -m "Dummy commit to trigger PR"
+```
 
 
 [![Orion](https://github.com/NOAA-EMC/GDASApp/actions/workflows/orion.yaml/badge.svg)](https://github.com/NOAA-EMC/GDASApp/actions/workflows/orion.yaml)

--- a/ci/gw_driver.sh
+++ b/ci/gw_driver.sh
@@ -65,7 +65,7 @@ for pr in $open_pr_list; do
   cd $GDAS_CI_ROOT/workflow/PR/$pr
 
   # clone global workflow develop branch
-  git clone --recursive $workflow_url
+  git clone --recursive --jobs 8 --branch dev/gdasapp $workflow_url
 
   # checkout pull request
   cd $GDAS_CI_ROOT/workflow/PR/$pr/global-workflow/sorc/gdas.cd

--- a/ci/gw_driver.sh
+++ b/ci/gw_driver.sh
@@ -73,12 +73,9 @@ for pr in $open_pr_list; do
     # get the PR number
     companion_pr=$(echo "$companion_pr_exists" | awk '{print $1;}')
 
-    # get the fork information
-    pr_details=$(gh pr view ${companion_pr} --repo ${workflow_url} --json headRepository,headRepositoryOwner,headRefName)
-
     # extract the necessary info
-    fork_owner=$(echo "$pr_details" | jq -r '.headRepositoryOwner.login')
-    fork_name=$(echo "$pr_details" | jq -r '.headRepository.name')
+    fork_owner=$(gh pr view $companion_pr --repo $workflow_url --json headRepositoryOwner --jq '.headRepositoryOwner.login')
+    fork_name=$(gh pr view $companion_pr --repo $workflow_url --json headRepository --jq '.headRepository.name')
 
     # Construct the fork URL
     workflow_url="https://github.com/$fork_owner/$fork_name.git"

--- a/ci/gw_driver.sh
+++ b/ci/gw_driver.sh
@@ -76,14 +76,14 @@ for pr in $open_pr_list; do
     # get the fork information
     pr_details=$(gh pr view ${companion_pr} --repo ${workflow_url} --json headRepository,headRepositoryOwner,headRefName)
 
-    # Extract the necessary details
+    # extract the necessary info
     fork_owner=$(echo "$pr_details" | jq -r '.headRepositoryOwner.login')
     fork_name=$(echo "$pr_details" | jq -r '.headRepository.name')
 
     # Construct the fork URL
     workflow_url="https://github.com/$fork_owner/$fork_name.git"
 
-    echo "Fork URL: $fork_url"
+    echo "Fork URL: $workflow_url"
     echo "Branch Name: $gdasapp_branch"
   fi
 


### PR DESCRIPTION
- fixes #1168 

I have not touched the "stable" script, this is just to change the CI to point to `dev/gdsaapp`. 

I'll work next on fixing the gw_ci test, for some reason the hpc account is not updated properly. But in the meantime, the plan is to do bushiness as usual with a different branch.