### PR TITLE
turn off g-w based ctest reference checks on WCOSS2

### DIFF
--- a/test/gw-ci/atm/jcb-prototype_3dvar-fv3inc_ufs_hybatmDA.yaml.j2
+++ b/test/gw-ci/atm/jcb-prototype_3dvar-fv3inc_ufs_hybatmDA.yaml.j2
@@ -4,7 +4,7 @@ algorithm: fv3jedi_fv3inc_variational
 
 # Testing things
 # --------------
-{% if DO_TEST_MODE == true and RUN == 'gdas' and current_cycle | to_YMDH == '2024022400' %}
+{% if DO_TEST_MODE == true and RUN == 'gdas' and current_cycle | to_YMDH == '2024022400' and machine == 'HERA' %}
 do_testing: true
 test_reference_filename: {{ HOMEgfs }}/sorc/gdas.cd/test/testreference/{{ CASE }}{{ CASE_ENS }}_ufs_hybatmDA_3dvar-fv3inc.ref
 test_output_filename: {{ HOMEgfs }}/sorc/gdas.cd/build/gdas/test/testoutput/{{ CASE }}{{ CASE_ENS }}_ufs_hybatmDA_3dvar-fv3inc.test.out

--- a/test/gw-ci/atm/jcb-prototype_3dvar-fv3inc_ufs_hybatmDA.yaml.j2
+++ b/test/gw-ci/atm/jcb-prototype_3dvar-fv3inc_ufs_hybatmDA.yaml.j2
@@ -4,7 +4,7 @@ algorithm: fv3jedi_fv3inc_variational
 
 # Testing things
 # --------------
-{% if DO_TEST_MODE == true and RUN == 'gdas' and current_cycle | to_YMDH == '2024022400' and machine == 'HERA' %}
+{% if DO_TEST_MODE == true and RUN == 'gdas' and current_cycle | to_YMDH == '2024022400' and machine != 'WCOSS2' %}
 do_testing: true
 test_reference_filename: {{ HOMEgfs }}/sorc/gdas.cd/test/testreference/{{ CASE }}{{ CASE_ENS }}_ufs_hybatmDA_3dvar-fv3inc.ref
 test_output_filename: {{ HOMEgfs }}/sorc/gdas.cd/build/gdas/test/testoutput/{{ CASE }}{{ CASE_ENS }}_ufs_hybatmDA_3dvar-fv3inc.test.out

--- a/test/gw-ci/atm/jcb-prototype_3dvar_ufs_hybatmDA.yaml.j2
+++ b/test/gw-ci/atm/jcb-prototype_3dvar_ufs_hybatmDA.yaml.j2
@@ -33,7 +33,7 @@ observations:
 
 # Testing things
 # --------------
-{% if DO_TEST_MODE == true and RUN == 'gdas' and current_cycle | to_YMDH == '2024022400' and machine == 'HERA' %}
+{% if DO_TEST_MODE == true and RUN == 'gdas' and current_cycle | to_YMDH == '2024022400' and machine != 'WCOSS2' %}
 do_testing: true
 test_reference_filename: {{ HOMEgfs }}/sorc/gdas.cd/test/testreference/{{ CASE }}{{ CASE_ENS }}_ufs_hybatmDA_3dvar.ref
 test_output_filename: {{ HOMEgfs }}/sorc/gdas.cd/build/gdas/test/testoutput/{{ CASE }}{{ CASE_ENS }}_ufs_hybatmDA_3dvar.test.out

--- a/test/gw-ci/atm/jcb-prototype_3dvar_ufs_hybatmDA.yaml.j2
+++ b/test/gw-ci/atm/jcb-prototype_3dvar_ufs_hybatmDA.yaml.j2
@@ -33,7 +33,7 @@ observations:
 
 # Testing things
 # --------------
