### PR TITLE
Create JEDI installs and insert logic for using pre-installed JEDI when building GDASapp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,4 +183,8 @@ install*/
 /sorc/gdas
 /sorc/gdas-utils
 !/bundle/CMakeLists.txt
+!/bundle/CMakeLists-j2.txt
+!/bundle/generate_cmakelists.py
+!/bundle/get_big_jedi_hash.py
+!/bundle/gdas_jedi_bundle.yaml
 /bundle/*

--- a/build.sh
+++ b/build.sh
@@ -164,4 +164,12 @@ if [[ -n ${INSTALL_PREFIX:-} ]]; then
   set +x
 fi
 
+# If we were searching for a JEDI build we should link all the executables in that install to the
+# gdas build directory. global-workflow tasks look for the executables there.
+if [[ -n ${SEARCH_FOR_JEDI_INSTALL:-} ]]; then
+  # This is a placeholder for a future feature
+  echo "ERROR: SEARCH_FOR_JEDI_INSTALL is not yet supported"
+  exit 1
+fi
+
 exit 0

--- a/build.sh
+++ b/build.sh
@@ -112,17 +112,6 @@ if [[ $BUILD_TARGET == 'hera' ]]; then
   ln -sf $GDASAPP_TESTDATA/crtm $dir_root/bundle/test-data-release/crtm
 fi
 
-# Before configuring, look for an exising JEDI install for this platform and set of JEDI hashes.
-# If found add the the library paths (containning cmake files) to the path.
-
-# Check if environement variable SEARCH_FOR_JEDI_INSTALL is set and exit if it is since this is not
-# yet supported
-if [[ -n ${SEARCH_FOR_JEDI_INSTALL:-} ]]; then
-  # This is a placeholder for a future feature
-  echo "ERROR: SEARCH_FOR_JEDI_INSTALL is not yet supported"
-  exit 1
-fi
-
 # Configure
 echo "Configuring ..."
 set -x
@@ -139,15 +128,9 @@ if [[ $BUILD_JCSDA == 'YES' ]]; then
 else
   builddirs="gdas iodaconv land-imsproc land-jediincr gdas-utils"
   for b in $builddirs; do
-    # Check that b exists and if it does perform the build
-    if [ -d $b ]; then
-      cd $b
-      make -j ${BUILD_JOBS:-6} VERBOSE=$BUILD_VERBOSE
-      cd ../
-    else
-      echo "WARNING: $b was not part of the bundle, skipping build. Usually this happens because it was found in the path"
-    fi
-
+    cd $b
+    make -j ${BUILD_JOBS:-6} VERBOSE=$BUILD_VERBOSE
+    cd ../
   done
 fi
 set +x
@@ -156,20 +139,8 @@ set +x
 if [[ -n ${INSTALL_PREFIX:-} ]]; then
   echo "Installing ..."
   set -x
-  # TODO: this does not simply copy files to install. It will build the rest of the bundle that was
-  # not built above but with one processor, and then install it. We might need to think about what
-  # we actually want here. We could install individual packages but that would leave lots of
-  # libraries out. Install potentially only makes sense with $BUILD_JCSDA
   make install
   set +x
-fi
-
-# If we were searching for a JEDI build we should link all the executables in that install to the
-# gdas build directory. global-workflow tasks look for the executables there.
-if [[ -n ${SEARCH_FOR_JEDI_INSTALL:-} ]]; then
-  # This is a placeholder for a future feature
-  echo "ERROR: SEARCH_FOR_JEDI_INSTALL is not yet supported"
-  exit 1
 fi
 
 exit 0

--- a/bundle/CMakeLists-j2.txt
+++ b/bundle/CMakeLists-j2.txt
@@ -1,0 +1,110 @@
+# ------------------------------------------------------------------------- #
+# JEDI GDAS Bundle             #
+# ------------------------------------------------------------------------- #
+
+# Check for minimim cmake requirement
+cmake_minimum_required( VERSION 3.20 FATAL_ERROR )
+
+find_package(ecbuild 3.5 REQUIRED HINTS ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/../ecbuild)
+
+project(GDAS-bundle VERSION 1.0.0 LANGUAGES C CXX Fortran )
+
+include(GNUInstallDirs)
+enable_testing()
+
+# Build type.
+if(NOT CMAKE_BUILD_TYPE MATCHES "^(Debug|Release|RelWithDebInfo|MinSizeRel)$")
+  message(STATUS "Setting build type to 'Release' as none was specified.")
+  set(CMAKE_BUILD_TYPE
+      "Release"
+      CACHE STRING "Choose the type of build." FORCE)
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release"
+                                               "MinSizeRel" "RelWithDebInfo")
+endif()
+
+# Find dependencies.
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
+# Include ecbuild_bundle macro
+include( ecbuild_bundle )
+
+# Enable MPI
+set( ENABLE_MPI ON CACHE BOOL "Compile with MPI" )
+
+# Handle user options.
+option(BUILD_GDASBUNDLE "Build GDAS Bundle" ON)
+option(BUILD_JEDI "Build JEDI repositories in the bundle" ON)
+option(BUILD_GDAS_JEDI "Build JEDI repositories in the bundle" ON)
+option(CLONE_JCSDADATA "Clone JCSDA test data repositories" OFF)
+option(WORKFLOW_TESTS "Include global-workflow dependent tests" OFF)
+
+# Initialize bundle
+# -----------------
+ecbuild_bundle_initialize()
+
+# --------------------------------------------------------------------------------------------------
+
+  ######################################
+  #                                    #
+  # BEING AUTOMATIC GENERATION SECTION #
+  #                                    #
+  ######################################
+
+# Build bundle source code.
+if(BUILD_GDASBUNDLE)
+
+  # Add JEDI packages to the bundle
+  if (BUILD_JEDI)
+    {% for jedi_package in jedi_packages %}
+    # {{jedi_package.project}}
+    {%- if jedi_package.pre_include %}
+    {%- for pre_include_line in jedi_package.pre_include %}
+    {{pre_include_line}}
+    {%- endfor %}
+    {%- endif %}
+    {%- if jedi_package.location == "GIT" %}
+    ecbuild_bundle(PROJECT {{jedi_package.project}} GIT "{{jedi_package.path}}" TAG {{jedi_package.min_version}} )
+    {%- elif jedi_package.location == "SOURCE" %}
+    ecbuild_bundle(PROJECT {{jedi_package.project}} SOURCE "{{jedi_package.path}}")
+    {%- endif %}
+    {%- if jedi_package.post_include %}
+    {%- for post_include_line in jedi_package.post_include %}
+    {{post_include_line}}
+    {%- endfor %}
+    {%- endif %}
+    {% endfor %}
+  endif (BUILD_JEDI)
+
+  # Add GDAS-JEDI packages to the bundle
+  if (BUILD_GDAS_JEDI)
+    {% for gdas_package in gdas_packages %}
+    # {{gdas_package.project}}
+    ecbuild_bundle( PROJECT {{gdas_package.project}} SOURCE "{{gdas_package.path}}")
+    {% endfor %}
+  endif (BUILD_GDAS_JEDI)
+
+  endif (BUILD_GDASBUNDLE)
+
+  ####################################
+  #                                  #
+  # END AUTOMATIC GENERATION SECTION #
+  #                                  #
+  ####################################
+
+  # --------------------------------------------------------------------------------------------------
+
+  # Clone test data
+  #----------------
+  option(CLONE_JCSDADATA "Clone JCSDA test data repositories" OFF)
+  if(CLONE_JCSDADATA)
+    set(JCSDA_DATA_ROOT "$ENV{GDASAPP_TESTDATA}/jcsda")
+    ecbuild_bundle( PROJECT ioda-data SOURCE "${JCSDA_DATA_ROOT}/ioda-data" )
+    ecbuild_bundle( PROJECT ufo-data SOURCE "${JCSDA_DATA_ROOT}/ufo-data" )
+    ecbuild_bundle( PROJECT fv3-jedi-data SOURCE "${JCSDA_DATA_ROOT}/fv3-jedi-data" )
+  endif(CLONE_JCSDADATA)
+
+endif(BUILD_GDASBUNDLE)
+
+# Finalize bundle
+# ---------------
+ecbuild_bundle_finalize()

--- a/bundle/CMakeLists.txt
+++ b/bundle/CMakeLists.txt
@@ -33,7 +33,8 @@ set( ENABLE_MPI ON CACHE BOOL "Compile with MPI" )
 
 # Handle user options.
 option(BUILD_GDASBUNDLE "Build GDAS Bundle" ON)
-option(JEDI_ONLY "Build only the JEDI code" OFF)
+option(BUILD_JEDI "Build JEDI repositories in the bundle" ON)
+option(BUILD_GDAS_JEDI "Build JEDI repositories in the bundle" ON)
 option(CLONE_JCSDADATA "Clone JCSDA test data repositories" OFF)
 option(WORKFLOW_TESTS "Include global-workflow dependent tests" OFF)
 
@@ -43,200 +44,102 @@ ecbuild_bundle_initialize()
 
 # --------------------------------------------------------------------------------------------------
 
-macro(add_package_to_bundle PROJECT_NAME PACKAGE_NAME LOCATION URL MIN_REQUIRED_VERSION )
-
-  # This macro finds dependencies and checks that they are either not present at all (not found)
-  # or whether a minimum required version is satisfied. If the package is found but the version
-  # is too old, the build will be stopped. If the package is not found, a message will be issued
-  # but the build will continue without it.
-
-  # Building with a package that is too old will not work. And having it in the path will likely
-  # cause problems if a sufficiently new version is built anyway. But we also want to continue
-  # if the package is not found at all because we can add it to the bundle and build locally.
-
-  # If path ${CMAKE_BINARY_DIR}/PROJECT_NAME does not exist then look for the package.
-  # This is needed because sometimes CMake is re-triggered and this results in packages that are
-  # being built in the bundle as being found, when the following logic assumes they are not.
-  if (NOT EXISTS "${CMAKE_BINARY_DIR}/${PROJECT_NAME}")
-
-    # First try to find the pacakge, do so silenty and do not abort if not found
-    find_package(${PACKAGE_NAME} QUIET)
-
-    # Check if the package is found and if the version is sufficient
-    string(APPEND message "Assessing whether to add project '${PROJECT_NAME}' to the bundle ... ")
-    if (NOT ${PACKAGE_NAME}_FOUND)
-      string(APPEND message "${PROJECT_NAME} not found so will be built with the bundle")
-      message(STATUS "${message}")
-    else()
-      if (${PACKAGE_NAME}_VERSION VERSION_LESS ${MIN_REQUIRED_VERSION})
-        string(APPEND message "${PROJECT_NAME} found but the version is too old. Found version ")
-        string(APPEND message "${${PACKAGE_NAME}_VERSION}. Minimum required version is ")
-        string(APPEND message "${MIN_REQUIRED_VERSION}. Adding this package to the bundle will ")
-        string(APPEND message "likely lead to conflicts and build/runtime errors. Ensure this ")
-        string(APPEND message "version of the package is not in the path before continuing.")
-        message(FATAL_ERROR "${message}")
-      else()
-
-        # Find the package again with the minimum required version and make it required
-        # This is not technically required but it prevents the package being listed as optional
-        # at the end of the cmake step, which could otherwise be misleading.
-        find_package(${PACKAGE_NAME} ${MIN_REQUIRED_VERSION} REQUIRED QUIET)
-
-        string(APPEND message "${PROJECT_NAME} found and the version is ")
-        string(APPEND message "${${PACKAGE_NAME}_VERSION}. Package not added to bundle.")
-        message(STATUS "${message}")
-      endif()
-    endif()
-
-    # Remove global message variable
-    unset(message)
-
-  endif()
-
-  # If the package is not found at all then add it to the bundle
-  # This might include some pre- and post-amble to the bundle line, which is added via templating.
-  if (NOT ${PACKAGE_NAME}_FOUND)
-
-    # Unset the package found flag. This is required because the package is not found and otherwise
-    # it makes ecbuild think the package is setting the flag manually, which would not be permitted.
-    unset(${PACKAGE_NAME}_FOUND)
-
-    ############# BEGIN AUTOGENERATION SECTION #############
-    # If PRE_INCLUDE is not an empty string then put it here
-    if (${PROJECT_NAME} STREQUAL "oops")
-      option( ENABLE_LORENZ95_MODEL "Build LORENZ95 toy model" OFF )
-      option( ENABLE_QG_MODEL "Build QG toy model" OFF )
-    endif()
-    if (${PROJECT_NAME} STREQUAL "ioda")
-      option(ENABLE_IODA_DATA "Obtain ioda test data from ioda-data repository (vs tarball)" ON)
-    endif()
-    if (${PROJECT_NAME} STREQUAL "ufo")
-      option(ENABLE_UFO_DATA "Obtain ufo test data from ufo-data repository (vs tarball)" ON)
-    endif()
-    if (${PROJECT_NAME} STREQUAL "gsibec")
-      option(BUILD_GSIBEC "Build GSI-B" OFF)
-    endif()
-    if (${PROJECT_NAME} STREQUAL "icepack")
-      set(BUILD_ICEPACK "ON" CACHE STRING "Build the icepack library")
-    endif()
-    if (${PROJECT_NAME} STREQUAL "fv3-jedi")
-      option(ENABLE_FV3_JEDI_DATA "Obtain fv3-jedi test data from fv3-jedi-data repository (vs tarball)" ON)
-    endif()
-    ############## END AUTOGENERATION SECTION ##############
-
-    # Based on the location (GIT or SOURCE) add the package to the bundle
-    if (${LOCATION} STREQUAL "GIT")
-      ecbuild_bundle( PROJECT ${PROJECT_NAME} GIT ${URL} TAG ${MIN_REQUIRED_VERSION} )
-    elseif (${LOCATION} STREQUAL "SOURCE")
-      ecbuild_bundle( PROJECT ${PROJECT_NAME} SOURCE ${URL} )
-    else()
-      message(FATAL_ERROR "Unknown location type '${LOCATION}'")
-    endif()
-
-    ############# BEGIN AUTOGENERATION SECTION #############
-    # If POST_INCLUDE is not an empty string then put it here
-    if (${PROJECT_NAME} STREQUAL "jedicmake")
-      include( jedicmake/cmake/Functions/git_functions.cmake )
-    endif()
-    ############## END AUTOGENERATION SECTION ##############
-
-  endif()
-
-endmacro()
-
-# --------------------------------------------------------------------------------------------------
-
-######################################
-#                                    #
-# THE BELOW SECTION IS AUTOMATICALLY #
-# GENERATED FROM gdas_bundle.yaml    #
-# AND BY RUNNING:                    #
-# python3 generate_bundle.py         #
-#                                    #
-# DO NOT EDIT MANUALLY!              #
-#                                    #
-######################################
+  ######################################
+  #                                    #
+  # BEING AUTOMATIC GENERATION SECTION #
+  #                                    #
+  ######################################
 
 # Build bundle source code.
 if(BUILD_GDASBUNDLE)
 
-  # Add all the JEDI packages to the bundle (if needed)
-  # JEDI packages are only built in the bundle if they are not found in the path
-  # ----------------------------------------------------------------------------
-  
-  # jedicmake
-  add_package_to_bundle(jedicmake jedicmake SOURCE "../sorc/jedicmake" 1.4.0)
-  
-  # eckit
-  add_package_to_bundle(eckit eckit GIT "https://github.com/ecmwf/eckit.git" 1.16.0)
-  
-  # fckit
-  add_package_to_bundle(fckit fckit GIT "https://github.com/ecmwf/fckit.git" 0.9.2)
-  
-  # atlas
-  add_package_to_bundle(atlas atlas GIT "https://github.com/ecmwf/atlas.git" 0.35.0)
-  
-  # oops
-  add_package_to_bundle(oops oops SOURCE "../sorc/oops" 1.10.0)
-  
-  # ioda
-  add_package_to_bundle(ioda ioda SOURCE "../sorc/ioda" 2.9.0)
-  
-  # iodaconv
-  add_package_to_bundle(iodaconv iodaconv SOURCE "../sorc/iodaconv" 0.0.1)
-  
-  # crtm
-  add_package_to_bundle(crtm crtm SOURCE "../sorc/crtm" 2.4.1)
-  
-  # ufo
-  add_package_to_bundle(ufo ufo SOURCE "../sorc/ufo" 1.10.0)
-  
-  # gsibec
-  add_package_to_bundle(gsibec gsibec SOURCE "../sorc/gsibec" 1.2.1)
-  
-  # saber
-  add_package_to_bundle(saber saber SOURCE "../sorc/saber" 1.10.0)
-  
-  # vader
-  add_package_to_bundle(vader vader SOURCE "../sorc/vader" 1.7.0)
-  
-  # femps
-  add_package_to_bundle(femps femps SOURCE "../sorc/femps" 1.3.0)
-  
-  # gsw
-  add_package_to_bundle(gsw gsw SOURCE "../sorc/gsw" 3.0.7)
-  
-  # icepack
-  add_package_to_bundle(icepack icepack SOURCE "../sorc/icepack" 1.2.0)
-  
-  # land-imsproc
-  add_package_to_bundle(land-imsproc imsproc SOURCE "../sorc/land-imsproc" 2022.1)
-  
-  # land-jediincr
-  add_package_to_bundle(land-jediincr jediincr SOURCE "../sorc/land-jediincr" 2022.1)
-  
-  # fms
-  add_package_to_bundle(fms fms SOURCE "../sorc/fms" 2020.4.0)
-  
-  # fv3
-  add_package_to_bundle(fv3 fv3 SOURCE "../sorc/fv3" 1.2.0)
-  
-  # fv3-jedi-lm
-  add_package_to_bundle(fv3-jedi-lm fv3jedilm SOURCE "../sorc/fv3-jedi-lm" 1.5.0)
-  
-  # fv3-jedi
-  add_package_to_bundle(fv3-jedi fv3jedi SOURCE "../sorc/fv3-jedi" 1.9.0)
-  
-  # mom6
-  add_package_to_bundle(mom6 mom6 SOURCE "../sorc/mom6" 2022.1.0)
-  
-  # soca
-  add_package_to_bundle(soca soca SOURCE "../sorc/soca" 1.8.0)
-  
+  # Add JEDI packages to the bundle
+  if (BUILD_JEDI)
+    
+    # jedicmake
+    ecbuild_bundle(PROJECT jedicmake SOURCE "../sorc/jedicmake")
+    include( jedicmake/cmake/Functions/git_functions.cmake )
+    
+    # eckit
+    option("BUNDLE_SKIP_ECKIT" "Don't build eckit" "ON" )
+    ecbuild_bundle(PROJECT eckit GIT "https://github.com/ecmwf/eckit.git" TAG 1.16.0 )
+    
+    # fckit
+    option("BUNDLE_SKIP_FCKIT" "Don't build fckit" "ON" )
+    ecbuild_bundle(PROJECT fckit GIT "https://github.com/ecmwf/fckit.git" TAG 0.9.2 )
+    
+    # atlas
+    option("BUNDLE_SKIP_ATLAS" "Don't build atlas" "ON" )
+    ecbuild_bundle(PROJECT atlas GIT "https://github.com/ecmwf/atlas.git" TAG 0.35.0 )
+    
+    # oops
+    option( ENABLE_LORENZ95_MODEL "Build LORENZ95 toy model" OFF )
+    option( ENABLE_QG_MODEL "Build QG toy model" OFF )
+    ecbuild_bundle(PROJECT oops SOURCE "../sorc/oops")
+    
+    # ioda
+    option(ENABLE_IODA_DATA "Obtain ioda test data from ioda-data repository (vs tarball)" ON)
+    ecbuild_bundle(PROJECT ioda SOURCE "../sorc/ioda")
+    
+    # iodaconv
+    ecbuild_bundle(PROJECT iodaconv SOURCE "../sorc/iodaconv")
+    
+    # crtm
+    ecbuild_bundle(PROJECT crtm SOURCE "../sorc/crtm")
+    
+    # ufo
+    option(ENABLE_UFO_DATA "Obtain ufo test data from ufo-data repository (vs tarball)" ON)
+    ecbuild_bundle(PROJECT ufo SOURCE "../sorc/ufo")
+    
+    # gsibec
+    option(BUILD_GSIBEC "Build GSI-B" OFF)
+    ecbuild_bundle(PROJECT gsibec SOURCE "../sorc/gsibec")
+    
+    # saber
+    ecbuild_bundle(PROJECT saber SOURCE "../sorc/saber")
+    
+    # vader
+    ecbuild_bundle(PROJECT vader SOURCE "../sorc/vader")
+    
+    # femps
+    ecbuild_bundle(PROJECT femps SOURCE "../sorc/femps")
+    
+    # gsw
+    ecbuild_bundle(PROJECT gsw SOURCE "../sorc/gsw")
+    
+    # icepack
+    set(BUILD_ICEPACK "ON" CACHE STRING "Build the icepack library")
+    ecbuild_bundle(PROJECT icepack SOURCE "../sorc/icepack")
+    
+    # land-imsproc
+    ecbuild_bundle(PROJECT land-imsproc SOURCE "../sorc/land-imsproc")
+    
+    # land-jediincr
+    ecbuild_bundle(PROJECT land-jediincr SOURCE "../sorc/land-jediincr")
+    
+    # fms
+    ecbuild_bundle(PROJECT fms SOURCE "../sorc/fms")
+    
+    # fv3
+    ecbuild_bundle(PROJECT fv3 SOURCE "../sorc/fv3")
+    
+    # fv3-jedi-lm
+    ecbuild_bundle(PROJECT fv3-jedi-lm SOURCE "../sorc/fv3-jedi-lm")
+    
+    # fv3-jedi
+    option(ENABLE_FV3_JEDI_DATA "Obtain fv3-jedi test data from fv3-jedi-data repository (vs tarball)" ON)
+    ecbuild_bundle(PROJECT fv3-jedi SOURCE "../sorc/fv3-jedi")
+    
+    # mom6
+    ecbuild_bundle(PROJECT mom6 SOURCE "../sorc/mom6")
+    
+    # soca
+    ecbuild_bundle(PROJECT soca SOURCE "../sorc/soca")
+    
+  endif (BUILD_JEDI)
 
-  # Build GDAS pacakges (only if JEDI_ONLY is not set or is set to OFF)
-  # -------------------------------------------------------------------
-  if(NOT JEDI_ONLY)
+  # Add GDAS-JEDI packages to the bundle
+  if (BUILD_GDAS_JEDI)
     
     # gdas-utils
     ecbuild_bundle( PROJECT gdas-utils SOURCE "../utils")
@@ -244,7 +147,9 @@ if(BUILD_GDASBUNDLE)
     # gdas
     ecbuild_bundle( PROJECT gdas SOURCE "../")
     
-  endif(NOT JEDI_ONLY)
+  endif (BUILD_GDAS_JEDI)
+
+  endif (BUILD_GDASBUNDLE)
 
   ####################################
   #                                  #

--- a/bundle/CMakeLists.txt
+++ b/bundle/CMakeLists.txt
@@ -33,6 +33,7 @@ set( ENABLE_MPI ON CACHE BOOL "Compile with MPI" )
 
 # Handle user options.
 option(BUILD_GDASBUNDLE "Build GDAS Bundle" ON)
+option(JEDI_ONLY "Build only the JEDI code" OFF)
 option(CLONE_JCSDADATA "Clone JCSDA test data repositories" OFF)
 option(WORKFLOW_TESTS "Include global-workflow dependent tests" OFF)
 
@@ -40,94 +41,227 @@ option(WORKFLOW_TESTS "Include global-workflow dependent tests" OFF)
 # -----------------
 ecbuild_bundle_initialize()
 
+# --------------------------------------------------------------------------------------------------
+
+macro(add_package_to_bundle PROJECT_NAME PACKAGE_NAME LOCATION URL MIN_REQUIRED_VERSION )
+
+  # This macro finds dependencies and checks that they are either not present at all (not found)
+  # or whether a minimum required version is satisfied. If the package is found but the version
+  # is too old, the build will be stopped. If the package is not found, a message will be issued
+  # but the build will continue without it.
+
+  # Building with a package that is too old will not work. And having it in the path will likely
+  # cause problems if a sufficiently new version is built anyway. But we also want to continue
+  # if the package is not found at all because we can add it to the bundle and build locally.
+
+  # If path ${CMAKE_BINARY_DIR}/PROJECT_NAME does not exist then look for the package.
+  # This is needed because sometimes CMake is re-triggered and this results in packages that are
+  # being built in the bundle as being found, when the following logic assumes they are not.
+  if (NOT EXISTS "${CMAKE_BINARY_DIR}/${PROJECT_NAME}")
+
+    # First try to find the pacakge, do so silenty and do not abort if not found
+    find_package(${PACKAGE_NAME} QUIET)
+
+    # Check if the package is found and if the version is sufficient
+    string(APPEND message "Assessing whether to add project '${PROJECT_NAME}' to the bundle ... ")
+    if (NOT ${PACKAGE_NAME}_FOUND)
+      string(APPEND message "${PROJECT_NAME} not found so will be built with the bundle")
+      message(STATUS "${message}")
+    else()
+      if (${PACKAGE_NAME}_VERSION VERSION_LESS ${MIN_REQUIRED_VERSION})
+        string(APPEND message "${PROJECT_NAME} found but the version is too old. Found version ")
+        string(APPEND message "${${PACKAGE_NAME}_VERSION}. Minimum required version is ")
+        string(APPEND message "${MIN_REQUIRED_VERSION}. Adding this package to the bundle will ")
+        string(APPEND message "likely lead to conflicts and build/runtime errors. Ensure this ")
+        string(APPEND message "version of the package is not in the path before continuing.")
+        message(FATAL_ERROR "${message}")
+      else()
+
+        # Find the package again with the minimum required version and make it required
+        # This is not technically required but it prevents the package being listed as optional
+        # at the end of the cmake step, which could otherwise be misleading.
+        find_package(${PACKAGE_NAME} ${MIN_REQUIRED_VERSION} REQUIRED QUIET)
+
+        string(APPEND message "${PROJECT_NAME} found and the version is ")
+        string(APPEND message "${${PACKAGE_NAME}_VERSION}. Package not added to bundle.")
+        message(STATUS "${message}")
+      endif()
+    endif()
+
+    # Remove global message variable
+    unset(message)
+
+  endif()
+
+  # If the package is not found at all then add it to the bundle
+  # This might include some pre- and post-amble to the bundle line, which is added via templating.
+  if (NOT ${PACKAGE_NAME}_FOUND)
+
+    # Unset the package found flag. This is required because the package is not found and otherwise
+    # it makes ecbuild think the package is setting the flag manually, which would not be permitted.
+    unset(${PACKAGE_NAME}_FOUND)
+
+    ############# BEGIN AUTOGENERATION SECTION #############
+    # If PRE_INCLUDE is not an empty string then put it here
+    if (${PROJECT_NAME} STREQUAL "oops")
+      option( ENABLE_LORENZ95_MODEL "Build LORENZ95 toy model" OFF )
+      option( ENABLE_QG_MODEL "Build QG toy model" OFF )
+    endif()
+    if (${PROJECT_NAME} STREQUAL "ioda")
+      option(ENABLE_IODA_DATA "Obtain ioda test data from ioda-data repository (vs tarball)" ON)
+    endif()
+    if (${PROJECT_NAME} STREQUAL "ufo")
+      option(ENABLE_UFO_DATA "Obtain ufo test data from ufo-data repository (vs tarball)" ON)
+    endif()
+    if (${PROJECT_NAME} STREQUAL "gsibec")
+      option(BUILD_GSIBEC "Build GSI-B" OFF)
+    endif()
+    if (${PROJECT_NAME} STREQUAL "icepack")
+      set(BUILD_ICEPACK "ON" CACHE STRING "Build the icepack library")
+    endif()
+    if (${PROJECT_NAME} STREQUAL "fv3-jedi")
+      option(ENABLE_FV3_JEDI_DATA "Obtain fv3-jedi test data from fv3-jedi-data repository (vs tarball)" ON)
+    endif()
+    ############## END AUTOGENERATION SECTION ##############
+
+    # Based on the location (GIT or SOURCE) add the package to the bundle
+    if (${LOCATION} STREQUAL "GIT")
+      ecbuild_bundle( PROJECT ${PROJECT_NAME} GIT ${URL} TAG ${MIN_REQUIRED_VERSION} )
+    elseif (${LOCATION} STREQUAL "SOURCE")
+      ecbuild_bundle( PROJECT ${PROJECT_NAME} SOURCE ${URL} )
+    else()
+      message(FATAL_ERROR "Unknown location type '${LOCATION}'")
+    endif()
+
+    ############# BEGIN AUTOGENERATION SECTION #############
+    # If POST_INCLUDE is not an empty string then put it here
+    if (${PROJECT_NAME} STREQUAL "jedicmake")
+      include( jedicmake/cmake/Functions/git_functions.cmake )
+    endif()
+    ############## END AUTOGENERATION SECTION ##############
+
+  endif()
+
+endmacro()
+
+# --------------------------------------------------------------------------------------------------
+
+######################################
+#                                    #
+# THE BELOW SECTION IS AUTOMATICALLY #
+# GENERATED FROM gdas_bundle.yaml    #
+# AND BY RUNNING:                    #
+# python3 generate_bundle.py         #
+#                                    #
+# DO NOT EDIT MANUALLY!              #
+#                                    #
+######################################
+
 # Build bundle source code.
 if(BUILD_GDASBUNDLE)
 
-# jedi-cmake
-  ecbuild_bundle( PROJECT jedicmake SOURCE "../sorc/jedicmake" )
-  include( jedicmake/cmake/Functions/git_functions.cmake )
+  # Add all the JEDI packages to the bundle (if needed)
+  # JEDI packages are only built in the bundle if they are not found in the path
+  # ----------------------------------------------------------------------------
+  
+  # jedicmake
+  add_package_to_bundle(jedicmake jedicmake SOURCE "../sorc/jedicmake" 1.4.0)
+  
+  # eckit
+  add_package_to_bundle(eckit eckit GIT "https://github.com/ecmwf/eckit.git" 1.16.0)
+  
+  # fckit
+  add_package_to_bundle(fckit fckit GIT "https://github.com/ecmwf/fckit.git" 0.9.2)
+  
+  # atlas
+  add_package_to_bundle(atlas atlas GIT "https://github.com/ecmwf/atlas.git" 0.35.0)
+  
+  # oops
+  add_package_to_bundle(oops oops SOURCE "../sorc/oops" 1.10.0)
+  
+  # ioda
+  add_package_to_bundle(ioda ioda SOURCE "../sorc/ioda" 2.9.0)
+  
+  # iodaconv
+  add_package_to_bundle(iodaconv iodaconv SOURCE "../sorc/iodaconv" 0.0.1)
+  
+  # crtm
+  add_package_to_bundle(crtm crtm SOURCE "../sorc/crtm" 2.4.1)
+  
+  # ufo
+  add_package_to_bundle(ufo ufo SOURCE "../sorc/ufo" 1.10.0)
+  
+  # gsibec
+  add_package_to_bundle(gsibec gsibec SOURCE "../sorc/gsibec" 1.2.1)
+  
+  # saber
+  add_package_to_bundle(saber saber SOURCE "../sorc/saber" 1.10.0)
+  
+  # vader
+  add_package_to_bundle(vader vader SOURCE "../sorc/vader" 1.7.0)
+  
+  # femps
+  add_package_to_bundle(femps femps SOURCE "../sorc/femps" 1.3.0)
+  
+  # gsw
+  add_package_to_bundle(gsw gsw SOURCE "../sorc/gsw" 3.0.7)
+  
+  # icepack
+  add_package_to_bundle(icepack icepack SOURCE "../sorc/icepack" 1.2.0)
+  
+  # land-imsproc
+  add_package_to_bundle(land-imsproc imsproc SOURCE "../sorc/land-imsproc" 2022.1)
+  
+  # land-jediincr
+  add_package_to_bundle(land-jediincr jediincr SOURCE "../sorc/land-jediincr" 2022.1)
+  
+  # fms
+  add_package_to_bundle(fms fms SOURCE "../sorc/fms" 2020.4.0)
+  
+  # fv3
+  add_package_to_bundle(fv3 fv3 SOURCE "../sorc/fv3" 1.2.0)
+  
+  # fv3-jedi-lm
+  add_package_to_bundle(fv3-jedi-lm fv3jedilm SOURCE "../sorc/fv3-jedi-lm" 1.5.0)
+  
+  # fv3-jedi
+  add_package_to_bundle(fv3-jedi fv3jedi SOURCE "../sorc/fv3-jedi" 1.9.0)
+  
+  # mom6
+  add_package_to_bundle(mom6 mom6 SOURCE "../sorc/mom6" 2022.1.0)
+  
+  # soca
+  add_package_to_bundle(soca soca SOURCE "../sorc/soca" 1.8.0)
+  
 
-# ECMWF libraries
-  option("BUNDLE_SKIP_ECKIT" "Don't build eckit" "ON" ) # Skip eckit build unless user passes -DBUNDLE_SKIP_ECKIT=OFF
-  option("BUNDLE_SKIP_FCKIT" "Don't build fckit" "ON") # Skip fckit build unless user passes -DBUNDLE_SKIP_FCKIT=OFF
-  option("BUNDLE_SKIP_ATLAS" "Don't build atlas" "ON") # Skip atlas build unless user passes -DBUNDLE_SKIP_ATLAS=OFF
+  # Build GDAS pacakges (only if JEDI_ONLY is not set or is set to OFF)
+  # -------------------------------------------------------------------
+  if(NOT JEDI_ONLY)
+    
+    # gdas-utils
+    ecbuild_bundle( PROJECT gdas-utils SOURCE "../utils")
+    
+    # gdas
+    ecbuild_bundle( PROJECT gdas SOURCE "../")
+    
+  endif(NOT JEDI_ONLY)
 
-# turn off optional OOPS toy models
-  option( ENABLE_LORENZ95_MODEL "Build LORENZ95 toy model" OFF )
-  option( ENABLE_QG_MODEL "Build QG toy model" OFF )
+  ####################################
+  #                                  #
+  # END AUTOMATIC GENERATION SECTION #
+  #                                  #
+  ####################################
 
-  ecbuild_bundle( PROJECT eckit GIT "https://github.com/ecmwf/eckit.git" TAG 1.16.0 )
-  ecbuild_bundle( PROJECT fckit GIT "https://github.com/ecmwf/fckit.git" TAG 0.9.2 )
-  ecbuild_bundle( PROJECT atlas GIT "https://github.com/ecmwf/atlas.git" TAG 0.35.0 )
+  # --------------------------------------------------------------------------------------------------
 
-# External (required) observation operators
-  # TODO remove the CRTM from here and use it as a library
-  #option("BUNDLE_SKIP_CRTM" "Don't build CRTM" "OFF") # Don't build crtm unless user passes -DBUNDLE_SKIP_CRTM=OFF
-  #ecbuild_bundle( PROJECT crtm GIT "https://github.com/JCSDA/crtm.git"   TAG v2.4.1-jedi.1 )
-  ecbuild_bundle( PROJECT crtm SOURCE "../sorc/crtm" )
-
-# Build GSI-B
-  option(BUILD_GSIBEC "Build GSI-B" OFF)
-  if(BUILD_GSIBEC)
-    ecbuild_bundle( PROJECT gsibec SOURCE "../sorc/gsibec" )
-  endif()
-
-# Gibbs seawater
-  ecbuild_bundle( PROJECT gsw SOURCE "../sorc/gsw" )
-
-# Core JEDI repositories
-  ecbuild_bundle( PROJECT oops SOURCE "../sorc/oops" )
-  ecbuild_bundle( PROJECT vader SOURCE "../sorc/vader" )
-  ecbuild_bundle( PROJECT saber SOURCE "../sorc/saber" )
-  option(ENABLE_IODA_DATA "Obtain ioda test data from ioda-data repository (vs tarball)" ON)
-  ecbuild_bundle( PROJECT ioda SOURCE "../sorc/ioda" )
-  option(ENABLE_UFO_DATA "Obtain ufo test data from ufo-data repository (vs tarball)" ON)
-  ecbuild_bundle( PROJECT ufo SOURCE "../sorc/ufo" )
-
-# FMS and FV3 dynamical core
-  ecbuild_bundle( PROJECT fms SOURCE "../sorc/fms" )
-  ecbuild_bundle( PROJECT fv3 SOURCE "../sorc/fv3" )
-
-# fv3-jedi and associated repositories
-  ecbuild_bundle( PROJECT femps SOURCE "../sorc/femps" )
-  ecbuild_bundle( PROJECT fv3-jedi-lm SOURCE "../sorc/fv3-jedi-lm" )
-  option(ENABLE_FV3_JEDI_DATA "Obtain fv3-jedi test data from fv3-jedi-data repository (vs tarball)" ON)
-  ecbuild_bundle( PROJECT fv3-jedi SOURCE "../sorc/fv3-jedi" )
-
-# SOCA associated repositories
-# TODO: Move the Icepack fork to EMC github
-  set(BUILD_ICEPACK "ON" CACHE STRING "Build the icepack library")
-  if ( BUILD_ICEPACK )
-    ecbuild_bundle( PROJECT icepack SOURCE "../sorc/icepack" )
-  endif()
-  ecbuild_bundle( PROJECT mom6 SOURCE "../sorc/mom6" )
-  ecbuild_bundle( PROJECT soca SOURCE "../sorc/soca" )
-
-  # Build JEDI/DA or other peripherals
-  ecbuild_bundle( PROJECT gdas-utils SOURCE "../utils" )
-
-# Build IODA converters
-  option(BUILD_IODA_CONVERTERS "Build IODA Converters" ON)
-  if(BUILD_IODA_CONVERTERS)
-    ecbuild_bundle( PROJECT iodaconv SOURCE "../sorc/iodaconv" )
-  endif()
-
-# Land associated repositories
-  ecbuild_bundle( PROJECT land-imsproc SOURCE "../sorc/land-imsproc" )
-  ecbuild_bundle( PROJECT land-jediincr SOURCE "../sorc/land-jediincr" )
-
-# GDASApp
-  ecbuild_bundle( PROJECT gdas SOURCE "../")
-
-# ioda, ufo, fv3-jedi, and saber test data
-#---------------------------------
+  # Clone test data
+  #----------------
+  option(CLONE_JCSDADATA "Clone JCSDA test data repositories" OFF)
   if(CLONE_JCSDADATA)
-
-   set(JCSDA_DATA_ROOT "$ENV{GDASAPP_TESTDATA}/jcsda")
-   ecbuild_bundle( PROJECT ioda-data SOURCE "${JCSDA_DATA_ROOT}/ioda-data" )
-   ecbuild_bundle( PROJECT ufo-data SOURCE "${JCSDA_DATA_ROOT}/ufo-data" )
-   ecbuild_bundle( PROJECT fv3-jedi-data SOURCE "${JCSDA_DATA_ROOT}/fv3-jedi-data" )
-
+    set(JCSDA_DATA_ROOT "$ENV{GDASAPP_TESTDATA}/jcsda")
+    ecbuild_bundle( PROJECT ioda-data SOURCE "${JCSDA_DATA_ROOT}/ioda-data" )
+    ecbuild_bundle( PROJECT ufo-data SOURCE "${JCSDA_DATA_ROOT}/ufo-data" )
+    ecbuild_bundle( PROJECT fv3-jedi-data SOURCE "${JCSDA_DATA_ROOT}/fv3-jedi-data" )
   endif(CLONE_JCSDADATA)
 
 endif(BUILD_GDASBUNDLE)

--- a/bundle/gdas_jedi_bundle.yaml
+++ b/bundle/gdas_jedi_bundle.yaml
@@ -1,0 +1,147 @@
+# List of JEDI packages
+# ---------------------
+jedi_packages:
+
+# cmake things for jedi
+- project: jedicmake
+  location: SOURCE
+  path: ../sorc/jedicmake
+  min_version: 1.4.0
+  post_include:
+  - "include( jedicmake/cmake/Functions/git_functions.cmake )"
+
+# ecmwf libraries
+- project: eckit
+  location: GIT
+  path: https://github.com/ecmwf/eckit.git
+  min_version: 1.16.0
+  pre_include:
+  - "option(\"BUNDLE_SKIP_ECKIT\" \"Don't build eckit\" \"ON\" )"
+- project: fckit
+  location: GIT
+  path: https://github.com/ecmwf/fckit.git
+  min_version: 0.9.2
+  pre_include:
+  - "option(\"BUNDLE_SKIP_FCKIT\" \"Don't build fckit\" \"ON\" )"
+- project: atlas
+  location: GIT
+  path: https://github.com/ecmwf/atlas.git
+  min_version: 0.35.0
+  pre_include:
+  - "option(\"BUNDLE_SKIP_ATLAS\" \"Don't build atlas\" \"ON\" )"
+
+# oops
+- project: oops
+  location: SOURCE
+  path: ../sorc/oops
+  min_version: 1.10.0
+  pre_include:
+  - "option( ENABLE_LORENZ95_MODEL \"Build LORENZ95 toy model\" OFF )"
+  - "option( ENABLE_QG_MODEL \"Build QG toy model\" OFF )"
+
+# IODA things
+- project: ioda
+  location: SOURCE
+  path: ../sorc/ioda
+  min_version: 2.9.0
+  pre_include:
+  - "option(ENABLE_IODA_DATA \"Obtain ioda test data from ioda-data repository (vs tarball)\" ON)"
+- project: iodaconv
+  location: SOURCE
+  path: ../sorc/iodaconv
+  min_version: 0.0.1
+
+# UFO things
+- project: crtm
+  location: SOURCE
+  path: ../sorc/crtm
+  min_version: 2.4.1
+- project: ufo
+  location: SOURCE
+  path: ../sorc/ufo
+  min_version: 1.10.0
+  pre_include:
+  - "option(ENABLE_UFO_DATA \"Obtain ufo test data from ufo-data repository (vs tarball)\" ON)"
+
+# Saber things
+- project: gsibec
+  location: SOURCE
+  path: ../sorc/gsibec
+  min_version: 1.2.1
+  pre_include:
+  - "option(BUILD_GSIBEC \"Build GSI-B\" OFF)"
+- project: saber
+  location: SOURCE
+  path: ../sorc/saber
+  min_version: 1.10.0
+
+# Model agnostic model things
+- project: vader
+  location: SOURCE
+  path: ../sorc/vader
+  min_version: 1.7.0
+- project: femps
+  location: SOURCE
+  path: ../sorc/femps
+  min_version: 1.3.0
+- project: gsw
+  location: SOURCE
+  path: ../sorc/gsw
+  min_version: 3.0.7
+- project: icepack
+  location: SOURCE
+  path: ../sorc/icepack
+  min_version: 1.2.0
+  pre_include:
+  - "set(BUILD_ICEPACK \"ON\" CACHE STRING \"Build the icepack library\")"
+- project: land-imsproc
+  location: SOURCE
+  path: ../sorc/land-imsproc
+  min_version: 2022.10
+- project: land-jediincr
+  location: SOURCE
+  path: ../sorc/land-jediincr
+  min_version: 2022.10
+
+# List of JEDI repos that will depend on things built in the workflow (e.g. UFS)
+# ------------------------------------------------------------------------------
+# fv3jedi things
+- project: fms
+  location: SOURCE
+  path: ../sorc/fms
+  min_version: 2020.4.0
+- project: fv3
+  location: SOURCE
+  path: ../sorc/fv3
+  min_version: 1.2.0
+- project: fv3-jedi-lm
+  location: SOURCE
+  path: ../sorc/fv3-jedi-lm
+  min_version: 1.5.0
+- project: fv3-jedi
+  location: SOURCE
+  path: ../sorc/fv3-jedi
+  min_version: 1.9.0
+  pre_include:
+  - "option(ENABLE_FV3_JEDI_DATA \"Obtain fv3-jedi test data from fv3-jedi-data repository (vs tarball)\" ON)"
+
+# marine things
+- project: mom6
+  location: SOURCE
+  path: ../sorc/mom6
+  min_version: 2022.1.0
+- project: soca
+  location: SOURCE
+  path: ../sorc/soca
+  min_version: 1.8.0
+
+
+# GDAS packages
+# -------------
+gdas_packages:
+
+- project: gdas-utils
+  path: ../utils
+
+- project: gdas
+  path: ../

--- a/bundle/generate_cmakelists.py
+++ b/bundle/generate_cmakelists.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+
+# --------------------------------------------------------------------------------------------------
+
+
+import jinja2 as j2
+import os
+import yaml
+
+
+# --------------------------------------------------------------------------------------------------
+
+
+def generate_bundle():
+
+    # Get the path of this file
+    root = os.path.dirname(os.path.realpath(__file__))
+
+    # Open the gdas_bundle.yaml file
+    with open(os.path.join(root, 'gdas_jedi_bundle.yaml'), 'r') as f:
+        bundles = yaml.safe_load(f)
+
+    # Open CMakeLists-j2.txt
+    with open(os.path.join(root, 'CMakeLists-j2.txt'), 'r') as f:
+        cmake_template = j2.Template(f.read())
+
+    # Render the template with the data
+    cmake_rendered = cmake_template.render(bundles)
+
+    # Write rendered to CMakeLists.txt
+    cmake_output_file = os.path.join(root, 'CMakeLists.txt')
+    if os.path.exists(cmake_output_file):
+        os.remove(cmake_output_file)
+    with open(cmake_output_file, 'w') as f:
+        f.write(cmake_rendered)
+
+
+# --------------------------------------------------------------------------------------------------
+
+
+if __name__ == '__main__':
+    generate_bundle()
+
+
+# --------------------------------------------------------------------------------------------------

--- a/bundle/get_big_jedi_hash.py
+++ b/bundle/get_big_jedi_hash.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+
+
+# --------------------------------------------------------------------------------------------------
+
+
+import hashlib
+import os
+import yaml
+
+
+# --------------------------------------------------------------------------------------------------
+
+
+def combine_hashes(hashes):
+    # Concatenate all hashes in the list of hashes
+    combined = ''
+    for hash in hashes:
+        combined += hash
+
+    # Create sha1 hash for the long string
+    combined_hash = hashlib.sha1(combined.encode()).hexdigest()
+
+    return combined_hash
+
+
+# --------------------------------------------------------------------------------------------------
+
+
+def get_jedi_big_hash():
+
+    # Get the path of this file
+    root = os.path.dirname(os.path.realpath(__file__))
+
+    # Set the sorc path
+    base_path = os.path.join(root, '..')
+
+    # Open the gdas_bundle.yaml file
+    with open(os.path.join(root, 'gdas_jedi_bundle.yaml'), 'r') as f:
+        bundles = yaml.safe_load(f)
+
+    # Loop over the bundles and get the paths for packages coming from sorc
+    sorc_package_paths = []
+    jedi_packages = bundles['jedi_packages']
+    for jedi_package in jedi_packages:
+        if jedi_package['location'] == 'SOURCE':
+            sorc_package_paths.append(os.path.join(root, jedi_package['path']))
+
+    # For each sorc_package_paths get the git hash for that repo
+    hashes = []
+    for sorc_package_path in sorc_package_paths:
+        os.chdir(sorc_package_path)
+        hash = os.popen('git rev-parse HEAD').read().strip()
+        # print(sorc_package_path, hash)
+        hashes.append(hash)
+
+    # Get a hash that represents the concatenation of hashes
+    big_hash = combine_hashes(hashes)
+
+    # Print the big hash (to be picked up by bash script usually)
+    print(big_hash)
+
+    # Done
+    return
+
+
+# --------------------------------------------------------------------------------------------------
+
+
+if __name__ == '__main__':
+    get_jedi_big_hash()
+
+
+# --------------------------------------------------------------------------------------------------

--- a/modulefiles/GDAS/hera.intel.lua
+++ b/modulefiles/GDAS/hera.intel.lua
@@ -91,6 +91,8 @@ setenv("GDASAPP_TESTDATA","/scratch1/NCEPDEV/da/Cory.R.Martin/CI/GDASApp/data")
 setenv("GDASAPP_UNIT_TEST_DATA_PATH", "/scratch1/NCEPDEV/da/Cory.R.Martin/CI/GDASApp/data/test")
 --prepend_path("PATH","/scratch2/NCEPDEV/nwprod/hpc-stack/libs/hpc-stack/intel-18.0.5.274/prod_util/1.2.2/bin")
 
+setenv("JEDI_INSTALL_SEARCH_PATH", "/scratch1/NCEPDEV/da/role.jedipara/JEDI_installs")
+
 whatis("Name: ".. pkgName)
 whatis("Version: ".. pkgVersion)
 whatis("Category: GDASApp")


### PR DESCRIPTION
I wasted a lot of time trying to achieve what's in this PR with clever CMake that didn't work out so I didn't get to finish this cleanly before going on leave but this should be the basis for prepping and then using JEDI installs with GDASapp. Certainly I could see this speeding up all of our development cycles when we're not changing something in JEDI.

The idea would be to be to set an environment variable `$SEARCH_FOR_JEDI_INSTALL` and then the build script will try to find an install at some path on each machine. The path will be given by a concatenation of all the hashes of all the JEDI repos and an upper path in the module file for each machine.

To prepare these builds the idea would be to have a cron activated script running on the role account that recursively clones GDASapp, runs `build.sh -p` and then removes GDASapp. It could run nightly for example. That script would also need to decide on how many concurrent builds are allowed and how old they are allowed to get.

This is in no way ready for use. I've prepped all the scripts but haven't tested in this form yet. Up to you guys if you want to try and take this forward while I'm on leave. Otherwise I'll pick it up when I get back.