### PR TITLE
Build GDASApp outside of global-workflow

### DIFF
--- a/test/aero/CMakeLists.txt
+++ b/test/aero/CMakeLists.txt
@@ -1,10 +1,12 @@
 # tests that can run without needing all JEDI components
 
-# test to generate YAML for aerosol 3DVar
-add_test(NAME test_gdasapp_aero_gen_3dvar_yaml
-         COMMAND ${PROJECT_SOURCE_DIR}/test/aero/genyaml_3dvar.sh ${PROJECT_BINARY_DIR} ${PROJECT_SOURCE_DIR}
-         WORKING DIRECTORY ${PROJECT_BINARY_DIR}/test/testrun/)
-
+# test to generate YAML for aerosol 3DVar.
+if (WORKFLOW_TESTS)
+  add_test(NAME test_gdasapp_aero_gen_3dvar_yaml
+           COMMAND ${PROJECT_SOURCE_DIR}/test/aero/genyaml_3dvar.sh ${PROJECT_BINARY_DIR} ${PROJECT_SOURCE_DIR}
+           WORKING DIRECTORY ${PROJECT_BINARY_DIR}/test/testrun/)
+endif()
+       
 # tests that require the full build
 if(BUILD_GDASBUNDLE)
     # Test exgdas scripts from the global-worflow

--- a/test/gw-ci/CMakeLists.txt
+++ b/test/gw-ci/CMakeLists.txt
@@ -44,26 +44,26 @@ function(add_cycling_tests pslot YAML_PATH HOMEgfs RUNTESTS PROJECT_SOURCE_DIR T
   endforeach()
 endfunction()
 
-# Setup the environement
-set(HOMEgfs ${CMAKE_SOURCE_DIR}/../../..)
-set(RUNTESTS ${CMAKE_CURRENT_BINARY_DIR}/../../test/gw-ci)
-
-# 3DVAR WCDA, low-res
-# -------------------
-set(pslot "WCDA-3DVAR-C48mx500")
-set(YAML_PATH ${HOMEgfs}/ci/cases/pr/C48mx500_3DVarAOWCDA.yaml)
-set(TASK_LIST
-  "gdasprepoceanobs"
-  "gdasmarinebmat"
-  "gdasmarineanlinit"
-  "gdasmarineanlvar"
-  "gdasmarineanlchkpt"
-  "gdasmarineanlfinal"
-  )
-add_cycling_tests(${pslot} ${YAML_PATH} ${HOMEgfs} ${RUNTESTS} ${PROJECT_SOURCE_DIR} "${TASK_LIST}")
-
 option(RUN_GW_CI "Enable the global-workflow CI tests" OFF)
 if (RUN_GW_CI)
+  # Setup the environement
+  set(HOMEgfs ${CMAKE_SOURCE_DIR}/../../..)
+  set(RUNTESTS ${CMAKE_CURRENT_BINARY_DIR}/../../test/gw-ci)
+
+  # 3DVAR WCDA, low-res
+  # -------------------
+  set(pslot "WCDA-3DVAR-C48mx500")
+  set(YAML_PATH ${HOMEgfs}/ci/cases/pr/C48mx500_3DVarAOWCDA.yaml)
+  set(TASK_LIST
+    "gdasprepoceanobs"
+    "gdasmarinebmat"
+    "gdasmarineanlinit"
+    "gdasmarineanlvar"
+    "gdasmarineanlchkpt"
+    "gdasmarineanlfinal"
+    )
+  add_cycling_tests(${pslot} ${YAML_PATH} ${HOMEgfs} ${RUNTESTS} ${PROJECT_SOURCE_DIR} "${TASK_LIST}")
+
   # Aero-Land DA, C96
   # -----------------
   set(pslot "Aero-Snow-3DVAR-C96")

--- a/test/gw-ci/CMakeLists.txt
+++ b/test/gw-ci/CMakeLists.txt
@@ -44,8 +44,7 @@ function(add_cycling_tests pslot YAML_PATH HOMEgfs RUNTESTS PROJECT_SOURCE_DIR T
   endforeach()
 endfunction()
 
-option(RUN_GW_CI "Enable the global-workflow CI tests" OFF)
-if (RUN_GW_CI)
+if (WORKFLOW_TESTS)
   # Setup the environement
   set(HOMEgfs ${CMAKE_SOURCE_DIR}/../../..)
   set(RUNTESTS ${CMAKE_CURRENT_BINARY_DIR}/../../test/gw-ci)
@@ -63,7 +62,10 @@ if (RUN_GW_CI)
     "gdasmarineanlfinal"
     )
   add_cycling_tests(${pslot} ${YAML_PATH} ${HOMEgfs} ${RUNTESTS} ${PROJECT_SOURCE_DIR} "${TASK_LIST}")
+endif()
 
+option(RUN_GW_CI "Enable the global-workflow CI tests" OFF)
+if (RUN_GW_CI)
   # Aero-Land DA, C96
   # -----------------
   set(pslot "Aero-Snow-3DVAR-C96")


### PR DESCRIPTION
Tests in `tests/gw-ci` require global-workflow.  As such, GDASApp can not build outside of g-w.  This PR places gw-ci tests under the flag `RUN_GW_CI`.  gw-ci tests are built when `RUN_GI_CW` is set to `ON`.  The default is `OFF`.  With this change GDASApp can be built without g-w.

Resolves #1305