-{% if DO_TEST_MODE == true and RUN == 'gdas' and current_cycle | to_YMDH == '2024022400' %}
+{% if DO_TEST_MODE == true and RUN == 'gdas' and current_cycle | to_YMDH == '2024022400' and machine == 'HERA' %}
 do_testing: true
 test_reference_filename: {{ HOMEgfs }}/sorc/gdas.cd/test/testreference/{{ CASE }}{{ CASE_ENS }}_ufs_hybatmDA_3dvar.ref
 test_output_filename: {{ HOMEgfs }}/sorc/gdas.cd/build/gdas/test/testoutput/{{ CASE }}{{ CASE_ENS }}_ufs_hybatmDA_3dvar.test.out

--- a/test/gw-ci/atm/jcb-prototype_lgetkf-fv3inc_ufs_hybatmDA.yaml.j2
+++ b/test/gw-ci/atm/jcb-prototype_lgetkf-fv3inc_ufs_hybatmDA.yaml.j2
@@ -4,7 +4,7 @@ algorithm: fv3jedi_fv3inc_lgetkf
 
 # Testing things
 # --------------
-{% if DO_TEST_MODE == true and RUN == 'enkfgdas' and current_cycle | to_YMDH == '2024022400' and machine == 'HERA' %}
+{% if DO_TEST_MODE == true and RUN == 'enkfgdas' and current_cycle | to_YMDH == '2024022400' and machine != 'WCOSS2' %}
 do_testing: true
 test_reference_filename: {{ HOMEgfs }}/sorc/gdas.cd/test/testreference/{{ CASE }}{{ CASE_ENS }}_ufs_hybatmDA_lgetkf-fv3inc.ref
 test_output_filename: {{ HOMEgfs }}/sorc/gdas.cd/build/gdas/test/testoutput/{{ CASE }}{{ CASE_ENS }}_ufs_hybatmDA_lgetkf-fv3inc.test.out

--- a/test/gw-ci/atm/jcb-prototype_lgetkf-fv3inc_ufs_hybatmDA.yaml.j2
+++ b/test/gw-ci/atm/jcb-prototype_lgetkf-fv3inc_ufs_hybatmDA.yaml.j2
@@ -4,7 +4,7 @@ algorithm: fv3jedi_fv3inc_lgetkf
 
 # Testing things
 # --------------
-{% if DO_TEST_MODE == true and RUN == 'enkfgdas' and current_cycle | to_YMDH == '2024022400' %}
+{% if DO_TEST_MODE == true and RUN == 'enkfgdas' and current_cycle | to_YMDH == '2024022400' and machine == 'HERA' %}
 do_testing: true
 test_reference_filename: {{ HOMEgfs }}/sorc/gdas.cd/test/testreference/{{ CASE }}{{ CASE_ENS }}_ufs_hybatmDA_lgetkf-fv3inc.ref
 test_output_filename: {{ HOMEgfs }}/sorc/gdas.cd/build/gdas/test/testoutput/{{ CASE }}{{ CASE_ENS }}_ufs_hybatmDA_lgetkf-fv3inc.test.out

--- a/test/gw-ci/atm/jcb-prototype_lgetkf_observer_ufs_hybatmDA.yaml.j2
+++ b/test/gw-ci/atm/jcb-prototype_lgetkf_observer_ufs_hybatmDA.yaml.j2
@@ -47,7 +47,7 @@ distribution_type: RoundRobin
 
 # Testing things
 # --------------
-{% if DO_TEST_MODE == true and RUN == 'enkfgdas' and current_cycle | to_YMDH == '2024022400' and machine == 'HERA' %}
+{% if DO_TEST_MODE == true and RUN == 'enkfgdas' and current_cycle | to_YMDH == '2024022400' and machine != 'WCOSS2' %}
 do_testing: true
 test_reference_filename: {{ HOMEgfs }}/sorc/gdas.cd/test/testreference/{{ CASE }}{{ CASE_ENS }}_ufs_hybatmDA_lgetkf_observer.ref
 test_output_filename: {{ HOMEgfs }}/sorc/gdas.cd/build/gdas/test/testoutput/{{ CASE }}{{ CASE_ENS }}_ufs_hybatmDA_lgetkf_observer.test.out

