### PR TITLE
New jcb-gdas # and insitu obs prep bug fix 

### DIFF
--- a/parm/soca/obsprep/obsprep_config.yaml
+++ b/parm/soca/obsprep/obsprep_config.yaml
@@ -237,6 +237,10 @@ observations:
     provider: GTS
     dmpdir subdir: atmos
     type: bufr
+    error ratio: 0.4
+    window:
+       back: 4
+       forward: 4
     dmpdir regex: 'gdas.*.bathy.*.bufr_d'
 
 - obs space:
@@ -244,7 +248,7 @@ observations:
     provider: GTS
     dmpdir subdir: atmos
     type: bufr
-    error ratio: 0.4 
+    error ratio: 0.4
     window:
        back: 4
        forward: 4
@@ -255,7 +259,7 @@ observations:
     provider: GTS
     dmpdir subdir: atmos
     type: bufr
-    error ratio: 0.4 
+    error ratio: 0.4
     window:
        back: 4
        forward: 4
@@ -266,6 +270,10 @@ observations:
     provider: GTS
     dmpdir subdir: atmos
     type: bufr
+    error ratio: 0.4
+    window:
+       back: 4
+       forward: 4
     dmpdir regex: 'gdas.*.subpfl.*.bufr_d'
 
 - obs space:
@@ -273,6 +281,10 @@ observations:
     provider: GTS
     dmpdir subdir: atmos
     type: bufr
+    error ratio: 0.4
+    window:
+       back: 4
+       forward: 4
     dmpdir regex: 'gdas.*.tesac.*.bufr_d'
 
 - obs space:
@@ -280,6 +292,10 @@ observations:
     provider: GTS
     dmpdir subdir: atmos
     type: bufr
+    error ratio: 0.4
+    window:
+       back: 4
+       forward: 4
     dmpdir regex: 'gdas.*.tesac.*.bufr_d'
 
 - obs space:
@@ -287,6 +303,10 @@ observations:
     provider: GTS
     dmpdir subdir: atmos
     type: bufr
+    error ratio: 0.4
+    window:
+       back: 4
+       forward: 4
     dmpdir regex: 'gdas.*.xbtctd.*.bufr_d'
 
 - obs space:
@@ -294,6 +314,10 @@ observations:
     provider: GTS
     dmpdir subdir: atmos
     type: bufr
+    error ratio: 0.4
+    window:
+       back: 4
+       forward: 4
     dmpdir regex: 'gdas.*.altkob.*.bufr_d'
 
 - obs space:
@@ -301,6 +325,10 @@ observations:
     provider: GTS
     dmpdir subdir: atmos
     type: bufr
+    error ratio: 0.4
+    window:
+       back: 4
+       forward: 4
     dmpdir regex: 'gdas.*.trkob.*.bufr_d'
 
 # in situ: daily
@@ -309,6 +337,10 @@ observations:
     provider: GTS
     dmpdir subdir: atmos
     type: bufr
+    error ratio: 0.4
+    window:
+       back: 4
+       forward: 4
     dmpdir regex: 'gdas.*.dbuoy.*.bufr_d'
 
 - obs space:
@@ -316,6 +348,10 @@ observations:
     provider: GTS
     dmpdir subdir: atmos
     type: bufr
+    error ratio: 0.4
+    window:
+       back: 4
+       forward: 4
     dmpdir regex: 'gdas.*.dbuoyb.*.bufr_d'
 
 - obs space:
@@ -323,6 +359,10 @@ observations:
     provider: GTS
     dmpdir subdir: atmos
     type: bufr
+    error ratio: 0.4
+    window:
+       back: 4
+       forward: 4
     dmpdir regex: 'gdas.*.mbuoy.*.bufr_d'
 
 - obs space:
@@ -330,6 +370,10 @@ observations:
     provider: GTS
     dmpdir subdir: atmos
     type: bufr
+    error ratio: 0.4
+    window:
+       back: 4
+       forward: 4
     dmpdir regex: 'gdas.*.mbuoyb.*.bufr_d'
 
 - obs space:
@@ -337,6 +381,10 @@ observations:
     provider: GTS
     dmpdir subdir: atmos
     type: bufr
+    error ratio: 0.4
+    window:
+       back: 4
+       forward: 4
     dmpdir regex: 'gdas.*.dbuoy.*.bufr_d'
 
 - obs space:
@@ -344,4 +392,8 @@ observations:
     provider: GTS
     dmpdir subdir: atmos
     type: bufr
+    error ratio: 0.4
+    window:
+       back: 4
+       forward: 4
     dmpdir regex: 'gdas.*.dbuoy.*.bufr_d'


### PR DESCRIPTION
# Description
- added the overlapping window configuration to all insitu obs
- updated the `jcb-gdas` commit (forgotten in #1511)

# Issues
- fixes #1521 

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmaerosnowDA  <!-- JEDI aero/snow cycled DA !-->
- [x] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [x] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
