### PR TITLE
Tier-2 tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,19 @@ The one app to rule them all
 
 ## Notes to developers
 
-1 - As a developer, you will have to build the GDASApp againt the `dev/gdasapp` branch of the `global-workflow`
+1 - As a developer, you will have to build the GDASApp againt the up to date `develop` branch of the `global-workflow`
 
 ```bash
-git clone --recursive --jobs 8 --branch dev/gdasapp https://github.com/NOAA-EMC/global-workflow.git
+git clone --recursive --jobs 8 https://github.com/NOAA-EMC/global-workflow.git
 ```
 
-2 - For the most part (boundaries of that terminology is stil TBD), changes to the `global-workflow` related to the `GDASApp` developement will be issued in the `dev/gdasapp` branch.
+2 - To trigger the "fast" GDASApp tests: add the label **`{machine}-GW-RT`**
 
-3 - If your feature development involves changes to the global-workflow and the GDASApp, you will have to issue a PR in each repository. The GDASApp PR will have to have the same name in order for the GDASApp CI to build and run the correct branches.
+3 - To trigger all the GDASApp tests, including the tier-2 testing (subset of the global-workflow ci): add the labels **`{machine}-GW-RT`** and **`{machine}-GW-RT-tier2`**
 
-4 - If your work is contained within the `global-workflow` only, you will have to submit a dummy PR in the `GDASApp` with the same branch name.
+4 - If your feature development involves changes to the `global-workflow` and the `GDASApp`, you will have to issue a PR in each repository. The `GDASApp` PR will have to have the same name in order for the `GDASApp` CI to build and run the correct branches.
+
+5 - If your work is contained within the `global-workflow` only, you will have to submit a dummy PR in the `GDASApp` with the same branch name.
 To submit a dummy PR, just create a branch with an empty commit:
 ```
 git commit --allow-empty -m "Dummy commit to trigger PR"

--- a/build.sh
+++ b/build.sh
@@ -102,6 +102,11 @@ mkdir -p ${BUILD_DIR} && cd ${BUILD_DIR}
 WORKFLOW_BUILD=${WORKFLOW_BUILD:-"OFF"}
 CMAKE_OPTS+=" -DWORKFLOW_TESTS=${WORKFLOW_BUILD}"
 
+# check if tier-2 testing needs to be activated
+if [[ $GDAS_TIER2_TESTING == 'ON' ]]; then
+  CMAKE_OPTS+=" -DGDAS_TIER2_TESTING=ON"
+fi
+
 # JCSDA changed test data things, need to make a dummy CRTM directory
 if [[ $BUILD_TARGET == 'hera' ]]; then
   if [ -d "$dir_root/bundle/fix/test-data-release/" ]; then rm -rf $dir_root/bundle/fix/test-data-release/; fi

--- a/build.sh
+++ b/build.sh
@@ -103,7 +103,8 @@ WORKFLOW_BUILD=${WORKFLOW_BUILD:-"OFF"}
 CMAKE_OPTS+=" -DWORKFLOW_TESTS=${WORKFLOW_BUILD}"
 
 # check if tier-2 testing needs to be activated
-if [[ $GDAS_TIER2_TESTING == 'ON' ]]; then
+if [[ $GDAS_TIER2_TESTING == "ON" ]]; then
+  echo "Activating tier-2 testing"
   CMAKE_OPTS+=" -DGDAS_TIER2_TESTING=ON"
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -102,12 +102,6 @@ mkdir -p ${BUILD_DIR} && cd ${BUILD_DIR}
 WORKFLOW_BUILD=${WORKFLOW_BUILD:-"OFF"}
 CMAKE_OPTS+=" -DWORKFLOW_TESTS=${WORKFLOW_BUILD}"
 
-# check if tier-2 testing needs to be activated
-if [[ $GDAS_TIER2_TESTING == "ON" ]]; then
-  echo "Activating tier-2 testing"
-  CMAKE_OPTS+=" -DGDAS_TIER2_TESTING=ON"
-fi
-
 # JCSDA changed test data things, need to make a dummy CRTM directory
 if [[ $BUILD_TARGET == 'hera' ]]; then
   if [ -d "$dir_root/bundle/fix/test-data-release/" ]; then rm -rf $dir_root/bundle/fix/test-data-release/; fi

--- a/ci/gw_driver.sh
+++ b/ci/gw_driver.sh
@@ -57,6 +57,7 @@ open_pr_list=$(cat $GDAS_CI_ROOT/open_pr_list_gw)
 # clone, checkout, build, test, etc.
 repo_url="https://github.com/NOAA-EMC/GDASApp.git"
 workflow_url="https://github.com/guillaumevernieres/global-workflow.git"
+workflow_branch="dev/da/gdasapp"
 # loop through all open PRs
 for pr in $open_pr_list; do
   gh pr edit $pr --remove-label $CI_LABEL --add-label ${CI_LABEL}-Running
@@ -77,7 +78,7 @@ for pr in $open_pr_list; do
 
     # Construct the fork URL
     workflow_url="https://github.com/$fork_owner/$fork_name.git"
-
+    workflow_branch=$gdasapp_branch
     echo "Fork URL: $workflow_url"
     echo "Branch Name: $gdasapp_branch"
   fi
@@ -90,7 +91,7 @@ for pr in $open_pr_list; do
   cd $GDAS_CI_ROOT/workflow/PR/$pr
 
   # clone global workflow develop branch
-  git clone --recursive --jobs 8 --branch dev/da/gdasapp $workflow_url
+  git clone --recursive --jobs 8 --branch $workflow_branch $workflow_url
 
   # checkout pull request
   cd $GDAS_CI_ROOT/workflow/PR/$pr/global-workflow/sorc/gdas.cd

--- a/ci/gw_driver.sh
+++ b/ci/gw_driver.sh
@@ -56,7 +56,7 @@ open_pr_list=$(cat $GDAS_CI_ROOT/open_pr_list_gw)
 # ==============================================================================
 # clone, checkout, build, test, etc.
 repo_url="https://github.com/NOAA-EMC/GDASApp.git"
-workflow_url="https://github.com/NOAA-EMC/global-workflow.git"
+workflow_url="https://github.com/guillaumevernieres/global-workflow.git"
 # loop through all open PRs
 for pr in $open_pr_list; do
   gh pr edit $pr --remove-label $CI_LABEL --add-label ${CI_LABEL}-Running
@@ -88,9 +88,9 @@ for pr in $open_pr_list; do
   fi
   mkdir -p $GDAS_CI_ROOT/workflow/PR/$pr
   cd $GDAS_CI_ROOT/workflow/PR/$pr
-  
+
   # clone global workflow develop branch
-  git clone --recursive --jobs 8 --branch dev/gdasapp $workflow_url
+  git clone --recursive --jobs 8 --branch dev/da/gdasapp $workflow_url
 
   # checkout pull request
   cd $GDAS_CI_ROOT/workflow/PR/$pr/global-workflow/sorc/gdas.cd
@@ -116,4 +116,3 @@ done
 # ==============================================================================
 # scrub working directory for older files
 find $GDAS_CI_ROOT/workflow/PR/* -maxdepth 1 -mtime +3 -exec rm -rf {} \;
-

--- a/ci/gw_driver.sh
+++ b/ci/gw_driver.sh
@@ -50,6 +50,7 @@ esac
 # pull on the repo and get list of open PRs
 cd $GDAS_CI_ROOT/repo
 CI_LABEL="${GDAS_CI_HOST}-GW-RT"
+tier2_label="${GDAS_CI_HOST}-GW-RT-tier2"
 gh pr list --label "$CI_LABEL" --state "open" | awk '{print $1;}' > $GDAS_CI_ROOT/open_pr_list_gw
 open_pr_list=$(cat $GDAS_CI_ROOT/open_pr_list_gw)
 
@@ -65,6 +66,15 @@ for pr in $open_pr_list; do
 
   # get the branch name used for the PR
   gdasapp_branch=$(gh pr view $pr --json headRefName -q ".headRefName")
+
+  # check if we should run the tier-2 tests
+  pr_number=$(gh pr list --head "$gdasapp_branch" --json number --jq '.[0].number')
+  all_labels=$(gh pr view "$pr_number" --json labels --jq '.labels[].name')
+  do_tier2=false
+  if echo "$all_labels" | grep -q "^$tier2_label$"; then
+      echo "Tier-2 label found"
+      do_tier2=true
+  fi
 
   # check for a companion PR in the global-workflow
   companion_pr_exists=$(gh pr list --repo ${workflow_url} --head ${gdasapp_branch} --state open)
@@ -104,7 +114,9 @@ for pr in $open_pr_list; do
   commit=$(git log --pretty=format:'%h' -n 1)
   echo "$commit" > $GDAS_CI_ROOT/workflow/PR/$pr/commit
 
-  $my_dir/run_gw_ci.sh -d $GDAS_CI_ROOT/workflow/PR/$pr/global-workflow -o $GDAS_CI_ROOT/workflow/PR/$pr/output_${commit}
+  $my_dir/run_gw_ci.sh -d $GDAS_CI_ROOT/workflow/PR/$pr/global-workflow \
+                       -o $GDAS_CI_ROOT/workflow/PR/$pr/output_${commit} \
+                       -t $do_tier2
   ci_status=$?
   gh pr comment $pr --body-file $GDAS_CI_ROOT/workflow/PR/$pr/output_${commit}
   if [ $ci_status -eq 0 ]; then

--- a/ci/gw_driver.sh
+++ b/ci/gw_driver.sh
@@ -57,8 +57,8 @@ open_pr_list=$(cat $GDAS_CI_ROOT/open_pr_list_gw)
 # ==============================================================================
 # clone, checkout, build, test, etc.
 repo_url="https://github.com/NOAA-EMC/GDASApp.git"
-workflow_url="https://github.com/guillaumevernieres/global-workflow.git"
-workflow_branch="dev/da/gdasapp"
+workflow_url="https://github.com/NOAA-EMC/global-workflow.git"
+workflow_branch="develop"
 # loop through all open PRs
 for pr in $open_pr_list; do
   gh pr edit $pr --remove-label $CI_LABEL --add-label ${CI_LABEL}-Running

--- a/ci/gw_driver.sh
+++ b/ci/gw_driver.sh
@@ -70,10 +70,10 @@ for pr in $open_pr_list; do
   # check if we should run the tier-2 tests
   pr_number=$(gh pr list --head "$gdasapp_branch" --json number --jq '.[0].number')
   all_labels=$(gh pr view "$pr_number" --json labels --jq '.labels[].name')
-  do_tier2=false
+  do_tier2="false"
   if echo "$all_labels" | grep -q "^$tier2_label$"; then
       echo "Tier-2 label found"
-      do_tier2=true
+      do_tier2="true"
   fi
 
   # check for a companion PR in the global-workflow

--- a/ci/run_gw_ci.sh
+++ b/ci/run_gw_ci.sh
@@ -16,7 +16,7 @@ usage() {
 }
 
 # ==============================================================================
-do_tier2=false
+do_tier2="false"
 while getopts "d:o:h:t:" opt; do
   case $opt in
     d)
@@ -70,7 +70,7 @@ echo "---------------------------------------------------" >> $outfile
 # Reconfigure if the tier-2 testing is required
 # TODO: Not the most efficient, but even when exported, the variable is out of scope
 #       when running build.sh
-if [ $do_tier2 == "true" ]; then
+if [ "$do_tier2" = "true" ]; then
   echo "Tier-2 Testing: Activated" >> $outfile
   cmake -DGDAS_TIER2_TESTING=ON . >> log.cmake_tier2
 fi

--- a/ci/run_gw_ci.sh
+++ b/ci/run_gw_ci.sh
@@ -39,8 +39,10 @@ echo "---------------------------------------------------" >> $outfile
 # ==============================================================================
 # check if the PR needs tier-2 testing to be activated
 cd $repodir/sorc/gdas.cd
-pr_number=$(gh pr view --json number -q ".head.ref=='$branch_name'" | jq -r '.[0].number')
-if gh pr view $pr_number --json labels -q ".[].name=='${GDAS_CI_HOST}-GW-RT-tier2'" >/dev/null; then
+pr_number=$(gh pr list --head "$branch_name" --json number --jq '.[0].number')
+tier2_label="${GDAS_CI_HOST}-GW-RT-tier2"
+do_tier2=$(gh pr view "$pr_number" --json labels --jq ".labels | map(select(.name == \"$tier2_label\")) | length > 0")
+if [ "$do_tier2" == "true" ]; then
   echo "Triggering tier-2 testing"
   export GDAS_TIER2_TESTING="ON"
 fi

--- a/ci/run_gw_ci.sh
+++ b/ci/run_gw_ci.sh
@@ -9,14 +9,15 @@ usage() {
   echo
   echo "  -d  Run build and ctest for clone in <directory>"
   echo "  -o  Path to output message detailing results of CI tests"
-  echo "  -t  run the tier-2 testing, default is OFF"
+  echo "  -t  run the tier-2 testing, default is false"
   echo "  -h  display this message and quit"
   echo
   exit 1
 }
 
 # ==============================================================================
-while getopts "d:o:h" opt; do
+do_tier2=false
+while getopts "d:o:h:t:" opt; do
   case $opt in
     d)
       repodir=$OPTARG
@@ -25,14 +26,15 @@ while getopts "d:o:h" opt; do
       outfile=$OPTARG
       ;;
     t)
-      do_tier2=${OPTARG:-false}
+      do_tier2=$OPTARG
       ;;
     h|\?|:)
       usage
       ;;
   esac
 done
-
+echo "do_tier2: $do_tier2"
+exit
 # ==============================================================================
 # start output file
 echo "Automated Global-Workflow GDASApp Testing Results:" > $outfile

--- a/ci/run_gw_ci.sh
+++ b/ci/run_gw_ci.sh
@@ -34,7 +34,7 @@ while getopts "d:o:h:t:" opt; do
   esac
 done
 echo "do_tier2: $do_tier2"
-exit
+
 # ==============================================================================
 # start output file
 echo "Automated Global-Workflow GDASApp Testing Results:" > $outfile

--- a/ci/run_gw_ci.sh
+++ b/ci/run_gw_ci.sh
@@ -37,6 +37,14 @@ echo '```' >> $outfile
 echo "Start: $(date) on $(hostname)" >> $outfile
 echo "---------------------------------------------------" >> $outfile
 # ==============================================================================
