### PR TITLE
Update OCEAN_BASIN_FILE_ORION for marine ctest (#1568)

### DIFF
--- a/test/marine/CMakeLists.txt
+++ b/test/marine/CMakeLists.txt
@@ -101,7 +101,7 @@ else()
 		"/scratch2/NCEPDEV/ocean/Guillaume.Vernieres/data/static/common/RECCAP2_region_masks_all_v20221025.nc"
 	)
 	set(OCEAN_BASIN_FILE_ORION
-		"/work/noaa/global/glopara/fix/gdas/soca/20240802/common/RECCAP2_region_masks_all_v20221025.nc"
+		"/work2/noaa/global/role-global/fix/gdas/soca/20240802/common/RECCAP2_region_masks_all_v20221025.nc"
 	)
 	CHECK_AND_SET_PATH(
 		${OCEAN_BASIN_FILE_ORION} 


### PR DESCRIPTION
# Description

Update the path to `OCEAN_BASIN_FILE_ORION` in marine ctests.  This change brings GDASApp into consistency with the change merged into g-w `develop` via PR [#3488](https://github.com/NOAA-EMC/global-workflow/pull/3488)

# Companion PRs

Required by g-w PR [#3488](https://github.com/NOAA-EMC/global-workflow/pull/3488)

# Issues

Resolves #1568

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmaerosnowDA  <!-- JEDI aero/snow cycled DA !-->
- [x] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [x] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
