### PR TITLE
Fix jjob testing in related to change if setup_expt.py

### DIFF
--- a/test/atm/global-workflow/config.yaml
+++ b/test/atm/global-workflow/config.yaml
@@ -10,7 +10,7 @@ base:
   PTMP: "@bindir@/test/atm/global-workflow/testrun"
 
 atmanl:
-  JCB_ALGO_YAML: "@srcdir@/test/atm/global-workflow/jcb-prototype_3dvar.yaml.j2"
+  JCB_ALGO_YAML_VAR: "@srcdir@/test/atm/global-workflow/jcb-prototype_3dvar.yaml.j2"
   STATICB_TYPE: "identity"
   ATMRES_ANL: "C48"
   LAYOUT_X_ATMANL: 1
@@ -19,11 +19,6 @@ atmanl:
 atmensanl:
   JCB_ALGO_YAML_LETKF: "@srcdir@/test/atm/global-workflow/jcb-prototype_lgetkf.yaml.j2"
   JCB_ALGO_YAML_OBS: "@srcdir@/test/atm/global-workflow/jcb-prototype_lgetkf_observer.yaml.j2"
+  JCB_ALGO_YAML_SOL: "@srcdir@/test/atm/global-workflow/jcb-prototype_lgetkf_solver.yaml.j2"
   LAYOUT_X_ATMENSANL: 1
   LAYOUT_Y_ATMENSANL: 1
-
-atmensanlobs:
-  JCB_ALGO_YAML: "@srcdir@/test/atm/global-workflow/jcb-prototype_lgetkf_observer.yaml.j2"
-
-atmensanlsol:
-  JCB_ALGO_YAML: "@srcdir@/test/atm/global-workflow/jcb-prototype_lgetkf_solver.yaml.j2"

--- a/test/atm/global-workflow/config.yaml
+++ b/test/atm/global-workflow/config.yaml
@@ -10,7 +10,7 @@ base:
   PTMP: "@bindir@/test/atm/global-workflow/testrun"
 
 atmanl:
-  JCB_ALGO_YAML_VAR: "@srcdir@/test/atm/global-workflow/jcb-prototype_3dvar.yaml.j2"
+  JCB_ALGO_YAML: "@srcdir@/test/atm/global-workflow/jcb-prototype_3dvar.yaml.j2"
   STATICB_TYPE: "identity"
   ATMRES_ANL: "C48"
   LAYOUT_X_ATMANL: 1
@@ -19,6 +19,11 @@ atmanl:
 atmensanl:
   JCB_ALGO_YAML_LETKF: "@srcdir@/test/atm/global-workflow/jcb-prototype_lgetkf.yaml.j2"
   JCB_ALGO_YAML_OBS: "@srcdir@/test/atm/global-workflow/jcb-prototype_lgetkf_observer.yaml.j2"
-  JCB_ALGO_YAML_SOL: "@srcdir@/test/atm/global-workflow/jcb-prototype_lgetkf_solver.yaml.j2"
   LAYOUT_X_ATMENSANL: 1
   LAYOUT_Y_ATMENSANL: 1
+
+atmensanlobs:
+  JCB_ALGO_YAML: "@srcdir@/test/atm/global-workflow/jcb-prototype_lgetkf_observer.yaml.j2"
+
+atmensanlsol:
+  JCB_ALGO_YAML: "@srcdir@/test/atm/global-workflow/jcb-prototype_lgetkf_solver.yaml.j2"

--- a/test/atm/global-workflow/setup_workflow_exp.sh
+++ b/test/atm/global-workflow/setup_workflow_exp.sh
@@ -10,7 +10,7 @@ idate=2021032312
 edate=2021032318
 app=ATM
 starttype='warm'
-gfscyc='4'
+interval='6'
 resdetatmos='48'
 resensatmos='48'
 nens=3
@@ -37,7 +37,7 @@ $srcdir/../../workflow/setup_expt.py gfs cycled --idate $idate  \
                        --edate $edate \
                        --app $app \
                        --start $starttype \
-                       --gfs_cyc $gfscyc \
+                       --interval $interval \
                        --resdetatmos $resdetatmos \
                        --resensatmos $resensatmos \
                        --nens $nens \


### PR DESCRIPTION
Resolves GDASApp issue [#1347](https://github.com/NOAA-EMC/GDASApp/issues/1347)

jjob tests pass with this change now, but you have to revert ```test/atm/global-workflow/config.yaml``` to https://github.com/NOAA-EMC/GDASApp/commit/6fb0a655ffe61c6dd4f2acaa4c4490121ba980fb since jjob testing will not work without modification until Global Workflow PR [#2992](https://github.com/NOAA-EMC/global-workflow/pull/2992) is merged.