+# check if the PR needs tier-2 testing to be activated
+cd $repodir/sorc/gdas.cd
+pr_number=$(gh pr view --json number -q ".head.ref=='$branch_name'" | jq -r '.[0].number')
+if gh pr view $pr_number --json labels -q ".[].name=='${GDAS_CI_HOST}-GW-RT-tier2'" >/dev/null; then
+  echo "Triggering tier-2 testing"
+  export GDAS_TIER2_TESTING="ON"
+fi
+
 # run build and link as part of the workflow
 export WORKFLOW_BUILD="ON"
 cd $repodir/sorc

--- a/ci/run_gw_ci.sh
+++ b/ci/run_gw_ci.sh
@@ -77,9 +77,9 @@ echo "---------------------------------------------------" >> $outfile
 #       when running build.sh
 if [ "$GDAS_TIER2_TESTING" == "ON" ]; then
   echo "Tier-2 Testing: Activated" >> $outfile
-  cmake -DGDAS_TIER2_TESTING=ON .
-  exit $ctest_status
+  cmake -DGDAS_TIER2_TESTING=ON . >> log.cmake_tier2
 fi
+(cd gdas && ctest -N) >> log.gdasapp_tests
 
 rm -rf log.ctest
 ctest -R gdasapp --output-on-failure &>> log.ctest

