### PR TITLE
add tostring(pkgVersion) to select GDAS modulefiles

### DIFF
--- a/modulefiles/GDAS/hera.intel.lua
+++ b/modulefiles/GDAS/hera.intel.lua
@@ -92,6 +92,6 @@ setenv("GDASAPP_UNIT_TEST_DATA_PATH", "/scratch1/NCEPDEV/da/role.jedipara/GDASAp
 --prepend_path("PATH","/scratch2/NCEPDEV/nwprod/hpc-stack/libs/hpc-stack/intel-18.0.5.274/prod_util/1.2.2/bin")
 
 whatis("Name: ".. pkgName)
-whatis("Version: ".. pkgVersion)
+whatis("Version: ".. tostring(pkgVersion))
 whatis("Category: GDASApp")
 whatis("Description: Load all libraries needed for GDASApp")

--- a/modulefiles/GDAS/hercules.gnu.lua
+++ b/modulefiles/GDAS/hercules.gnu.lua
@@ -88,6 +88,6 @@ setenv("GDASAPP_UNIT_TEST_DATA_PATH", "/work2/noaa/da/role-da/GDASApp/unittestda
 execute{cmd="ulimit -s unlimited",modeA={"load"}}
 
 whatis("Name: ".. pkgName)
-whatis("Version: ".. pkgVersion)
+whatis("Version: ".. tostring(pkgVersion))
 whatis("Category: GDASApp")
 whatis("Description: Load all libraries needed for GDASApp")

--- a/modulefiles/GDAS/hercules.intel.lua
+++ b/modulefiles/GDAS/hercules.intel.lua
@@ -89,6 +89,6 @@ prepend_path("PATH","/apps/contrib/NCEP/libs/hpc-stack/intel-2018.4/prod_util/1.
 execute{cmd="ulimit -s unlimited",modeA={"load"}}
 
 whatis("Name: ".. pkgName)
-whatis("Version: ".. pkgVersion)
+whatis("Version: ".. tostring(pkgVersion))
 whatis("Category: GDASApp")
 whatis("Description: Load all libraries needed for GDASApp")

--- a/modulefiles/GDAS/orion.intel.lua
+++ b/modulefiles/GDAS/orion.intel.lua
@@ -89,6 +89,6 @@ prepend_path("PATH","/apps/contrib/NCEP/libs/hpc-stack/intel-2018.4/prod_util/1.
 execute{cmd="ulimit -s unlimited",modeA={"load"}}
 
 whatis("Name: ".. pkgName)
-whatis("Version: ".. pkgVersion)
+whatis("Version: ".. tostring(pkgVersion))
 whatis("Category: GDASApp")
 whatis("Description: Load all libraries needed for GDASApp")

--- a/modulefiles/GDAS/wcoss2.intel.lua
+++ b/modulefiles/GDAS/wcoss2.intel.lua
@@ -55,6 +55,6 @@ setenv("GDASAPP_TESTDATA","/lfs/h2/emc/da/noscrub/emc.da/GDASApp/testdata")
 setenv("GDASAPP_UNIT_TEST_DATA_PATH", "/lfs/h2/emc/da/noscrub/emc.da/GDASApp/unittestdata")
 
 whatis("Name: ".. pkgName)
-whatis("Version: ".. pkgVersion)
+whatis("Version: ".. tostring(pkgVersion))
 whatis("Category: GDASApp")
 whatis("Description: Load all libraries needed for GDASApp")


### PR DESCRIPTION
# Description

This PR modifies select machine modulefiles in `modulefiles/GDAS` to allow them to be loaded via
- `module use ${path}/modulefiles/GDAS`
- `module load ${machine}.${comp}`

# Companion PRs

none

# Issues

Resolves #1418


# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmaerosnowDA  <!-- JEDI aero/snow cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [ ] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
