### PR TITLE
Update to soca changes that significantly improve memory/runtime

### DIFF
--- a/utils/soca/gdas_ens_handler.h
+++ b/utils/soca/gdas_ens_handler.h
@@ -230,8 +230,7 @@ namespace gdasapp {
 
         // Save total ssh
         oops::Log::info() << "ssh ensemble member "  << i << std::endl;
-        soca::Increment ssh_tmp(geomOut, socaSshVar, postProcIncr.dt_);
-        ssh_tmp = ensMembers[i];
+        soca::Increment ssh_tmp(socaSshVar, ensMembers[i]);
         sshTotal.push_back(ssh_tmp);
 
         // Zero out ssh and other specified fields
@@ -242,8 +241,8 @@ namespace gdasapp {
         // Compute the original steric height perturbation from T and S
         eckit::LocalConfiguration stericConfig(fullConfig, "steric height");
         postProcIncr.applyLinVarChange(incr, stericConfig, ensMeanTraj);
-        ssh_tmp = incr;
-        sshSteric.push_back(ssh_tmp);
+        soca::Increment ssh_tmp2(socaSshVar, incr);
+        sshSteric.push_back(ssh_tmp2);
 
         // Compute unbalanced ssh
         ssh_tmp = sshTotal[i];


### PR DESCRIPTION
# Description

See description of GDASApp PR #1505

# Companion PRs

This PR replaces GDASApp PR #1505

# Issues


# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmaerosnowDA  <!-- JEDI aero/snow cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [ ] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
