### PR TITLE
add diagb weight in yaml template

### DIFF
--- a/parm/aero/berror/aero_diagb.yaml.j2
+++ b/parm/aero/berror/aero_diagb.yaml.j2
@@ -54,6 +54,7 @@ variables:
 
 rescale: 2.0    # rescales the filtered std. dev. by "rescale"
 number of halo points: 4
+alpha_diagb: 0.5 
 number of neighbors: 16
 simple smoothing:
   horizontal iterations: 0 


### PR DESCRIPTION
Adding the coefficient alpha_diagb to the aero_diagb.yaml template. This is needed for aerosol DA covariance tuning.
