### PR TITLE
update build_all.sh argument list

### DIFF
--- a/ci/run_ci.sh
+++ b/ci/run_ci.sh
@@ -46,7 +46,7 @@ if [[ $TEST_WORKFLOW == 1 ]]; then
     gdasapp_dir=$workflow_dir/sorc/gdas.cd
 
     build_cmd_dir=$workflow_dir/sorc
-    build_cmd="./build_all.sh -ug &>> log.build"
+    build_cmd="./build_all.sh gfs gsi gdas"
     build_dir=$workflow_dir/build
 else
     export BUILD_JOBS=8
@@ -54,7 +54,7 @@ else
     gdasapp_dir=$repodir
 
     build_cmd_dir=$gdasapp_dir
-    build_cmd="./build.sh -t $TARGET &>> log.build"
+    build_cmd="./build.sh -t $TARGET"
     build_dir=$gdasapp_dir/build
 fi
 
@@ -74,7 +74,7 @@ echo "---------------------------------------------------" >> $outfile
 cd $build_cmd_dir
 module purge
 rm -rf log.build
-$build_cmd
+$build_cmd &>> log.build
 build_status=$?
 if [ $build_status -eq 0 ]; then
   echo "Build:                                 *SUCCESS*" >> $outfile

--- a/prototypes/gen_prototype.sh
+++ b/prototypes/gen_prototype.sh
@@ -47,7 +47,7 @@ if [[ $BUILD == 'YES' ]]; then
     cd gdas.cd
     git checkout $GDASHASH
     cd ../
-    ./build_all.sh
+    ./build_all.sh gfs gsi gdas
     ./link_workflow.sh
 fi
 


### PR DESCRIPTION
# Description

This PR updates the argument list for `build_all.sh` to be consistent with g-w PR [#3186](https://github.com/NOAA-EMC/global-workflow/pull/3186) which was merged into g-w `develop` on  12/24/2024.

Two files are modified
```
ci/run_ci.sh
prototypes/gen_prototype.sh
```

# Companion PRs

None

# Issues

Resolves #1427


# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmaerosnowDA  <!-- JEDI aero/snow cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [ ] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
