### PR TITLE
Make sure gfs_* DA jobs are not regression tests

### DIFF
--- a/parm/atm/jcb-base.yaml.j2
+++ b/parm/atm/jcb-base.yaml.j2
@@ -30,7 +30,7 @@ analysis_variables: [ua,va,t,ps,sphum,ice_wat,liq_wat,o3mr]
 # Testing
 # -------
 
-do_testing: {{ DO_TEST_MODE | default(false, true) }}
+#do_testing: {{ DO_TEST_MODE | default(false, true) }}
 
 # Model things
 # ------------

--- a/parm/atm/jcb-base.yaml.j2
+++ b/parm/atm/jcb-base.yaml.j2
@@ -27,11 +27,6 @@ final_prints_frequency: PT3H
 number_of_outer_loops: 2
 analysis_variables: [ua,va,t,ps,sphum,ice_wat,liq_wat,o3mr]
 
-# Testing
-# -------
-
-#do_testing: {{ DO_TEST_MODE | default(false, true) }}
-
 # Model things
 # ------------
 # Geometry

--- a/parm/atm/jcb-prototype_3dvar-fv3inc.yaml.j2
+++ b/parm/atm/jcb-prototype_3dvar-fv3inc.yaml.j2
@@ -4,7 +4,10 @@ algorithm: fv3jedi_fv3inc_variational
 
 # Testing things
 # --------------
+{% if DO_TEST_MODE and RUN == 'gdas'  %}
+do_testing: true
 test_reference_filename: {{ HOMEgfs }}/sorc/gdas.cd/test/testreference/C96C48_ufs_hybatmDA_3dvar-fv3inc.ref
 test_output_filename: {{ HOMEgfs }}/sorc/gdas.cd/build/gdas/test/testoutput/C96C48_ufs_hybatmDA_3dvar-fv3inc.test.out
 test_float_relative_tolerance: 1.0e-3
 test_float_absolute_tolerance: 1.0e-5
+{% endif %}

--- a/parm/atm/jcb-prototype_3dvar.yaml.j2
+++ b/parm/atm/jcb-prototype_3dvar.yaml.j2
@@ -33,7 +33,10 @@ observations:
 
 # Testing things
 # --------------
+{% if DO_TEST_MODE and RUN == 'gdas'  %}
+do_testing: true
 test_reference_filename: {{ HOMEgfs }}/sorc/gdas.cd/test/testreference/C96C48_ufs_hybatmDA_3dvar.ref
 test_output_filename: {{ HOMEgfs }}/sorc/gdas.cd/build/gdas/test/testoutput/C96C48_ufs_hybatmDA_3dvar.test.out
 test_float_relative_tolerance: 1.0e-3
 test_float_absolute_tolerance: 1.0e-5
+{% endif %}

--- a/parm/atm/jcb-prototype_lgetkf-fv3inc.yaml.j2
+++ b/parm/atm/jcb-prototype_lgetkf-fv3inc.yaml.j2
@@ -4,7 +4,10 @@ algorithm: fv3jedi_fv3inc_lgetkf
 
 # Testing things
 # --------------
+{% if DO_TEST_MODE and RUN == 'enkfgdas'  %}
+do_testing: true
 test_reference_filename: {{ HOMEgfs }}/sorc/gdas.cd/test/testreference/C96C48_ufs_hybatmDA_lgetkf-fv3inc.ref
 test_output_filename: {{ HOMEgfs }}/sorc/gdas.cd/build/gdas/test/testoutput/C96C48_ufs_hybatmDA_lgetkf-fv3inc.test.out
 test_float_relative_tolerance: 1.0e-3
 test_float_absolute_tolerance: 1.0e-5
+{% endif %}

--- a/parm/atm/jcb-prototype_lgetkf.yaml.j2
+++ b/parm/atm/jcb-prototype_lgetkf.yaml.j2
@@ -41,7 +41,10 @@ observations:
 
 # Testing things
 # --------------
+{% if DO_TEST_MODE and RUN == 'enkfgdas'  %}
+do_testing: true
 test_reference_filename: {{ HOMEgfs }}/sorc/gdas.cd/test/testreference/C96C48_ufs_hybatmDA_lgetkf.ref
 test_output_filename: {{ HOMEgfs }}/sorc/gdas.cd/build/gdas/test/testoutput/C96C48_ufs_hybatmDA_lgetkf.test.out
 test_float_relative_tolerance: 1.0e-3
 test_float_absolute_tolerance: 1.0e-5
+{% endif %}

