### PR TITLE
add --force option to create_experiment.py in create_exp.sh

### DIFF
--- a/ci/run_ci.sh
+++ b/ci/run_ci.sh
@@ -93,17 +93,13 @@ fi
 # run ctests
 
 # PATCH START
-# g-w setup_xml.py checks if the user can write to HOMEDIR, PTMP, and STMP
-# g-w defaults these directories to global filesets. Hera role.jedipara and
-# MSU role-da do not belong to the global group. The logic below changes
-# the default paths that role.jedipara and role-da can write to.
-if [[ "${TARGET}" = "hera" ]]; then
-    echo "***WARNING*** apply HERA global-->da patch to $workflow_dir/workflow/hosts/${TARGET}.yaml"
-    sed -i "s|/scratch1/NCEPDEV/global/\${USER}|/scratch1/NCEPDEV/da/\${USER}|g" $workflow_dir/workflow/hosts/${TARGET}.yaml
-fi
+# MSU role-da can not use /work/noaa/stmp at present. The logic below
+# modifies the stmp path used by g-w so that role-da can run g-w based
+# ctests. This logic will be removed after MSU role-da is added to the
+# stmp group.
 if [[ "${TARGET}" = "orion" || "${TARGET}" = "hercules" ]]; then
-    echo "***WARNING*** apply ${TARGET} global-->da patch to $workflow_dir/workflow/hosts/${TARGET}.yaml"
-    sed -i "s|work2/noaa/global/\${USER}|work2/noaa/da/\${USER}|g" $workflow_dir/workflow/hosts/${TARGET}.yaml
+    echo "***WARNING*** apply MSU stmp patch to $workflow_dir/workflow/hosts/${TARGET}.yaml"
+    sed -i "s|/noaa/stmp|/noaa/da|g" $workflow_dir/workflow/hosts/${TARGET}.yaml
 fi
 # PATCH END
 

--- a/ci/run_ci.sh
+++ b/ci/run_ci.sh
@@ -101,13 +101,8 @@ if [[ "${TARGET}" = "hera" ]]; then
     echo "***WARNING*** apply HERA global-->da patch to $workflow_dir/workflow/hosts/${TARGET}.yaml"
     sed -i "s|/scratch1/NCEPDEV/global/\${USER}|/scratch1/NCEPDEV/da/\${USER}|g" $workflow_dir/workflow/hosts/${TARGET}.yaml
 fi
-if [[ "${TARGET}" = "orion" ]]; then
-    echo "***WARNING*** apply ORION global-->da patch to $workflow_dir/workflow/hosts/${TARGET}.yaml"
-    sed -i "s|work/noaa/global/\${USER}|work/noaa/da/\${USER}|g" $workflow_dir/workflow/hosts/${TARGET}.yaml
-    sed -i "s|work/noaa/stmp/\${USER}|work/noaa/da/\${USER}|g"   $workflow_dir/workflow/hosts/${TARGET}.yaml
-fi
-if [[ "${TARGET}" = "hercules" ]]; then
-    echo "***WARNING*** apply HERCULES global-->da patch to $workflow_dir/workflow/hosts/${TARGET}.yaml"
+if [[ "${TARGET}" = "orion" || "${TARGET}" = "hercules" ]]; then
+    echo "***WARNING*** apply ${TARGET} global-->da patch to $workflow_dir/workflow/hosts/${TARGET}.yaml"
     sed -i "s|work2/noaa/global/\${USER}|work2/noaa/da/\${USER}|g" $workflow_dir/workflow/hosts/${TARGET}.yaml
 fi
 # PATCH END

--- a/ci/run_ci.sh
+++ b/ci/run_ci.sh
@@ -93,13 +93,22 @@ fi
 # run ctests
 
 # PATCH START
-# MSU role-da can not use /work/noaa/stmp at present. The logic below
-# modifies the stmp path used by g-w so that role-da can run g-w based
-# ctests. This logic will be removed after MSU role-da is added to the
-# stmp group.
-if [[ "${TARGET}" = "orion" || "${TARGET}" = "hercules" ]]; then
-    echo "***WARNING*** apply MSU stmp patch to $workflow_dir/workflow/hosts/${TARGET}.yaml"
-    sed -i "s|/noaa/stmp|/noaa/da|g" $workflow_dir/workflow/hosts/${TARGET}.yaml
+# g-w setup_xml.py checks if the user can write to HOMEDIR, PTMP, and STMP
+# g-w defaults these directories to global filesets. Hera role.jedipara and
+# MSU role-da do not belong to the global group. The logic below changes
+# the default paths that role.jedipara and role-da can write to.
+if [[ "${TARGET}" = "hera" ]]; then
+    echo "***WARNING*** apply HERA global-->da patch to $workflow_dir/workflow/hosts/${TARGET}.yaml"
+    sed -i "s|/scratch1/NCEPDEV/global/\${USER}|/scratch1/NCEPDEV/da/\${USER}|g" $workflow_dir/workflow/hosts/${TARGET}.yaml
+fi
+if [[ "${TARGET}" = "orion" ]]; then
+    echo "***WARNING*** apply ORION global-->da patch to $workflow_dir/workflow/hosts/${TARGET}.yaml"
+    sed -i "s|work/noaa/global/\${USER}|work/noaa/da/\${USER}|g" $workflow_dir/workflow/hosts/${TARGET}.yaml
+    sed -i "s|work/noaa/stmp/\${USER}|work/noaa/da/\${USER}|g"   $workflow_dir/workflow/hosts/${TARGET}.yaml
+fi
+if [[ "${TARGET}" = "hercules" ]]; then
+    echo "***WARNING*** apply HERCULES global-->da patch to $workflow_dir/workflow/hosts/${TARGET}.yaml"
+    sed -i "s|work2/noaa/global/\${USER}|work2/noaa/da/\${USER}|g" $workflow_dir/workflow/hosts/${TARGET}.yaml
 fi
 # PATCH END
 

--- a/test/gw-ci/create_exp.sh
+++ b/test/gw-ci/create_exp.sh
@@ -21,4 +21,4 @@ fi
 source ${HOMEgfs}/workflow/gw_setup.sh
 
 # Create the experiment
-${HOMEgfs}/workflow/create_experiment.py --yaml ${expyaml} --overwrite
+${HOMEgfs}/workflow/create_experiment.py --yaml ${expyaml} --overwrite --force


### PR DESCRIPTION
# Description

This PR adds logic to `ci/run_ci.sh` to modify select paths on various machines for g-w user writability checks.

# Companion PRs

None

# Issues

Resolves #1545


# Automated CI tests to run in Global Workflow
- [x] atm_jjob <!-- JEDI atm single cycle DA !-->
- [x] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [x] C96C48_hybatmaerosnowDA  <!-- JEDI aero/snow cycled DA !-->
- [x] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [x] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [x] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
