### PR TITLE
Only run 2 members for the marine hybrid

### DIFF
--- a/test/gw-ci/CMakeLists.txt
+++ b/test/gw-ci/CMakeLists.txt
@@ -6,16 +6,9 @@ function(add_task task_name test_prefix is_full_cycle HALF_CYCLE FULL_CYCLE pslo
     set(subtask_names_list
       "gdas_fcst_seg0")
   elseif("${task_name}" STREQUAL "enkfgdas_fcst")
-    if("${pslot}" STREQUAL "C48mx500_hybAOWCDA")
-      set(subtask_names_list
-        "enkfgdas_fcst_mem001"
-        "enkfgdas_fcst_mem002"
-        "enkfgdas_fcst_mem003")
-    else()
       set(subtask_names_list
         "enkfgdas_fcst_mem001"
         "enkfgdas_fcst_mem002")
-    endif()
   elseif("${task_name}" STREQUAL "gdas_atmos_prod")
     set(subtask_names_list
       "gdas_atmos_prod_f000"
@@ -244,11 +237,11 @@ endfunction()
 
 if (WORKFLOW_TESTS)
   # List of tests to run
-  option(TEST_GSI "Enable the GFSv17 GSI tests" ON)
-  option(TEST_GFS18 "Enable the GFSv18 Atmos JEDI tests" ON)
-  option(TEST_AERO_LAND "Enable the GFSv17 Aero-Land JEDI tests" ON)
-  option(TEST_MARINE_VAR "Enable the GFSv17 Marine JEDI 3D VAR FGAT tests" ON)
-  option(TEST_MARINE_HYB "Enable the GFSv17 Marine JEDI 3d HYB VAR tests" OFF)
+  option(TEST_GSI "Enable the GFSv17 GSI tests" OFF)
+  option(TEST_GFS18 "Enable the GFSv18 Atmos JEDI tests" OFF)
+  option(TEST_AERO_LAND "Enable the GFSv17 Aero-Land JEDI tests" OFF)
+  option(TEST_MARINE_VAR "Enable the GFSv17 Marine JEDI 3D VAR FGAT tests" OFF)
+  option(TEST_MARINE_HYB "Enable the GFSv17 Marine JEDI 3d HYB VAR tests" ON)
   option(TEST_GFS17 "Enable the GFSv17 WCDA tests" OFF)
 
   # Setup the environement

--- a/test/gw-ci/CMakeLists.txt
+++ b/test/gw-ci/CMakeLists.txt
@@ -237,10 +237,10 @@ endfunction()
 
 if (WORKFLOW_TESTS)
   # List of tests to run
-  option(TEST_GSI "Enable the GFSv17 GSI tests" OFF)
-  option(TEST_GFS18 "Enable the GFSv18 Atmos JEDI tests" OFF)
-  option(TEST_AERO_LAND "Enable the GFSv17 Aero-Land JEDI tests" OFF)
-  option(TEST_MARINE_VAR "Enable the GFSv17 Marine JEDI 3D VAR FGAT tests" OFF)
+  option(TEST_GSI "Enable the GFSv17 GSI tests" ON)
+  option(TEST_GFS18 "Enable the GFSv18 Atmos JEDI tests" ON)
+  option(TEST_AERO_LAND "Enable the GFSv17 Aero-Land JEDI tests" ON)
+  option(TEST_MARINE_VAR "Enable the GFSv17 Marine JEDI 3D VAR FGAT tests" ON)
   option(TEST_MARINE_HYB "Enable the GFSv17 Marine JEDI 3d HYB VAR tests" ON)
   option(TEST_GFS17 "Enable the GFSv17 WCDA tests" OFF)
 


### PR DESCRIPTION
# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmaerosnowDA  <!-- JEDI aero/snow cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [x] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->