### PR TITLE
fix for FMS paths that are too long in snow YAMLs

### DIFF
--- a/parm/snow/hofx/hofx_nomodel.yaml.j2
+++ b/parm/snow/hofx/hofx_nomodel.yaml.j2
@@ -3,16 +3,16 @@ time window:
   length: {{ SNOW_WINDOW_LENGTH }}
 geometry:
   fms initialization:
-    namelist filename: '{{ DATA }}/fv3jedi/fmsmpp.nml'
-    field table filename: '{{ DATA }}/fv3jedi/field_table'
-  akbk: '{{ DATA }}/fv3jedi/akbk.nc4'
+    namelist filename: './fv3jedi/fmsmpp.nml'
+    field table filename: './fv3jedi/field_table'
+  akbk: './fv3jedi/akbk.nc4'
   layout:
   - {{ layout_x }}
   - {{ layout_y }}
   npx: {{ npx_ges }}
   npy: {{ npy_ges }}
   npz: {{ npz_ges }}
-  field metadata override: '{{ DATA }}/fv3jedi/fv3jedi_fieldmetadata_restart.yaml'
+  field metadata override: './fv3jedi/fv3jedi_fieldmetadata_restart.yaml'
   time invariant fields:
     state fields:
       datetime: '{{ SNOW_WINDOW_BEGIN | to_isotime }}'
@@ -22,7 +22,7 @@ geometry:
       datapath: '{{ FIXgfs }}/fix_orog/{{ CASE }}/'
       filename_orog: '{{ CASE }}_oro_data.nc'
 state:
-  datapath: '{{ DATA }}/bkg'
+  datapath: './bkg'
   filetype: fms restart
   datetime: '{{ current_cycle | to_isotime }}'
   filename_sfcd: '{{ current_cycle | to_fv3time }}.sfc_data.nc'

--- a/parm/snow/letkfoi/apply_incr_nml.j2
+++ b/parm/snow/letkfoi/apply_incr_nml.j2
@@ -3,8 +3,8 @@
   hour_str = "{{ current_cycle | strftime('%H') }}",
   res = {{ CASE[1:] }},
   frac_grid = .true.,
-  rst_path = "{{ DATA }}/anl",
-  inc_path = "{{ DATA }}/anl",
+  rst_path = "./anl",
+  inc_path = "./anl",
   orog_path = "{{ HOMEgfs }}/fix/orog/{{ CASE }}",
   otype = "{{ CASE }}.mx{{ OCNRES }}_oro_data"
 /

--- a/parm/snow/letkfoi/letkfoi.yaml.j2
+++ b/parm/snow/letkfoi/letkfoi.yaml.j2
@@ -1,15 +1,15 @@
 geometry:
   fms initialization:
-    namelist filename: {{ DATA }}/fv3jedi/fmsmpp.nml
-    field table filename: {{ DATA }}/fv3jedi/field_table
-  akbk: {{ DATA }}/fv3jedi/akbk.nc4
+    namelist filename: ./fv3jedi/fmsmpp.nml
+    field table filename: ./fv3jedi/field_table
+  akbk: ./fv3jedi/akbk.nc4
   layout:
   - {{ layout_x }}
   - {{ layout_y }}
   npx: {{ npx_ges }}
   npy: {{ npy_ges }}
   npz: {{ npz_ges }}
-  field metadata override: {{ DATA }}/fv3jedi/fv3jedi_fieldmetadata_restart.yaml
+  field metadata override: ./fv3jedi/fv3jedi_fieldmetadata_restart.yaml
   time invariant fields:
     state fields:
       datetime: '{{ SNOW_WINDOW_BEGIN | to_isotime }}'
@@ -31,7 +31,7 @@ background:
        datetime: '{{ current_cycle | to_isotime }}'
        filetype: fms restart
        state variables: [snodl,vtype,slmsk]
-       datapath: {{ DATA }}/bkg/mem%mem%/RESTART
+       datapath: ./bkg/mem%mem%/RESTART
        filename_sfcd: '{{ current_cycle | to_fv3time }}.sfc_data.nc'
        filename_cplr: '{{ current_cycle | to_fv3time }}.coupler.res'
      pattern: '%mem%'