--- a/ci/run_gw_ci.sh
+++ b/ci/run_gw_ci.sh
@@ -39,6 +39,7 @@ echo "---------------------------------------------------" >> $outfile
 # ==============================================================================
 # check if the PR needs tier-2 testing to be activated
 cd $repodir/sorc/gdas.cd
+export GDAS_TIER2_TESTING="OFF"
 pr_number=$(gh pr list --head "$branch_name" --json number --jq '.[0].number')
 tier2_label="${GDAS_CI_HOST}-GW-RT-tier2"
 do_tier2=$(gh pr view "$pr_number" --json labels --jq ".labels | map(select(.name == \"$tier2_label\")) | length > 0")

--- a/ci/run_gw_ci.sh
+++ b/ci/run_gw_ci.sh
@@ -77,7 +77,7 @@ fi
 (cd gdas && ctest -N) >> log.gdasapp_tests
 
 rm -rf log.ctest
-ctest -R gdasapp --output-on-failure &>> log.ctest
+ctest -R gdasapp -L "gw-ci" --output-on-failure &>> log.ctest
 ctest_status=$?
 npassed=$(cat log.ctest | grep "tests passed")
 if [ $ctest_status -eq 0 ]; then

--- a/ci/run_gw_ci.sh
+++ b/ci/run_gw_ci.sh
@@ -77,7 +77,7 @@ fi
 (cd gdas && ctest -N) >> log.gdasapp_tests
 
 rm -rf log.ctest
