### PR TITLE
correct logic for upper loop limit in chem_diagb

### DIFF
--- a/utils/chem/chem_diagb.h
+++ b/utils/chem/chem_diagb.h
@@ -189,7 +189,7 @@ namespace gdasapp {
             auto stdDevBkg = atlas::array::make_view<double, 2>(bkgErrFs[var]);
 
             // Loops through nodes and levels
-            for (atlas::idx_t level = 0; level <= xbFs[var].shape(1); ++level) {
+            for (atlas::idx_t level = 0; level < xbFs[var].shape(1); ++level) {
               for (atlas::idx_t jnode = 0; jnode < xbFs[var].shape(0); ++jnode) {
                 std::vector<double> local;
                 auto neighbors = get_neighbors_of_node(jnode);


### PR DESCRIPTION
# Description

This PR modifies the logic used to specify the upper loop limit in the horizontal smoothing section of `utils/chem/chem_diagb.h`.  Less than or equal, `<=`, is replaced by less than, `<`


# Companion PRs

none

# Issues

Resolves #1515

# Automated CI tests to run in Global Workflow
- [x] C96C48_hybatmaerosnowDA  <!-- JEDI aero/snow cycled DA !-->