### PR TITLE
Bugfix for ensemble recenter + add a test

### DIFF
--- a/parm/soca/berror/soca_ensrecenter.yaml
+++ b/parm/soca/berror/soca_ensrecenter.yaml
@@ -60,5 +60,5 @@ output increment:
   date: '{{ MARINE_WINDOW_END_ISO }}'
   exp: trash
   type: incr
-  output file: 'ocn.recenter.incr.%mem%.nc'
+  output file: 'recenter.incr.%mem%.nc'
   pattern: '%mem%'

--- a/test/gw-ci/CMakeLists.txt
+++ b/test/gw-ci/CMakeLists.txt
@@ -180,6 +180,9 @@ function(add_task task_name test_prefix is_full_cycle HALF_CYCLE FULL_CYCLE pslo
     elseif("${task_name}" STREQUAL "gdas_marineanlletkf")
       list(APPEND TEST_DEPENDS "${test_prefix}_enkfgdas_fcst_${HALF_CYCLE}")
       list(APPEND TEST_DEPENDS "${test_prefix}_gdas_prepoceanobs_${FULL_CYCLE}")
+    elseif("${task_name}" STREQUAL "gdas_ocnanalecen")
+      list(APPEND TEST_DEPENDS "${test_prefix}_gdas_marineanlvar_${FULL_CYCLE}")
+      list(APPEND TEST_DEPENDS "${test_prefix}_gdas_marineanlletkf_${FULL_CYCLE}")
     else()
       list(APPEND TEST_DEPENDS "${test_prefix}")
     endif()
@@ -394,6 +397,7 @@ if (WORKFLOW_TESTS)
       "gdas_marinebmat"
       "gdas_marineanlinit"
       "gdas_marineanlvar"
+      "gdas_ocnanalecen"
       "gdas_marineanlchkpt"
       "gdas_marineanlfinal"
       )

--- a/utils/soca/gdas_ens_handler.h
+++ b/utils/soca/gdas_ens_handler.h
@@ -169,7 +169,7 @@ namespace gdasapp {
           postProcIncr.setToZero(incr);
 
           // Save the increments used to initialize the ensemble forecast
-          result = postProcIncr.save(mom6_incr, i+1);
+          result = postProcIncr.save(mom6_incr, i+1, {"ocn"});
         }
         return result;
       }


### PR DESCRIPTION
# Description

Bugfix for ensemble recenter; adds a gw-ci test for recenter as well.

# Companion PRs

Required for https://github.com/NOAA-EMC/global-workflow/pull/3238

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmaerosnowDA  <!-- JEDI aero/snow cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [x] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