-ctest -R gdasapp -L "gw-ci" --output-on-failure &>> log.ctest
+ctest -R gdasapp --output-on-failure &>> log.ctest
 ctest_status=$?
 npassed=$(cat log.ctest | grep "tests passed")
 if [ $ctest_status -eq 0 ]; then

--- a/ci/run_gw_ci.sh
+++ b/ci/run_gw_ci.sh
@@ -72,6 +72,15 @@ cd $repodir/sorc/gdas.cd/build
 module use $repodir/sorc/gdas.cd/modulefiles
 module load GDAS/$TARGET
 echo "---------------------------------------------------" >> $outfile
+# Reconfigure if the tier-2 testing is required
+# TODO: Not the most efficient, but even when exported, the variable is out of scope
+#       when running build.sh
+if [ "$GDAS_TIER2_TESTING" == "ON" ]; then
+  echo "Tier-2 Testing: Activated" >> $outfile
+  cmake -DGDAS_TIER2_TESTING=ON .
+  exit $ctest_status
+fi
+
 rm -rf log.ctest
 ctest -R gdasapp --output-on-failure &>> log.ctest
 ctest_status=$?

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -138,8 +138,8 @@ if (${BUILD_GDASBUNDLE})
   add_subdirectory(fv3jedi)   # fv3jedi tests
   add_subdirectory(soca)      # soca tests
   add_subdirectory(snow)      # snow da tests
