### PR TITLE
add LD_LIBRARY_PATH patch for wcoss2 build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -89,6 +89,11 @@ esac
 
 CMAKE_OPTS+=" -DCLONE_JCSDADATA=$CLONE_JCSDADATA -DMACHINE=$BUILD_TARGET"
 
+# TODO: Remove LD_LIBRARY_PATH line as soon as permanent solution is available
+if [[ $BUILD_TARGET == 'wcoss2' ]]; then
+    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/opt/cray/pe/mpich/8.1.19/ofi/intel/19.0/lib"
+fi
+
 BUILD_DIR=${BUILD_DIR:-$dir_root/build}
 if [[ $CLEAN_BUILD == 'YES' ]]; then
   [[ -d ${BUILD_DIR} ]] && rm -rf ${BUILD_DIR}


### PR DESCRIPTION
# Description

This PR fixes a problem with the GDASApp build on WCOSS2 following implementation of RFC 13644.


# Companion PRs

None

# Issues

Resolves #1482


# Automated CI tests to run in Global Workflow
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmaerosnowDA  <!-- JEDI aero/snow cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [ ] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