@@ -57,7 +57,7 @@ local ensemble DA:
     mult: 1.0
 
 output increment:
-  datapath: {{ DATA }}/anl
+  datapath: ./anl
   prefix: snowinc
   filetype: fms restart
   filename_sfcd: '{{ current_cycle | to_fv3time }}.sfc_data.nc'

--- a/parm/snow/obs/config/adpsfc_snow.yaml.j2
+++ b/parm/snow/obs/config/adpsfc_snow.yaml.j2
@@ -6,11 +6,11 @@
     obsdatain:
       engine:
         type: H5File
-        obsfile: '{{ DATA }}/obs/{{ OPREFIX }}adpsfc_snow.nc4'
+        obsfile: './obs/{{ OPREFIX }}adpsfc_snow.nc4'
     obsdataout:
       engine:
         type: H5File
-        obsfile: '{{ DATA }}/diags/diag_adpsfc_snow.nc4'
+        obsfile: './diags/diag_adpsfc_snow.nc4'
     simulated variables: [totalSnowDepth]
   obs operator:
     name: Composite

--- a/parm/snow/obs/config/ghcn_snow.yaml.j2
+++ b/parm/snow/obs/config/ghcn_snow.yaml.j2
@@ -6,11 +6,11 @@
     obsdatain:
       engine:
         type: H5File
-        obsfile: '{{ DATA }}/obs/{{ OPREFIX }}ghcn_snow_{{ current_cycle | to_YMDH }}.nc4'
+        obsfile: './obs/{{ OPREFIX }}ghcn_snow_{{ current_cycle | to_YMDH }}.nc4'
     obsdataout:
       engine:
         type: H5File
-        obsfile: '{{ DATA }}/diags/diag_ghcn_snow_{{ current_cycle | to_YMDH }}.nc4'
+        obsfile: './diags/diag_ghcn_snow_{{ current_cycle | to_YMDH }}.nc4'
 
   obs operator:
     name: Identity

--- a/parm/snow/obs/config/ims_snow.yaml.j2
+++ b/parm/snow/obs/config/ims_snow.yaml.j2
@@ -6,11 +6,11 @@
     obsdatain:
       engine:
         type: H5File
-        obsfile: '{{ DATA }}/obs/{{ OPREFIX }}ims_snow.nc4'
+        obsfile: './obs/{{ OPREFIX }}ims_snow.nc4'
     obsdataout:
       engine:
         type: H5File
-        obsfile: '{{ DATA }}/diags/diag_ims_snow.nc4'
+        obsfile: './diags/diag_ims_snow.nc4'
     simulated variables: [totalSnowDepth]
   obs operator:
     name: Identity

--- a/parm/snow/obs/config/snocvr_snow.yaml.j2
+++ b/parm/snow/obs/config/snocvr_snow.yaml.j2
@@ -6,11 +6,11 @@
     obsdatain:
       engine:
         type: H5File
-        obsfile: '{{ DATA }}/obs/{{ OPREFIX }}snocvr_snow.nc4'
+        obsfile: './obs/{{ OPREFIX }}snocvr_snow.nc4'
     obsdataout:
       engine:
         type: H5File
-        obsfile: '{{ DATA }}/diags/diag_snocvr_snow.nc4'
+        obsfile: './diags/diag_snocvr_snow.nc4'
     simulated variables: [totalSnowDepth]
   obs operator:
     name: Composite

--- a/parm/snow/prep/fims.nml.j2
+++ b/parm/snow/prep/fims.nml.j2
@@ -6,7 +6,7 @@
   yyyymmddhh = "{{ current_cycle | to_YMD }}.{{ current_cycle.strftime('%H') }}",
   imsformat = 1,
   imsversion = "1.3",
-  fcst_path = "{{ DATA }}/bkg/"
-  IMS_OBS_PATH = "{{ DATA }}/obs/",
-  IMS_IND_PATH = "{{ DATA }}/obs/"
+  fcst_path = "./bkg/"
+  IMS_OBS_PATH = "./obs/",
+  IMS_IND_PATH = "./obs/"
 /


### PR DESCRIPTION
FMS has a maximum of 128 characters for filenames... so instead of using full paths we will use relative paths for FMS and might as well do it with other things to be consistent.