### PR TITLE
apply ci path patch only when running g-w ctests

### DIFF
--- a/ci/run_ci.sh
+++ b/ci/run_ci.sh
@@ -96,13 +96,15 @@ fi
 # HERA role.jedipara can not use /scratch1/NCEPDEV/global. MSU role-da
 # can not use /work2/noaa/global. The logic below modifies the paths so
 # role.jedipara and role-da can run g-w based ctests.
-if [[ "${TARGET}" = "hera" ]]; then
+if [[ $TEST_WORKFLOW == 1 ]]; then
+  if [[ "${TARGET}" = "hera" ]]; then
     echo "***WARNING*** apply ${TARGET} global-->da patch to $workflow_dir/workflow/hosts/${TARGET}.yaml"
     sed -i "s|/scratch1/NCEPDEV/global/\${USER}|/scratch1/NCEPDEV/da/\${USER}|g" $workflow_dir/workflow/hosts/${TARGET}.yaml
-fi
-if [[ "${TARGET}" = "orion" || "${TARGET}" = "hercules" ]]; then
+  fi
+  if [[ "${TARGET}" = "orion" || "${TARGET}" = "hercules" ]]; then
     echo "***WARNING*** apply MSU stmp patch to $workflow_dir/workflow/hosts/${TARGET}.yaml"
     sed -i "s|/work2/noaa/global/\${USER}|/work2/noaa/da/\${USER}|g" $workflow_dir/workflow/hosts/${TARGET}.yaml
+  fi
 fi
 # PATCH END
 


### PR DESCRIPTION
# Description

This PR resolves an undefined variable bug in `ci/run_ci.sh`

# Companion PRs

None

# Issues

Resolves #1553

# Automated CI tests to run in Global Workflow

- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmaerosnowDA  <!-- JEDI aero/snow cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [ ] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
