### PR TITLE
Bugfix ocean ensemble recentering

### DIFF
--- a/utils/soca/gdas_ens_handler.h
+++ b/utils/soca/gdas_ens_handler.h
@@ -146,6 +146,7 @@ namespace gdasapp {
       soca::Increment recenteringIncr(geomOut, postProcIncr.socaIncrVar_, postProcIncr.dt_);
       recenteringIncr.diff(determTraj, ensMeanTraj);
       postProcIncr.setToZero(recenteringIncr);
+      oops::Log::info() << "recentering incr: " << recenteringIncr << std::endl;
 
       // Check if we're only re-centering the ensemble fcst around the det.
       bool recenterOnly = fullConfig.getBool("recentering around deterministic", false);
@@ -156,16 +157,12 @@ namespace gdasapp {
         oops::Log::info() << "Only recentering " << std::endl;
         int result = 0;
         for (size_t i = 0; i < postProcIncr.ensSize_; ++i) {
-          // make a copy of the ens. member
-          soca::Increment incr(ensMembers[i]);
-
-          // Add the recentering increment
-          incr += recenteringIncr;
-          oops::Log::info() << "recentered incr " << i << ":" << incr << std::endl;
+          // make a copy of the recentering increment
+          soca::Increment incr(recenteringIncr);
 
           // Append the vertical geometry (for MOM6 IAU)
           soca::Increment mom6_incr = postProcIncr.appendLayer(incr);
-          oops::Log::info() << "incr " << i << ":" << mom6_incr << std::endl;
+          oops::Log::info() << "recentering incr " << i << ":" << mom6_incr << std::endl;
 
           // Set variables to zero if specified in the configuration
           postProcIncr.setToZero(incr);


### PR DESCRIPTION
# Description

Ocean ensemble recentering was double-counting ensemble perturbations, effectively inflating the ensemble by a factor of 2 (almost, the extra perturbation was added with IAU, so some of it was probably damped). The accumulation of amplified perturbations over several cycles may have been the cause of ensemble forecast failures in gfsv17 trial experiments.

On develop:
IAU increment for ocean recentering = (det-mean) + (ensmember-mean).

In this branch:
IAU increment for ocean recentering = (det-mean)

With this branch, as expected, IAU increments passed to the ocean model are all the same, pulling from the mean towards deterministic background.
Tested with C48 one cycle, compared IAU increments and looked through the logs.

# Issues

Resolves https://github.com/NOAA-EMC/GDASApp/issues/1557

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmaerosnowDA  <!-- JEDI aero/snow cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [x] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
