### PR TITLE
Update jcb-base for aerosol VarBC

### DIFF
--- a/parm/aero/jcb-base.yaml.j2
+++ b/parm/aero/jcb-base.yaml.j2
@@ -137,3 +137,6 @@ bias_files:
   ssmis_f18: rad_varbc_params.tar
   cris-fsr_n20: rad_varbc_params.tar
   cris-fsr_npp: rad_varbc_params.tar
+  viirs_npp_aod: aero_varbc_params.tar
+  viirs_n20_aod: aero_varbc_params.tar
+  viirs_n21_aod: aero_varbc_params.tar

--- a/parm/aero/jcb-base.yaml.j2
+++ b/parm/aero/jcb-base.yaml.j2
@@ -128,15 +128,6 @@ aero_obsbiascovout_prefix: "{{APREFIX}}"
 aero_obsbiascovout_suffix: ".satbias_cov.nc"
 
 bias_files:
-  atms_n20: rad_varbc_params.tar
-  atms_npp: rad_varbc_params.tar
-  mtiasi_metop-a: rad_varbc_params.tar
-  mtiasi_metop-b: rad_varbc_params.tar
-  amsua_n19: rad_varbc_params.tar
-  ssmis_f17: rad_varbc_params.tar
-  ssmis_f18: rad_varbc_params.tar
-  cris-fsr_n20: rad_varbc_params.tar
-  cris-fsr_npp: rad_varbc_params.tar
   viirs_npp_aod: aero_varbc_params.tar
   viirs_n20_aod: aero_varbc_params.tar
   viirs_n21_aod: aero_varbc_params.tar


### PR DESCRIPTION
# Description

This PR adds the aerosol bias file names to the jcb-base template.

# Companion PRs
https://github.com/NOAA-EMC/global-workflow/pull/3189

# Issues
Resolves #https://github.com/NOAA-EMC/global-workflow/issues/3172


# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] C96C48_hybatmaerosnowDA  <!-- JEDI aero/snow cycled DA !-->
