### PR TITLE
add gdas_waveinit to C48mx500_3DVarAOWCDA ctest suite

### DIFF
--- a/test/gw-ci/CMakeLists.txt
+++ b/test/gw-ci/CMakeLists.txt
@@ -359,6 +359,7 @@ if (WORKFLOW_TESTS)
     set(YAML_PATH ${HOMEgfs}/ci/cases/pr/${pslot}.yaml)
     set(HALF_CYCLE_TASKS
       "gdas_stage_ic"
+      "gdas_waveinit"
       "gdas_fcst")
     set(FULL_CYCLE_TASKS
       "gdas_prepoceanobs"


### PR DESCRIPTION
# Description

g-w PR [#3249](https://github.com/NOAA-EMC/global-workflow/pull/3249) added waves to g-w CI case C48mx500_3DVarAOWCDA.  As such, the gdas_waveinit job needs to be added to GDASApp g-w CI testing.

# Companion PRs

none

# Issues

Resolves #1468


# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [x] atm_jjob <!-- JEDI atm single cycle DA !-->
- [x] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [x] C96C48_hybatmaerosnowDA  <!-- JEDI aero/snow cycled DA !-->
- [x] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [x] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [x] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
