### PR TITLE
Fixes task names in gw-ci tests

### DIFF
--- a/test/gw-ci/CMakeLists.txt
+++ b/test/gw-ci/CMakeLists.txt
@@ -20,17 +20,17 @@ function(add_cycling_tests pslot YAML_PATH HOMEgfs RUNTESTS PROJECT_SOURCE_DIR T
 
   # stage IC's
   message(STATUS "staging the 1/2 cycle IC's for ${test_name} ctest")
-  add_test(NAME ${test_name}_gdasstage_ic_${HALF_CYCLE}
-           COMMAND /bin/bash -c "${PROJECT_SOURCE_DIR}/test/gw-ci/run_exp.sh ${pslot} gdasstage_ic ${HALF_CYCLE}"
+  add_test(NAME ${test_name}_gdas_stage_ic_${HALF_CYCLE}
+           COMMAND /bin/bash -c "${PROJECT_SOURCE_DIR}/test/gw-ci/run_exp.sh ${pslot} gdas_stage_ic ${HALF_CYCLE}"
            WORKING_DIRECTORY ${RUNTESTS})
-  set_tests_properties(${test_name}_gdasstage_ic_${HALF_CYCLE} PROPERTIES LABELS "manual")
+  set_tests_properties(${test_name}_gdas_stage_ic_${HALF_CYCLE} PROPERTIES LABELS "manual")
 
-  # 1/2 cycle gdasfcst
-  message(STATUS "preparing 1/2 cycle gdasfcst for ${pslot} ctest")
-  add_test(NAME ${test_name}_gdasfcst_${HALF_CYCLE}
-           COMMAND /bin/bash -c "${PROJECT_SOURCE_DIR}/test/gw-ci/run_exp.sh ${pslot} gdasfcst_seg0 ${HALF_CYCLE}"
+  # 1/2 cycle gdas_fcst
+  message(STATUS "preparing 1/2 cycle gdas_fcst for ${pslot} ctest")
+  add_test(NAME ${test_name}_gdas_fcst_${HALF_CYCLE}
+           COMMAND /bin/bash -c "${PROJECT_SOURCE_DIR}/test/gw-ci/run_exp.sh ${pslot} gdas_fcst_seg0 ${HALF_CYCLE}"
            WORKING_DIRECTORY ${RUNTESTS})
-  set_tests_properties(${test_name}_gdasfcst_${HALF_CYCLE} PROPERTIES LABELS "manual")
+  set_tests_properties(${test_name}_gdas_fcst_${HALF_CYCLE} PROPERTIES LABELS "manual")
 
   # Select the list of tasks to run for the full cycle
   message(STATUS "Tasks ${TASK_LIST}")
@@ -54,12 +54,12 @@ if (WORKFLOW_TESTS)
   set(pslot "WCDA-3DVAR-C48mx500")
   set(YAML_PATH ${HOMEgfs}/ci/cases/pr/C48mx500_3DVarAOWCDA.yaml)
   set(TASK_LIST
-    "gdasprepoceanobs"
-    "gdasmarinebmat"
-    "gdasmarineanlinit"
-    "gdasmarineanlvar"
-    "gdasmarineanlchkpt"
-    "gdasmarineanlfinal"
+    "gdas_prepoceanobs"
+    "gdas_marinebmat"
+    "gdas_marineanlinit"
+    "gdas_marineanlvar"
+    "gdas_marineanlchkpt"
+    "gdas_marineanlfinal"
     )
   add_cycling_tests(${pslot} ${YAML_PATH} ${HOMEgfs} ${RUNTESTS} ${PROJECT_SOURCE_DIR} "${TASK_LIST}")
 endif()
@@ -85,15 +85,15 @@ if (RUN_GW_CI)
   set(pslot "GFSv17-3DVAR-C384mx025")
   set(YAML_PATH ${HOMEgfs}/ci/cases/gfsv17/C384mx025_3DVarAOWCDA.yaml)
   set(TASK_LIST
-    "gdasprepoceanobs"
-    "gdasmarinebmat"
-    "gdasmarineanlinit"
-    "gdasmarineanlvar"
-    "gdasmarineanlchkpt"
-    "gdasmarineanlfinal"
-    "gdasocnanalvrfy"
-    "gdasprep"
-    "gdasanal"
+    "gdas_prepoceanobs"
+    "gdas_marinebmat"
+    "gdas_marineanlinit"
+    "gdas_marineanlvar"
+    "gdas_marineanlchkpt"
+    "gdas_marineanlfinal"
+    "gdas_ocnanalvrfy"
+    "gdas_prep"
+    "gdas_anal"
     )
   add_cycling_tests(${pslot} ${YAML_PATH} ${HOMEgfs} ${RUNTESTS} ${PROJECT_SOURCE_DIR} "${TASK_LIST}")
 endif()


### PR DESCRIPTION
This fixes the renaming of g-w tasks in the gw-ci tests. Tested on Hera - some tests fail, but as they did before and evidently not because of this renaming.

Resolves https://github.com/NOAA-EMC/GDASApp/issues/1319
