### PR TITLE
Update to soca that significantly improves memory/runtime

### DIFF
--- a/utils/soca/gdas_ens_handler.h
+++ b/utils/soca/gdas_ens_handler.h
@@ -230,8 +230,7 @@ namespace gdasapp {
 
         // Save total ssh
         oops::Log::info() << "ssh ensemble member "  << i << std::endl;
-        soca::Increment ssh_tmp(geomOut, socaSshVar, postProcIncr.dt_);
-        ssh_tmp = ensMembers[i];
+        soca::Increment ssh_tmp(socaSshVar, ensMembers[i]);
         sshTotal.push_back(ssh_tmp);
 
         // Zero out ssh and other specified fields
@@ -242,8 +241,8 @@ namespace gdasapp {
         // Compute the original steric height perturbation from T and S
         eckit::LocalConfiguration stericConfig(fullConfig, "steric height");
         postProcIncr.applyLinVarChange(incr, stericConfig, ensMeanTraj);
-        ssh_tmp = incr;
-        sshSteric.push_back(ssh_tmp);
+        soca::Increment ssh_tmp2(socaSshVar, incr);
+        sshSteric.push_back(ssh_tmp2);
 
         // Compute unbalanced ssh
         ssh_tmp = sshTotal[i];


### PR DESCRIPTION
# Description

This update goes with https://github.com/JCSDA-internal/soca/pull/1130 that refactors data storage in soca, reduces memory footprint and more carefully handles halos and intermediate variables in soca states and increments.

The update in the gdas-utils here changes how we create an increment with a subset of variables, since assigning increments with different variables is now prohibited. 

I ran both low- and high- res hybrid experiments and confirmed that all the tasks (bmat, envar, letkf, recenter, chkpt) behave as expected, and all the differences are explained (and are a sign of better code in the branch). The differences in the logs are: removal of some intermediate variables that were not used in some states; fixes of scrambled data in some intermediate variables. The netcdf output produced by all of those tasks is the same as with develop with the exception of ice.ssh_recentering_error files that are not used (it’s the ice files) but on develop have garbage in the ice variables.

Differences in runtime and memory (hera/intel, 0.25 degree case):
EnVar:
```
dev:         Runtime: 413.73 sec, Memory: total: 685.13 Gb
soca branch: Runtime: 372.81 sec, Memory: total: 470.56 Gb
```
LETKF:
```
dev:         Runtime: 2305.72 sec, Memory: total: 4333.59 Gb
soca branch: Runtime: 2264.41 sec, Memory: total: 1910.04 Gb
```

The soca tag will need to change once soca PR is merged.

# Companion PRs

https://github.com/JCSDA-internal/soca/pull/1130

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmaerosnowDA  <!-- JEDI aero/snow cycled DA !-->
- [x] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [x] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
