### PR TITLE
Update to ecbuild/3.8.2 in github actions

### DIFF
--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -36,7 +36,7 @@ jobs:
       run: |
         git clone https://github.com/ecmwf/ecbuild.git ecbuild
         cd ecbuild
-        git checkout 3.6.1
+        git checkout 3.8.2
         mkdir bootstrap
         cd bootstrap
         ../bin/ecbuild ..

--- a/.github/workflows/unittests_g-w.yaml
+++ b/.github/workflows/unittests_g-w.yaml
@@ -47,7 +47,7 @@ jobs:
       run: |
         git clone https://github.com/ecmwf/ecbuild.git ecbuild
         cd ecbuild
-        git checkout 3.6.1
+        git checkout 3.8.2
         mkdir bootstrap
         cd bootstrap
         ../bin/ecbuild ..


### PR DESCRIPTION
# Description

This PR updates the `ecbuild` version in github actions unittests and unittests_g-w from `ecbuild/3.6.1` to `ecbuild/3.8.2`

# Companion PRs

None

# Issues

None


# Automated CI tests to run in Global Workflow

No need to run any of the tests below.  This PR only affects github actions.

- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmaerosnowDA  <!-- JEDI aero/snow cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [ ] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
