### PR TITLE
add soca fix yaml file for 1deg

### DIFF
--- a/parm/soca/soca_fix_stage_100.yaml.j2
+++ b/parm/soca/soca_fix_stage_100.yaml.j2
@@ -1,0 +1,25 @@
+# TODO(AFE): make resolution dependent
+mkdir:
+- "{{ DATA }}/INPUT"
+######################################
+# fix files to copy
+######################################
+copy:
+- ["{{ SOCA_INPUT_FIX_DIR }}/rossrad.nc", "{{ DATA }}/rossrad.nc"]
+- ["{{ SOCA_INPUT_FIX_DIR }}/field_table", "{{ DATA }}/field_table"]
+- ["{{ SOCA_INPUT_FIX_DIR }}/diag_table", "{{ DATA }}/diag_table"]
+- ["{{ SOCA_INPUT_FIX_DIR }}/MOM_input", "{{ DATA }}/MOM_input"]
+- ["{{ SOCA_INPUT_FIX_DIR }}/INPUT/grid_spec.nc", "{{ DATA }}/INPUT/grid_spec.nc"]
+- ["{{ SOCA_INPUT_FIX_DIR }}/INPUT/hycom1_75_800m.nc", "{{ DATA }}/INPUT/hycom1_75_800m.nc"]
+- ["{{ SOCA_INPUT_FIX_DIR }}/INPUT/layer_coord.nc", "{{ DATA }}/INPUT/layer_coord.nc"]
+- ["{{ SOCA_INPUT_FIX_DIR }}/INPUT/ocean_hgrid.nc", "{{ DATA }}/INPUT/ocean_hgrid.nc"]
+- ["{{ SOCA_INPUT_FIX_DIR }}/INPUT/ocean_mosaic.nc", "{{ DATA }}/INPUT/ocean_mosaic.nc"]
+- ["{{ SOCA_INPUT_FIX_DIR }}/INPUT/topog.nc", "{{ DATA }}/INPUT/topog.nc"]
+- ["{{ SOCA_INPUT_FIX_DIR }}/INPUT/vgrid_75_2m.nc", "{{ DATA }}/INPUT/vgrid_75_2m.nc"]
+- ["{{ SOCA_INPUT_FIX_DIR }}/INPUT/KH_background_2d.nc", "{{ DATA }}/INPUT/KH_background_2d.nc"]
+- ["{{ SOCA_INPUT_FIX_DIR }}/INPUT/tidal_amplitude.nc", "{{ DATA }}/INPUT/tidal_amplitude.nc"]
+- ["{{ SOCA_INPUT_FIX_DIR }}/INPUT/interpolate_zgrid_40L.nc", "{{ DATA }}/INPUT/interpolate_zgrid_40L.nc"]
+- ["{{ SOCA_INPUT_FIX_DIR }}/INPUT/interpolate_zgrid_46L.nc", "{{ DATA }}/INPUT/interpolate_zgrid_46L.nc"]
+- ["{{ SOCA_INPUT_FIX_DIR }}/INPUT/topo_edits_011818.nc", "{{ DATA }}/INPUT/topo_edits_011818.nc"]
+- ["{{ SOCA_INPUT_FIX_DIR }}/INPUT/MOM_channels_SPEAR", "{{ DATA }}/INPUT/MOM_channels_SPEAR"]
+- ["{{ SOCA_INPUT_FIX_DIR }}/INPUT/seawifs_1998-2006_smoothed_2X.nc", "{{ DATA }}/INPUT/seawifs_1998-2006_smoothed_2X.nc"]


### PR DESCRIPTION
this file is needed for 1 degree ocean DA cycling.  The fix directory at /scratch2/BMC/gsienkf/whitaker/fix/gdas/soca/360x320x75/ is also required (the existing directory in /scratch1/NCEPDEV/global/glopara/fix/gdas/soca/20240802 is missing some files).