--- a/parm/atm/jcb-prototype_lgetkf_observer.yaml.j2
+++ b/parm/atm/jcb-prototype_lgetkf_observer.yaml.j2
@@ -47,7 +47,10 @@ distribution_type: RoundRobin
 
 # Testing things
 # --------------
+{% if DO_TEST_MODE and RUN == 'enkfgdas'  %}
+do_testing: true
 test_reference_filename: {{ HOMEgfs }}/sorc/gdas.cd/test/testreference/C96C48_ufs_hybatmDA_lgetkf_observer.ref
 test_output_filename: {{ HOMEgfs }}/sorc/gdas.cd/build/gdas/test/testoutput/C96C48_ufs_hybatmDA_lgetkf_observer.test.out
 test_float_relative_tolerance: 1.0e-3
 test_float_absolute_tolerance: 1.0e-5
+{% endif %}

--- a/parm/atm/jcb-prototype_lgetkf_solver.yaml.j2
+++ b/parm/atm/jcb-prototype_lgetkf_solver.yaml.j2
@@ -50,7 +50,10 @@ distribution_type: Halo
 
 # Testing things
 # --------------
+{% if DO_TEST_MODE and RUN == 'enkfgdas'  %}
+do_testing: true
 test_reference_filename: {{ HOMEgfs }}/sorc/gdas.cd/test/testreference/C96C48_ufs_hybatmDA_lgetkf_solver.ref
 test_output_filename: {{ HOMEgfs }}/sorc/gdas.cd/build/gdas/test/testoutput/C96C48_ufs_hybatmDA_lgetkf_solver.test.out
 test_float_relative_tolerance: 1.0e-3
 test_float_absolute_tolerance: 1.0e-5
+{% endif %}

--- a/parm/soca/marine-jcb-3dfgat.yaml.j2
+++ b/parm/soca/marine-jcb-3dfgat.yaml.j2
@@ -6,7 +6,10 @@ observations: !INC ${OBS_LIST_SHORT}
 
 # Testing things
 # --------------
+{% if DO_TEST_MODE and RUN == 'gdas'  %}
+do_testing: true
 test_reference_filename: '{{HOMEgfs}}/sorc/gdas.cd/test/testreference/C48mx500_3DVarAOWCDA_3dfgat.ref'
 test_output_filename: '{{HOMEgfs}}/sorc/gdas.cd/build/gdas/test/testoutput/C48mx500_3DVarAOWCDA_3dfgat.test.out'
 test_float_relative_tolerance: 1.0e-3
 test_float_absolute_tolerance: 1.0e-5
+{% endif %}

--- a/parm/soca/marine-jcb-base.yaml
+++ b/parm/soca/marine-jcb-base.yaml
@@ -26,11 +26,6 @@ final_prints_frequency: PT3H
 number_of_outer_loops: 1
 analysis_variables: [sea_ice_area_fraction, sea_ice_thickness, sea_ice_snow_thickness, sea_water_salinity, sea_water_potential_temperature, eastward_sea_water_velocity, northward_sea_water_velocity, sea_surface_height_above_geoid]
 
-# Testing
-# -------
-
-do_testing: '{{ DO_TEST_MODE | default(false, true) }}'
-
 # Model things
 # ------------
 marine_window_begin: '{{MARINE_WINDOW_BEGIN}}'

--- a/test/atm/global-workflow/jcb-prototype_3dvar-fv3inc.yaml.j2
+++ b/test/atm/global-workflow/jcb-prototype_3dvar-fv3inc.yaml.j2
@@ -4,7 +4,10 @@ algorithm: fv3jedi_fv3inc_variational
 
 # Testing things
 # --------------
+{% if DO_TEST_MODE and RUN == 'gdas'  %}
+do_testing: true
 test_reference_filename: {{ HOMEgfs }}/sorc/gdas.cd/test/testreference/atm_jjob_3dvar-fv3inc.ref
 test_output_filename: {{ HOMEgfs }}/sorc/gdas.cd/build/gdas/test/testoutput/atm_jjob_3dvar-fv3inc.test.out
 test_float_relative_tolerance: 1.0e-3
 test_float_absolute_tolerance: 1.0e-5
+{% endif %}

--- a/test/atm/global-workflow/jcb-prototype_3dvar.yaml.j2
+++ b/test/atm/global-workflow/jcb-prototype_3dvar.yaml.j2
@@ -17,7 +17,10 @@ atmosphere_obsdatain_suffix: ".{{ current_cycle | to_YMDH }}.nc"
 
 # Testing things
 # --------------
