### PR TITLE
update spack-stack path in Hera modulefiles

### DIFF
--- a/modulefiles/EVA/hera.lua
+++ b/modulefiles/EVA/hera.lua
@@ -8,7 +8,7 @@ local pkgNameVer = myModuleFullName()
 
 conflict(pkgName)
 
-prepend_path("MODULEPATH", "/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.6.0/envs/unified-env-rocky8/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/contrib/spack-stack//spack-stack-1.6.0/envs/unified-env-rocky8/install/modulefiles/Core")
 load("stack-intel/2021.5.0")
 load("python/3.10.13")
 load("proj/9.2.1")

--- a/modulefiles/GDAS/hera.intel.lua
+++ b/modulefiles/GDAS/hera.intel.lua
@@ -6,7 +6,7 @@ local pkgName    = myModuleName()
 local pkgVersion = myModuleVersion()
 local pkgNameVer = myModuleFullName()
 
-prepend_path("MODULEPATH", '/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.6.0/envs/unified-env-rocky8/install/modulefiles/Core')
+prepend_path("MODULEPATH", '/contrib/spack-stack//spack-stack-1.6.0/envs/unified-env-rocky8/install/modulefiles/Core')
 --prepend_path("MODULEPATH", '/scratch1/NCEPDEV/da/python/opt/modulefiles/stack')
 
 -- below two lines get us access to the spack-stack modules


### PR DESCRIPTION
# Description

The Hera paths for stack-spack are changing from `/scratch1/NCEPDEV/nems/role.epic/spack-stack/` to `/contrib/spack-stack/`.  This PR updates the spack-stack paths in EVA and GDAS Hera modulefiles.

# Companion PRs

none

# Issues

Resolves #1467


# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [x] atm_jjob <!-- JEDI atm single cycle DA !-->
- [x] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [x] C96C48_hybatmaerosnowDA  <!-- JEDI aero/snow cycled DA !-->
- [x] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [x] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [x] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
