### PR TITLE
update jcb-gdas hash 20250128

### DIFF
--- a/parm/aero/jcb-base.yaml.j2
+++ b/parm/aero/jcb-base.yaml.j2
@@ -81,8 +81,8 @@ aero_diagb_weight: {{ aero_diagb_weight | default(1.0, true) }}
 aero_diagb_static_rescale_factor: {{aero_staticb_rescaling_factor | default(1.0, true) }}
 aero_diagb_n_halo: {{ aero_diagb_n_halo  | default(0)  }}
 aero_diagb_n_neighbors: {{ aero_diagb_n_neighbors | default(0) }}
-aero_diagb_smooth_horiz_iter: {{ aero_diagb_smooth_horiz_iters | default(0) }}
-aero_diagb_smooth_vert_iter: {{ aero_diagb_smooth_vert_iters | default(0) }}
+aero_diagb_smooth_horiz_iter: {{ aero_diagb_smooth_horiz_iter | default(0) }}
+aero_diagb_smooth_vert_iter: {{ aero_diagb_smooth_vert_iter | default(0) }}
 aero_diffusion_iter: {{ aero_diffusion_iter | default(0) }}
 aero_diffusion_horiz_len: {{ aero_diffusion_horiz_len  | default(1.0, true)}}
 aero_diffusion_fixed_val: {{ aero_diffusion_fixed_val  | default(1.0, true)}}


### PR DESCRIPTION
# Description

This PR updates the JCB-GDAS hash, which includes resolution changes for the aerosol gaussian increment plus GNSSRO observation YAMLs