+{% if DO_TEST_MODE and RUN == 'gdas'  %}
+do_testing: true
 test_reference_filename: {{ HOMEgfs }}/sorc/gdas.cd/test/testreference/atm_jjob_3dvar.ref
 test_output_filename: {{ HOMEgfs }}/sorc/gdas.cd/build/gdas/test/testoutput/atm_jjob_3dvar.test.out
 test_float_relative_tolerance: 1.0e-3
 test_float_absolute_tolerance: 1.0e-5
+{% endif %}

--- a/test/atm/global-workflow/jcb-prototype_lgetkf-fv3inc.yaml.j2
+++ b/test/atm/global-workflow/jcb-prototype_lgetkf-fv3inc.yaml.j2
@@ -4,7 +4,10 @@ algorithm: fv3jedi_fv3inc_lgetkf
 
 # Testing things
 # --------------
+{% if DO_TEST_MODE and RUN == 'enkfgdas'  %}
+do_testing: true
 test_reference_filename: {{ HOMEgfs }}/sorc/gdas.cd/test/testreference/atm_jjob_lgetkf-fv3inc.ref
 test_output_filename: {{ HOMEgfs }}/sorc/gdas.cd/build/gdas/test/testoutput/atm_jjob_lgetkf-fv3inc.test.out
 test_float_relative_tolerance: 1.0e-3
 test_float_absolute_tolerance: 1.0e-5
+{% endif %}

--- a/test/atm/global-workflow/jcb-prototype_lgetkf.yaml.j2
+++ b/test/atm/global-workflow/jcb-prototype_lgetkf.yaml.j2
@@ -22,7 +22,10 @@ atmosphere_obsdatain_suffix: ".{{ current_cycle | to_YMDH }}.nc"
 
 # Testing things
 # --------------
+{% if DO_TEST_MODE and RUN == 'enkfgdas'  %}
+do_testing: true
 test_reference_filename: {{ HOMEgfs }}/sorc/gdas.cd/test/testreference/atm_jjob_lgetkf.ref
 test_output_filename: {{ HOMEgfs }}/sorc/gdas.cd/build/gdas/test/testoutput/atm_jjob_lgetkf.test.out
 test_float_relative_tolerance: 1.0e-3
 test_float_absolute_tolerance: 1.0e-5
+{% endif %}

--- a/test/atm/global-workflow/jcb-prototype_lgetkf_observer.yaml.j2
+++ b/test/atm/global-workflow/jcb-prototype_lgetkf_observer.yaml.j2
@@ -28,7 +28,10 @@ distribution_type: RoundRobin
 
 # Testing things
 # --------------
+{% if DO_TEST_MODE and RUN == 'enkfgdas'  %}
+do_testing: true
 test_reference_filename: {{ HOMEgfs }}/sorc/gdas.cd/test/testreference/atm_jjob_lgetkf_observer.ref
 test_output_filename: {{ HOMEgfs }}/sorc/gdas.cd/build/gdas/test/testoutput/atm_jjob_lgetkf_observer.test.out
 test_float_relative_tolerance: 1.0e-3
 test_float_absolute_tolerance: 1.0e-5
+{% endif %}

--- a/test/atm/global-workflow/jcb-prototype_lgetkf_solver.yaml.j2
+++ b/test/atm/global-workflow/jcb-prototype_lgetkf_solver.yaml.j2
@@ -28,7 +28,10 @@ distribution_type: Halo
 
 # Testing things
 # --------------
+{% if DO_TEST_MODE and RUN == 'enkfgdas'  %}
+do_testing: true
 test_reference_filename: {{ HOMEgfs }}/sorc/gdas.cd/test/testreference/atm_jjob_lgetkf_solver.ref
 test_output_filename: {{ HOMEgfs }}/sorc/gdas.cd/build/gdas/test/testoutput/atm_jjob_lgetkf_solver.test.out
 test_float_relative_tolerance: 1.0e-3
 test_float_absolute_tolerance: 1.0e-5
+{% endif %}


### PR DESCRIPTION
This PR addresses the bug @RussTreadon-NOAA found that ```gfs_atmanlvar``` was being run as a regression test and using the same test reference as ```gdas_atmanlvar``` in GW PR [#3120](https://github.com/NOAA-EMC/global-workflow/pull/3120). 

See https://github.com/NOAA-EMC/global-workflow/pull/3120#issuecomment-2501783018

I've moved all activation of testing mode in JCB out of the JCB base YAMLs and into the JCB algorithm YAMLs. I test the ```RUN``` variables to make sure it's not equal to ```gfs```.

I re-ran all the regression tests, and they all passed.