--- a/test/gw-ci/atm/jcb-prototype_lgetkf_observer_ufs_hybatmDA.yaml.j2
+++ b/test/gw-ci/atm/jcb-prototype_lgetkf_observer_ufs_hybatmDA.yaml.j2
@@ -47,7 +47,7 @@ distribution_type: RoundRobin
 
 # Testing things
 # --------------
-{% if DO_TEST_MODE == true and RUN == 'enkfgdas' and current_cycle | to_YMDH == '2024022400' %}
+{% if DO_TEST_MODE == true and RUN == 'enkfgdas' and current_cycle | to_YMDH == '2024022400' and machine == 'HERA' %}
 do_testing: true
 test_reference_filename: {{ HOMEgfs }}/sorc/gdas.cd/test/testreference/{{ CASE }}{{ CASE_ENS }}_ufs_hybatmDA_lgetkf_observer.ref
 test_output_filename: {{ HOMEgfs }}/sorc/gdas.cd/build/gdas/test/testoutput/{{ CASE }}{{ CASE_ENS }}_ufs_hybatmDA_lgetkf_observer.test.out

--- a/test/gw-ci/atm/jcb-prototype_lgetkf_solver_ufs_hybatmDA.yaml.j2
+++ b/test/gw-ci/atm/jcb-prototype_lgetkf_solver_ufs_hybatmDA.yaml.j2
@@ -50,7 +50,7 @@ distribution_type: Halo
 
 # Testing things
 # --------------
-{% if DO_TEST_MODE == true and RUN == 'enkfgdas' and current_cycle | to_YMDH == '2024022400' %}
+{% if DO_TEST_MODE == true and RUN == 'enkfgdas' and current_cycle | to_YMDH == '2024022400' and machine == 'HERA' %}
 do_testing: true
 test_reference_filename: {{ HOMEgfs }}/sorc/gdas.cd/test/testreference/{{ CASE }}{{ CASE_ENS }}_ufs_hybatmDA_lgetkf_solver.ref
 test_output_filename: {{ HOMEgfs }}/sorc/gdas.cd/build/gdas/test/testoutput/{{ CASE }}{{ CASE_ENS }}_ufs_hybatmDA_lgetkf_solver.test.out

--- a/test/gw-ci/atm/jcb-prototype_lgetkf_solver_ufs_hybatmDA.yaml.j2
+++ b/test/gw-ci/atm/jcb-prototype_lgetkf_solver_ufs_hybatmDA.yaml.j2
@@ -50,7 +50,7 @@ distribution_type: Halo
 
 # Testing things
 # --------------
-{% if DO_TEST_MODE == true and RUN == 'enkfgdas' and current_cycle | to_YMDH == '2024022400' and machine == 'HERA' %}
+{% if DO_TEST_MODE == true and RUN == 'enkfgdas' and current_cycle | to_YMDH == '2024022400' and machine != 'WCOSS2' %}
 do_testing: true
 test_reference_filename: {{ HOMEgfs }}/sorc/gdas.cd/test/testreference/{{ CASE }}{{ CASE_ENS }}_ufs_hybatmDA_lgetkf_solver.ref
 test_output_filename: {{ HOMEgfs }}/sorc/gdas.cd/build/gdas/test/testoutput/{{ CASE }}{{ CASE_ENS }}_ufs_hybatmDA_lgetkf_solver.test.out

--- a/test/gw-ci/atm/jcb-prototype_lgetkf_ufs_hybatmDA.yaml.j2
+++ b/test/gw-ci/atm/jcb-prototype_lgetkf_ufs_hybatmDA.yaml.j2
@@ -41,7 +41,7 @@ observations:
 
 # Testing things
 # --------------