-  option(RUN_GW_CI "Enable the global-workflow CI tests" OFF)
-  if (RUN_GW_CI)
+  option(GDAS_TIER2_TESTING "Enable the global-workflow CI tests" OFF)
+  if (GDAS_TIER2_TESTING)
     add_subdirectory(gw-ci)   # subset of the global-workflow ci tests
   endif()
 

--- a/test/gw-ci/CMakeLists.txt
+++ b/test/gw-ci/CMakeLists.txt
@@ -26,7 +26,7 @@ function(add_cycling_tests pslot YAML_PATH HOMEgfs RUNTESTS PROJECT_SOURCE_DIR T
 
   # 1/2 cycle enkfgdasfcst
   message(STATUS "preparing 1/2 cycle ensemble forecast for ${pslot} ctest")
-  foreach(mem RANGE ${NMEM})
+  foreach(mem RANGE 1 ${NMEM})
     set(test_name "${pslot}_enkfgdasfcst_00${mem}_${HALF_CYCLE}")
     add_test(NAME ${test_name}
              COMMAND /bin/bash -c "${PROJECT_SOURCE_DIR}/test/gw-ci/run_exp.sh ${pslot} enkfgdasfcst_00${mem} ${HALF_CYCLE}"

--- a/test/gw-ci/CMakeLists.txt
+++ b/test/gw-ci/CMakeLists.txt
@@ -27,10 +27,11 @@ function(add_cycling_tests pslot YAML_PATH HOMEgfs RUNTESTS PROJECT_SOURCE_DIR T
   # 1/2 cycle enkfgdasfcst
   message(STATUS "preparing 1/2 cycle ensemble forecast for ${pslot} ctest")
   foreach(mem RANGE ${NMEM})
-    add_test(NAME ${pslot}_ensemble_${HALF_CYCLE}_${mem}
+    set(test_name "${pslot}_enkfgdasfcst_00${mem}_${HALF_CYCLE}")
+    add_test(NAME ${test_name}
              COMMAND /bin/bash -c "${PROJECT_SOURCE_DIR}/test/gw-ci/run_exp.sh ${pslot} enkfgdasfcst_00${mem} ${HALF_CYCLE}"
              WORKING_DIRECTORY ${RUNTESTS})
-    set_tests_properties(${pslot}_enkfgdasfcst_${mem}_${HALF_CYCLE} PROPERTIES LABELS "gw-ci")
+    set_tests_properties(${test_name} PROPERTIES LABELS "gw-ci")
   endforeach()
 
   # Select the list of tasks to run for the full cycle
@@ -74,7 +75,18 @@ add_cycling_tests(${pslot} ${YAML_PATH} ${HOMEgfs} ${RUNTESTS} ${PROJECT_SOURCE_
 # ---------------
 set(pslot "Atm-hyb-C96C48")
 set(YAML_PATH ${HOMEgfs}/ci/cases/pr/C96C48_ufs_hybatmDA.yaml)
-set(TASK_LIST)  # empty list for now
+set(TASK_LIST
+  "gdasprep"
+  "gdasprepatmiodaobs"
+  "gdasatmanlinit"
+  "gdasatmanlvar"
+  "gdasatmanlfv3inc"
+  "gdasatmanlfinal"
+  "enkfgdasatmensanlinit"
+  "enkfgdasatmensanlletkf"
+  "enkfgdasatmensanlfv3inc"
+  "enkfgdasatmensanlfinal"
+  )  # empty list for now
 add_cycling_tests(${pslot} ${YAML_PATH} ${HOMEgfs} ${RUNTESTS} ${PROJECT_SOURCE_DIR} "${TASK_LIST}" 2)
 
 # GFSv17, 3DVAR prototype

--- a/test/gw-ci/CMakeLists.txt
+++ b/test/gw-ci/CMakeLists.txt
@@ -1,10 +1,10 @@
 # Function that generates the 1/2 cycle forecast and DA tasks
-function(add_cycling_tests pslot YAML_PATH HOMEgfs RUNTESTS PROJECT_SOURCE_DIR TASK_LIST)
+function(add_cycling_tests pslot YAML_PATH HOMEgfs RUNTESTS PROJECT_SOURCE_DIR TASK_LIST NMEM)
   # Prepare the COMROOT and EXPDIR for the cycling ctests
   add_test(NAME ${pslot}
     COMMAND /bin/bash -c "${PROJECT_SOURCE_DIR}/test/gw-ci/create_exp.sh ${YAML_PATH} ${pslot} ${HOMEgfs} ${RUNTESTS}"
     WORKING_DIRECTORY ${RUNTESTS})
-  set_tests_properties(${pslot} PROPERTIES LABELS "manual")
+  set_tests_properties(${pslot} PROPERTIES LABELS "gw-ci")
 
   # Get the 1/2 cycle and full cycle's dates
   execute_process(
@@ -22,7 +22,16 @@ function(add_cycling_tests pslot YAML_PATH HOMEgfs RUNTESTS PROJECT_SOURCE_DIR T
   add_test(NAME ${pslot}_gdasfcst_${HALF_CYCLE}
            COMMAND /bin/bash -c "${PROJECT_SOURCE_DIR}/test/gw-ci/run_exp.sh ${pslot} gdasfcst ${HALF_CYCLE}"
            WORKING_DIRECTORY ${RUNTESTS})
-  set_tests_properties(${pslot}_gdasfcst_${HALF_CYCLE} PROPERTIES LABELS "manual")
+  set_tests_properties(${pslot}_gdasfcst_${HALF_CYCLE} PROPERTIES LABELS "gw-ci")
+
+  # 1/2 cycle enkfgdasfcst
+  message(STATUS "preparing 1/2 cycle ensemble forecast for ${pslot} ctest")
+  foreach(mem RANGE ${NMEM})
+    add_test(NAME ${pslot}_ensemble_${HALF_CYCLE}_${mem}
+             COMMAND /bin/bash -c "${PROJECT_SOURCE_DIR}/test/gw-ci/run_exp.sh ${pslot} enkfgdasfcst_00${mem} ${HALF_CYCLE}"
+             WORKING_DIRECTORY ${RUNTESTS})
+    set_tests_properties(${pslot}_enkfgdasfcst_${mem}_${HALF_CYCLE} PROPERTIES LABELS "gw-ci")
+  endforeach()
 
   # Select the list of tasks to run for the full cycle
   message(STATUS "Tasks ${TASK_LIST}")
@@ -32,7 +41,7 @@ function(add_cycling_tests pslot YAML_PATH HOMEgfs RUNTESTS PROJECT_SOURCE_DIR T
     add_test(NAME ${pslot}_${task}_${FULL_CYCLE}
              COMMAND /bin/bash -c "${PROJECT_SOURCE_DIR}/test/gw-ci/run_exp.sh ${pslot} ${task} ${FULL_CYCLE}"
              WORKING_DIRECTORY ${RUNTESTS})
-    set_tests_properties(${pslot}_${task}_${FULL_CYCLE} PROPERTIES LABELS "manual")
+    set_tests_properties(${pslot}_${task}_${FULL_CYCLE} PROPERTIES LABELS "gw-ci")
   endforeach()
 endfunction()
 
@@ -52,21 +61,21 @@ set(TASK_LIST
   "gdasocnanalchkpt"
   "gdasocnanalpost"
   )
-add_cycling_tests(${pslot} ${YAML_PATH} ${HOMEgfs} ${RUNTESTS} ${PROJECT_SOURCE_DIR} "${TASK_LIST}")
+add_cycling_tests(${pslot} ${YAML_PATH} ${HOMEgfs} ${RUNTESTS} ${PROJECT_SOURCE_DIR} "${TASK_LIST}" 0)
 
 # Aero-Land DA, C96
 # -----------------
 set(pslot "Aero-Snow-3DVAR-C96")
 set(YAML_PATH ${HOMEgfs}/ci/cases/pr/C96_atmaerosnowDA.yaml)
 set(TASK_LIST)  # empty list for now
-add_cycling_tests(${pslot} ${YAML_PATH} ${HOMEgfs} ${RUNTESTS} ${PROJECT_SOURCE_DIR} "${TASK_LIST}")
+add_cycling_tests(${pslot} ${YAML_PATH} ${HOMEgfs} ${RUNTESTS} ${PROJECT_SOURCE_DIR} "${TASK_LIST}" 0)
 
 # Atm DA, C96/C48
 # ---------------
 set(pslot "Atm-hyb-C96C48")
 set(YAML_PATH ${HOMEgfs}/ci/cases/pr/C96C48_ufs_hybatmDA.yaml)
 set(TASK_LIST)  # empty list for now
-add_cycling_tests(${pslot} ${YAML_PATH} ${HOMEgfs} ${RUNTESTS} ${PROJECT_SOURCE_DIR} "${TASK_LIST}")
+add_cycling_tests(${pslot} ${YAML_PATH} ${HOMEgfs} ${RUNTESTS} ${PROJECT_SOURCE_DIR} "${TASK_LIST}" 2)
 
 # GFSv17, 3DVAR prototype
 # -----------------------
@@ -83,4 +92,4 @@ set(TASK_LIST
   "gdasprep"
   "gdasanal"
   )
-add_cycling_tests(${pslot} ${YAML_PATH} ${HOMEgfs} ${RUNTESTS} ${PROJECT_SOURCE_DIR} "${TASK_LIST}")
+add_cycling_tests(${pslot} ${YAML_PATH} ${HOMEgfs} ${RUNTESTS} ${PROJECT_SOURCE_DIR} "${TASK_LIST}" 0)


### PR DESCRIPTION
Tier-2 tests would not be part of the regular GDASApp CI and would only be executed prior to submitting a PR of `dev/gdasapp` into `develop`.  

Untested.

@CoryMartin-NOAA , @RussTreadon-NOAA , could you give me a sequential list of the `jjobs` that you want tested? That or commit directly to my branch. What needs to be updated is here
https://github.com/NOAA-EMC/GDASApp/blob/6f27a49964429e23814eaeef1ba32857dbf41606/test/gw-ci/CMakeLists.txt#L61
and here
https://github.com/NOAA-EMC/GDASApp/blob/6f27a49964429e23814eaeef1ba32857dbf41606/test/gw-ci/CMakeLists.txt#L68
and the marine DA example is here:
https://github.com/NOAA-EMC/GDASApp/blob/6f27a49964429e23814eaeef1ba32857dbf41606/test/gw-ci/CMakeLists.txt#L47

