### PR TITLE
Bugfix for ensemble update: rollback changes in gdas_ens_handler

### DIFF
--- a/utils/soca/gdas_ens_handler.h
+++ b/utils/soca/gdas_ens_handler.h
@@ -151,14 +151,14 @@ namespace gdasapp {
           oops::Log::info() << "recentered incr " << i << ":" << incr << std::endl;
 
           // Append the vertical geometry (for MOM6 IAU)
-          postProcIncr.appendLayer(incr);
-          oops::Log::info() << "incr " << i << ":" << incr << std::endl;
+          soca::Increment mom6_incr = postProcIncr.appendLayer(incr);
+          oops::Log::info() << "incr " << i << ":" << mom6_incr << std::endl;
 
           // Set variables to zero if specified in the configuration
           postProcIncr.setToZero(incr);
 
           // Save the increments used to initialize the ensemble forecast
-          result = postProcIncr.save(incr, i+1);
+          result = postProcIncr.save(mom6_incr, i+1);
         }
         return result;
       }


### PR DESCRIPTION
# Description

Bugfix for https://github.com/NOAA-EMC/GDASApp/issues/1429.
I am rolling back the change in `gdas_ens_handler` from https://github.com/NOAA-EMC/GDASApp/pull/1417 that resulted in ensemble increments missing ssh which is used (at least to check dimensions) in mom6 IAU. From looking at the original PR I don't think this change was intentional, and I _think_ it's OK to roll it back, although it would be good if someone with the knowledge of this workflow can review.

# Issues

Fixes https://github.com/NOAA-EMC/GDASApp/issues/1429