### PR TITLE
More soca obsstats: obs error and ens spread

### DIFF
--- a/utils/soca/gdassoca_obsstats.h
+++ b/utils/soca/gdassoca_obsstats.h
@@ -52,6 +52,9 @@ namespace gdasapp {
       std::vector<eckit::LocalConfiguration> obsSpaces;
       fullConfig.get("obs spaces", obsSpaces);
 
+      // get ensemble size if available
+      size_t nens = fullConfig.getInt("nens", 0);
+
       // only the serial case works for now.
       ASSERT(getComm().size() == 1);
 
@@ -75,9 +78,9 @@ namespace gdasapp {
         ioda::ObsSpace ospace(obsConfig, getComm(), timeWindow, getComm());
         const size_t nlocs = ospace.nlocs();
         oops::Log::info() << "nlocs =" << nlocs << std::endl;
-        std::vector<float> var(nlocs);
+        std::vector<float> omb(nlocs);
         std::string group = "ombg";
-        ospace.get_db(group, variable, var);
+        ospace.get_db(group, variable, omb);
 
         // ocean basin partitioning
         std::vector<int> oceanBasins(nlocs);
@@ -88,13 +91,43 @@ namespace gdasapp {
         }
         ospace.get_db("MetaData", "oceanBasin", oceanBasins);
 
+        // obs error
+        // pre-qc obs errors are not saved: overwrite with zeroes
+        std::vector<float> obserr_preqc(nlocs, 0.0);
+        std::vector<float> obserr_postqc(nlocs);
+        ospace.get_db("EffectiveError0", variable, obserr_postqc);
+        // compute spread in the ensemble space
+        std::vector<float> ensspread(nlocs, 0.0);
+        std::vector<float> ensmean(nlocs, 0.0);
+        // iterative variance and mean calculation
+        for (size_t jens = 0; jens < nens; jens++) {
+          std::vector<float> enspert(nlocs);
+          std::string group = "hofx0_" + std::to_string(jens+1);
+          oops::Log::info() << " reading member " << jens << " : " << group << std::endl;
+          ospace.get_db(group, variable, enspert);
+          for (size_t jloc = 0; jloc < nlocs; jloc++) {
+            enspert[jloc] -= ensmean[jloc];
+            ensspread[jloc] += enspert[jloc] * enspert[jloc] *
+                            static_cast<double>(jens)/static_cast<double>(jens+1);
+            enspert[jloc] *= 1.0/static_cast<double>(jens+1);
+            ensmean[jloc] += enspert[jloc];
+          }
+        }
+        // Normalize variance and compute spread
+        // spread = sqrt( 1 / (N-1) * var)
+        if (nens > 0) {
+          for (size_t jloc = 0; jloc < nlocs; jloc++) {
+            ensspread[jloc] = std::sqrt(ensspread[jloc] * 1.0/static_cast<double>(nens-1));
+          }
+        }
+
         // Open an ofstream for output and write header
         std::string expId;
         obsSpace.get("experiment identifier", expId);
         std::string fileName;
         obsSpace.get("csv output", fileName);
         std::ofstream outputFile(fileName);
-        outputFile << "Exp,Variable,Ocean,date,RMSE,Bias,Count\n";
+        outputFile << "Exp,Variable,Ocean,date,RMSE,Bias,ObsErr,EnsStd,Count\n";
 
         // get the date
         int dateint = extractDateFromFilename(obsFile);
@@ -104,13 +137,14 @@ namespace gdasapp {
         std::string varname = group+"_noqc";
         std::vector<int> PreQC(nlocs);
         ospace.get_db("PreQC", variable, PreQC);
-        stats(var, oceanBasins, PreQC, outputFile, varname, dateint, expId);
+        stats(omb, obserr_preqc, ensspread, oceanBasins, PreQC, outputFile, varname, dateint,
+              expId);
 
         oops::Log::info() << "========= Effective QC" << std::endl;
         varname = group+"_qc";
         std::vector<int> eQC(nlocs);
         ospace.get_db("EffectiveQC1", variable, eQC);
-        stats(var, oceanBasins, eQC, outputFile, varname, dateint, expId);
+        stats(omb, obserr_postqc, ensspread, oceanBasins, eQC, outputFile, varname, dateint, expId);
 
         // Close the file
         outputFile.close();
@@ -123,6 +157,8 @@ namespace gdasapp {
 
     // -----------------------------------------------------------------------------
     void stats(const std::vector<float>& ombg,
+               const std::vector<float>& obserr,
+               const std::vector<float>& ensspread,
                const std::vector<int>& oceanBasins,
                const std::vector<int>& qc,
                std::ofstream& outputFile,
@@ -131,11 +167,15 @@ namespace gdasapp {
                const std::string expId) const {
       float rmseGlobal(0.0);
       float biasGlobal(0.0);
+      float obserrGlobal(0.0);
+      float ensspreadGlobal(0.0);
       int cntGlobal(0);
 
       for (const auto& ocean : oceans_) {
         float rmse(0.0);
         float bias(0.0);
+        float obserr_ocean(0.0);
+        float ensspread_ocean(0.0);
         int cnt(0);
         for (size_t i = 0; i < ombg.size(); ++i) {
           if (ombg[i] != fillVal_ &&
@@ -143,15 +183,21 @@ namespace gdasapp {
               qc[i] == 0) {
             rmse += std::pow(ombg[i], 2);
             bias += ombg[i];
+            obserr_ocean += obserr[i];
+            ensspread_ocean += ensspread[i];
             cnt += 1;
           }
         }
         if (cnt > 0) {  // Ensure division by cnt is valid
           rmseGlobal += rmse;
           biasGlobal += bias;
+          obserrGlobal += obserr_ocean;
+          ensspreadGlobal += ensspread_ocean;
           cntGlobal += cnt;
           rmse = std::sqrt(rmse / cnt);
           bias = bias / cnt;
+          obserr_ocean = obserr_ocean / cnt;
+          ensspread_ocean = ensspread_ocean / cnt;
 
           outputFile << expId << ","
                      << varname << ","
@@ -159,6 +205,8 @@ namespace gdasapp {
                      << dateint << ","
                      << rmse << ","
                      << bias << ","
+                     << obserr_ocean << ","
+                     << ensspread_ocean << ","
                      << cnt << "\n";
         }
       }
@@ -169,6 +217,8 @@ namespace gdasapp {
                    << dateint << ","
                    << std::sqrt(rmseGlobal / cntGlobal) << ","
                    << biasGlobal / cntGlobal << ","
+                   << obserrGlobal / cntGlobal << ","
+                   << ensspreadGlobal / cntGlobal << ","
                    << cntGlobal << "\n";
       }
     }


### PR DESCRIPTION
# Description

Adds obs error and ensemble spread in the obs space (if `nens` in yaml is larger than zero) to soca_obsstats.

An example output from letkf diags:
```
Exp,Variable,Ocean,date,RMSE,Bias,ObsErr,EnsStd,Count
C384mx025_hybAOWCDA,ombg_noqc,Arctic,2021070100,0.960433,0.00573102,0,0.0610415,2187
C384mx025_hybAOWCDA,ombg_noqc,Atlantic,2021070100,0.566898,-0.178547,0,0.0303036,26547
C384mx025_hybAOWCDA,ombg_noqc,Indian,2021070100,0.30812,0.000771846,0,0.0101121,10609
C384mx025_hybAOWCDA,ombg_noqc,Pacific,2021070100,0.646843,-0.0638578,0,0.0372161,24481
C384mx025_hybAOWCDA,ombg_noqc,Southern,2021070100,0.595513,-0.0129378,0,0.00961472,24614
C384mx025_hybAOWCDA,ombg_noqc,Global,2021070100,0.58753,-0.074639,0,0.0247969,88438
C384mx025_hybAOWCDA,ombg_qc,Arctic,2021070100,1.02619,-0.4097,0.417517,0.0632539,27
C384mx025_hybAOWCDA,ombg_qc,Atlantic,2021070100,0.470863,-0.168855,0.283,0.0288453,24685
C384mx025_hybAOWCDA,ombg_qc,Indian,2021070100,0.273696,-0.00689263,0.334229,0.0101664,9712
C384mx025_hybAOWCDA,ombg_qc,Pacific,2021070100,0.452282,-0.0771499,0.318417,0.035428,21103
C384mx025_hybAOWCDA,ombg_qc,Southern,2021070100,0.555977,-0.0968242,0.340004,0.0101257,20151
C384mx025_hybAOWCDA,ombg_qc,Global,2021070100,0.470805,-0.103404,0.314677,0.0233115,75678
```

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmaerosnowDA  <!-- JEDI aero/snow cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [x] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
