### PR TITLE
enable atmospheric lgetkf ctests to run in combined and split modes

### DIFF
--- a/test/atm/global-workflow/jjob_ens_init.sh
+++ b/test/atm/global-workflow/jjob_ens_init.sh
@@ -110,6 +110,10 @@ for imem in $(seq 1 $NMEM_ENS); do
     done
 done
 
+# Set lobsdiag_forenkf=.false. to run letkf as single observer and solver job
+# NOTE:  atmensanlinit creates input yaml for atmensanlletkf job
+cp $EXPDIR/config.base_lobsdiag_forenkf_false $EXPDIR/config.base
+
 # Execute j-job
 if [[ $machine = 'HERA' || $machine = 'ORION' || $machine = 'HERCULES' ]]; then
     sbatch --ntasks=1 --account=$ACCOUNT --qos=batch --time=00:10:00 --export=ALL --wait --output=atmensanlinit-%j.out ${HOMEgfs}/jobs/JGLOBAL_ATMENS_ANALYSIS_INITIALIZE

--- a/test/atm/global-workflow/jjob_ens_letkf.sh
+++ b/test/atm/global-workflow/jjob_ens_letkf.sh
@@ -48,6 +48,9 @@ elif [[ $machine = 'ORION' || $machine = 'HERCULES' ]]; then
     export UTILROOT=/work2/noaa/da/python/opt/intel-2022.1.2/prod_util/1.2.2
 fi
 
+# Set lobsdiag_forenkf=.false. to run letkf as combined observer and solver job
+cp $EXPDIR/config.base_lobsdiag_forenkf_false $EXPDIR/config.base
+
 # Execute j-job
 if [[ $machine = 'HERA' || $machine = 'ORION' || $machine = 'HERCULES' ]]; then
     sbatch --nodes=1 --ntasks=36 --account=$ACCOUNT --qos=batch --time=00:30:00 --export=ALL --wait --output=atmensanlletkf-%j.out ${HOMEgfs}/jobs/JGLOBAL_ATMENS_ANALYSIS_LETKF

--- a/test/atm/global-workflow/jjob_ens_obs.sh
+++ b/test/atm/global-workflow/jjob_ens_obs.sh
@@ -48,7 +48,7 @@ elif [[ $machine = 'ORION' || $machine = 'HERCULES' ]]; then
     export UTILROOT=/work2/noaa/da/python/opt/intel-2022.1.2/prod_util/1.2.2
 fi
 
-# Set lobsdiag_forenkf=.true. to run letkf as separate observer and solver jobs
+# Set lobsdiag_forenkf=.true. to run letkf as stand-alone observer job
 cp $EXPDIR/config.base_lobsdiag_forenkf_true $EXPDIR/config.base
 
 # Execute j-job

--- a/test/atm/global-workflow/jjob_ens_obs.sh
+++ b/test/atm/global-workflow/jjob_ens_obs.sh
@@ -48,6 +48,9 @@ elif [[ $machine = 'ORION' || $machine = 'HERCULES' ]]; then
     export UTILROOT=/work2/noaa/da/python/opt/intel-2022.1.2/prod_util/1.2.2
 fi
 
+# Set lobsdiag_forenkf=.true. to run letkf as separate observer and solver jobs
+cp $EXPDIR/config.base_lobsdiag_forenkf_true $EXPDIR/config.base
+
 # Execute j-job
 if [[ $machine = 'HERA' || $machine = 'ORION' || $machine = 'HERCULES' ]]; then
     sbatch --nodes=1 --ntasks=36 --account=$ACCOUNT --qos=debug --time=00:30:00 --export=ALL --wait --output=atmensanlobs-%j.out ${HOMEgfs}/jobs/JGLOBAL_ATMENS_ANALYSIS_OBS

--- a/test/atm/global-workflow/jjob_ens_sol.sh
+++ b/test/atm/global-workflow/jjob_ens_sol.sh
@@ -48,6 +48,9 @@ elif [[ $machine = 'ORION' || $machine = 'HERCULES' ]]; then
     export UTILROOT=/work2/noaa/da/python/opt/intel-2022.1.2/prod_util/1.2.2
 fi
 
+# Set lobsdiag_forenkf=.true. to run letkf as stand-alone solver job
+cp $EXPDIR/config.base_lobsdiag_forenkf_true $EXPDIR/config.base
+
 # Execute j-job
 if [[ $machine = 'HERA' || $machine = 'ORION' || $machine = 'HERCULES' ]]; then
     sbatch --nodes=1 --ntasks=36 --account=$ACCOUNT --qos=debug --time=00:30:00 --export=ALL --wait --output=atmensanlsol-%j.out ${HOMEgfs}/jobs/JGLOBAL_ATMENS_ANALYSIS_SOL

--- a/test/atm/global-workflow/setup_workflow_exp.sh
+++ b/test/atm/global-workflow/setup_workflow_exp.sh
@@ -51,4 +51,9 @@ echo " "
 echo "$expdir/../config.yaml is"
 cat $expdir/../config.yaml
 
+# config.base contains with lobsdiag_forenkf=.true.  Create config.base with lobsdiag_forenkf=.false. for jjob_ens_letkf.sh
+EXPDIR=$expdir/$pslot
+cp $EXPDIR/config.base $EXPDIR/config.base_lobsdiag_forenkf_true
+sed 's/export lobsdiag_forenkf=".true."/export lobsdiag_forenkf=".false."/' $EXPDIR/config.base > $EXPDIR/config.base_lobsdiag_forenkf_false
+
 exit $?


### PR DESCRIPTION
This PR generalizes the atmospheric lgetkf ctests to support the following ctests
- `test_gdasapp_atm_jjob_ens_letkf` - run lgetkf with observer and solver
- `test_gdasapp_atm_jjob_ens_obs` - run lgetkf in observer mode only
- `test_gdasapp_atm_jjob_ens_sol` - run lgetkf in solver mode only

These changes are necessitated by changes in g-w PR [#2833](https://github.com/NOAA-EMC/global-workflow/pull/2833).

Resolves #1261