### PR TITLE
Add the alpha_diagb parameter to aero_diagb.yaml.j2

### DIFF
--- a/parm/aero/berror/aero_diagb.yaml.j2
+++ b/parm/aero/berror/aero_diagb.yaml.j2
@@ -55,6 +55,7 @@ variables:
 rescale: 2.0    # rescales the filtered std. dev. by "rescale"
 number of halo points: 4
 number of neighbors: 16
+alpha_diagb: 0.5 
 simple smoothing:
   horizontal iterations: 0 
   vertical iterations: 0

--- a/parm/aero/berror/aero_diffusionparm.yaml.j2
+++ b/parm/aero/berror/aero_diffusionparm.yaml.j2
@@ -35,7 +35,7 @@ background error:
     saber block name: diffusion
     calibration:
       normalization:
-        iterations: {{ diff_iter }}    
+        iterations: {{ aero_diff_iter }}    
       groups:
       - horizontal:
           fixed value: {{ horiz_len }} 


### PR DESCRIPTION
The jinja2 yaml template: aero_diagb.yaml.j2 needs the parameter alpha_diagb to allow for tuning of the hybrid aerosol DA covariance.   