### PR TITLE
Save marine background and analysis spread

### DIFF
--- a/parm/soca/letkf/letkf_save.yaml.j2
+++ b/parm/soca/letkf/letkf_save.yaml.j2
@@ -1,10 +1,10 @@
 {% set PDY = current_cycle | to_YMD %}
 {% set cyc = current_cycle | strftime("%H") %}
 {% set timestr = WINDOW_BEGIN | to_isotime %}
+{% set antimestr = WINDOW_MIDDLE | to_isotime %}
 ######################################
 # save letkf analysis to comout
 ######################################
-
 copy:
 {% for mem in range(1, NMEM_ENS + 1) %}
    {% set tmpl_dict = {'${ROTDIR}':ROTDIR,
@@ -18,3 +18,11 @@ copy:
    - ["{{ DATA }}/letkf_output/ocn.letkf.ens.{{ mem }}.{{ timestr }}.PT3H.nc", "{{ COMOUT_OCEAN_LETKF_MEM }}/{{ GDUMP_ENS }}.ocean.t{{ cyc }}z.analysis.nc"]
    - ["{{ DATA }}/letkf_output/ice.letkf.ens.{{ mem }}.{{ timestr }}.PT3H.nc", "{{ COMOUT_ICE_LETKF_MEM }}/{{ GDUMP_ENS }}.ice.t{{ cyc }}z.analysis.nc"]
 {% endfor %}
+# Save LETKF background mean and background and analysis variance
+# TODO: save analysis mean when it's output by LETKF
+   - ["{{ DATA }}/letkf_output/ocn.letkf.mean_prior.fc.{{ timestr }}.PT3H.nc", "{{ COMOUT_OCEAN_LETKF }}/{{ GDUMP_ENS }}.ocean.t{{ cyc }}z.ensmean_prior.nc"]
+   - ["{{ DATA }}/letkf_output/ice.letkf.mean_prior.fc.{{ timestr }}.PT3H.nc", "{{ COMOUT_OCEAN_LETKF }}/{{ GDUMP_ENS }}.ice.t{{ cyc }}z.ensmean_prior.nc"]
+   - ["{{ DATA }}/letkf_output/ocn.letkf.var_prior.fc.{{ timestr }}.PT3H.nc", "{{ COMOUT_OCEAN_LETKF }}/{{ GDUMP_ENS }}.ocean.t{{ cyc }}z.ensvar_prior.nc"]
+   - ["{{ DATA }}/letkf_output/ice.letkf.var_prior.fc.{{ timestr }}.PT3H.nc", "{{ COMOUT_OCEAN_LETKF }}/{{ GDUMP_ENS }}.ice.t{{ cyc }}z.ensvar_prior.nc"]
+   - ["{{ DATA }}/letkf_output/ocn.letkf.var_post.an.{{ antimestr }}.nc", "{{ COMOUT_OCEAN_LETKF }}/{{ GDUMP_ENS }}.ocean.t{{ cyc }}z.ensvar_post.nc"]
+   - ["{{ DATA }}/letkf_output/ice.letkf.var_post.an.{{ antimestr }}.nc", "{{ COMOUT_OCEAN_LETKF }}/{{ GDUMP_ENS }}.ice.t{{ cyc }}z.ensvar_post.nc"]


### PR DESCRIPTION
# Description

Saves LETKF background and analysis variance and background mean. This useful both for LETKF diagnostics, and for v17 spread diagnostics.

# Companion PRs

Depends on https://github.com/NOAA-EMC/global-workflow/pull/3407. Intentionally, gw PR does not depend on this one, so best to wait till gw is merged before merging this. I'm keeping this as draft till then.

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmaerosnowDA  <!-- JEDI aero/snow cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [x] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