-{% if DO_TEST_MODE == true and RUN == 'enkfgdas' and current_cycle | to_YMDH == '2024022400' %}
+{% if DO_TEST_MODE == true and RUN == 'enkfgdas' and current_cycle | to_YMDH == '2024022400' and machine == 'HERA' %}
 do_testing: true
 test_reference_filename: {{ HOMEgfs }}/sorc/gdas.cd/test/testreference/{{ CASE }}{{ CASE_ENS }}_ufs_hybatmDA_lgetkf.ref
 test_output_filename: {{ HOMEgfs }}/sorc/gdas.cd/build/gdas/test/testoutput/{{ CASE }}{{ CASE_ENS }}_ufs_hybatmDA_lgetkf.test.out

--- a/test/gw-ci/atm/jcb-prototype_lgetkf_ufs_hybatmDA.yaml.j2
+++ b/test/gw-ci/atm/jcb-prototype_lgetkf_ufs_hybatmDA.yaml.j2
@@ -41,7 +41,7 @@ observations:
 
 # Testing things
 # --------------
-{% if DO_TEST_MODE == true and RUN == 'enkfgdas' and current_cycle | to_YMDH == '2024022400' and machine == 'HERA' %}
+{% if DO_TEST_MODE == true and RUN == 'enkfgdas' and current_cycle | to_YMDH == '2024022400' and machine != 'WCOSS2' %}
 do_testing: true
 test_reference_filename: {{ HOMEgfs }}/sorc/gdas.cd/test/testreference/{{ CASE }}{{ CASE_ENS }}_ufs_hybatmDA_lgetkf.ref
 test_output_filename: {{ HOMEgfs }}/sorc/gdas.cd/build/gdas/test/testoutput/{{ CASE }}{{ CASE_ENS }}_ufs_hybatmDA_lgetkf.test.out

--- a/test/gw-ci/soca/jcb-prototype_3dfgat_3DVarAOWCDA.yaml.j2
+++ b/test/gw-ci/soca/jcb-prototype_3dfgat_3DVarAOWCDA.yaml.j2
@@ -6,7 +6,7 @@ observations: !INC ${OBS_LIST_SHORT}
 
 # Testing things
 # --------------
-{% if DO_TEST_MODE == true and RUN == 'gdas' and current_cycle | to_YMDH == '2021032418' and machine == 'HERA' %}
+{% if DO_TEST_MODE == true and RUN == 'gdas' and current_cycle | to_YMDH == '2021032418' and machine != 'WCOSS2' %}
 do_testing: true
 test_reference_filename: '{{HOMEgfs}}/sorc/gdas.cd/test/testreference/{{ CASE }}mx{{ OCNRES }}_3DVarAOWCDA_3dfgat.ref'
 test_output_filename: '{{HOMEgfs}}/sorc/gdas.cd/build/gdas/test/testoutput/{{ CASE }}mx{{ OCNRES }}_3DVarAOWCDA_3dfgat.test.out'

--- a/test/gw-ci/soca/jcb-prototype_3dfgat_3DVarAOWCDA.yaml.j2
+++ b/test/gw-ci/soca/jcb-prototype_3dfgat_3DVarAOWCDA.yaml.j2
@@ -6,7 +6,7 @@ observations: !INC ${OBS_LIST_SHORT}
 
 # Testing things
 # --------------
-{% if DO_TEST_MODE == true and RUN == 'gdas' and current_cycle | to_YMDH == '2021032418' %}
+{% if DO_TEST_MODE == true and RUN == 'gdas' and current_cycle | to_YMDH == '2021032418' and machine == 'HERA' %}
 do_testing: true
 test_reference_filename: '{{HOMEgfs}}/sorc/gdas.cd/test/testreference/{{ CASE }}mx{{ OCNRES }}_3DVarAOWCDA_3dfgat.ref'
 test_output_filename: '{{HOMEgfs}}/sorc/gdas.cd/build/gdas/test/testoutput/{{ CASE }}mx{{ OCNRES }}_3DVarAOWCDA_3dfgat.test.out'


### PR DESCRIPTION
Add logic to g-w based ctest templates to turn off reference check on WCOSS2.

Resolves #1399