### PR TITLE
bugfix for paths

### DIFF
--- a/parm/aero/jcb-base.yaml.j2
+++ b/parm/aero/jcb-base.yaml.j2
@@ -74,8 +74,8 @@ aero_background_error_time_iso:  "{{ background_time | to_isotime }}"
 aero_background_error_time_fv3: "{{ background_time | to_fv3time }}"
 
 # Background error
-aero_berror_data_directory: "{{ DATA }}/berror"
-aero_berror_diffusion_directory: "{{ DATA }}/diffusion"
+aero_berror_data_directory: ./berror
+aero_berror_diffusion_directory: ./diffusion
 aero_standard_deviation_path: ./stddev
 aero_climatological_b_path: ./clm_stddev
 aero_rescale_b_path: ./rescale


### PR DESCRIPTION
# Description

Aero diffusion paths were absolute, FMS hates paths > 128 characters, so this is now made to be relative paths in the YAML

# Companion PRs

None

# Issues

Resolves #1580 


# Automated CI tests to run in Global Workflow
meh, none
