### PR TITLE
Save LETKF mean analysis and mean increment for verification

### DIFF
--- a/parm/soca/letkf/letkf_save.yaml.j2
+++ b/parm/soca/letkf/letkf_save.yaml.j2
@@ -18,11 +18,14 @@ copy:
    - ["{{ DATA }}/letkf_output/ocn.letkf.ens.{{ mem }}.{{ timestr }}.PT3H.nc", "{{ COMOUT_OCEAN_LETKF_MEM }}/{{ GDUMP_ENS }}.ocean.t{{ cyc }}z.analysis.nc"]
    - ["{{ DATA }}/letkf_output/ice.letkf.ens.{{ mem }}.{{ timestr }}.PT3H.nc", "{{ COMOUT_ICE_LETKF_MEM }}/{{ GDUMP_ENS }}.ice.t{{ cyc }}z.analysis.nc"]
 {% endfor %}
-# Save LETKF background mean and background and analysis variance
-# TODO: save analysis mean when it's output by LETKF
+# Save LETKF background and analysis mean and variance, mean analysis increment
    - ["{{ DATA }}/letkf_output/ocn.letkf.mean_prior.fc.{{ timestr }}.PT3H.nc", "{{ COMOUT_OCEAN_LETKF }}/{{ GDUMP_ENS }}.ocean.t{{ cyc }}z.ensmean_prior.nc"]
    - ["{{ DATA }}/letkf_output/ice.letkf.mean_prior.fc.{{ timestr }}.PT3H.nc", "{{ COMOUT_OCEAN_LETKF }}/{{ GDUMP_ENS }}.ice.t{{ cyc }}z.ensmean_prior.nc"]
    - ["{{ DATA }}/letkf_output/ocn.letkf.var_prior.fc.{{ timestr }}.PT3H.nc", "{{ COMOUT_OCEAN_LETKF }}/{{ GDUMP_ENS }}.ocean.t{{ cyc }}z.ensvar_prior.nc"]
    - ["{{ DATA }}/letkf_output/ice.letkf.var_prior.fc.{{ timestr }}.PT3H.nc", "{{ COMOUT_OCEAN_LETKF }}/{{ GDUMP_ENS }}.ice.t{{ cyc }}z.ensvar_prior.nc"]
+   - ["{{ DATA }}/letkf_output/ocn.letkf.ens.0.{{ timestr }}.PT3H.nc", "{{ COMOUT_OCEAN_LETKF }}/{{ GDUMP_ENS }}.ocean.t{{ cyc }}z.ensmean_post.nc"]
+   - ["{{ DATA }}/letkf_output/ice.letkf.ens.0.{{ timestr }}.PT3H.nc", "{{ COMOUT_OCEAN_LETKF }}/{{ GDUMP_ENS }}.ice.t{{ cyc }}z.ensmean_post.nc"]
    - ["{{ DATA }}/letkf_output/ocn.letkf.var_post.an.{{ antimestr }}.nc", "{{ COMOUT_OCEAN_LETKF }}/{{ GDUMP_ENS }}.ocean.t{{ cyc }}z.ensvar_post.nc"]
    - ["{{ DATA }}/letkf_output/ice.letkf.var_post.an.{{ antimestr }}.nc", "{{ COMOUT_OCEAN_LETKF }}/{{ GDUMP_ENS }}.ice.t{{ cyc }}z.ensvar_post.nc"]
+   - ["{{ DATA }}/letkf_output/ocn.letkf.inc.ens.0.{{ timestr }}.PT3H.nc", "{{ COMOUT_OCEAN_LETKF }}/{{ GDUMP_ENS }}.ocean.t{{ cyc }}z.ensmean_incr.nc"]
+   - ["{{ DATA }}/letkf_output/ice.letkf.inc.ens.0.{{ timestr }}.PT3H.nc", "{{ COMOUT_OCEAN_LETKF }}/{{ GDUMP_ENS }}.ice.t{{ cyc }}z.ensmean_incr.nc"]


### PR DESCRIPTION
# Description

Save LETKF mean analysis and mean increment -- useful for the verification and diagnostics. (See https://github.com/NOAA-EMC/gdas-marine-viz/pull/511 for sample plots).

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmaerosnowDA  <!-- JEDI aero/snow cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [x] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
