### PR TITLE
Enable gw-ci tests if WORKFLOW_TESTS is ON

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -117,7 +117,9 @@ add_test(NAME test_gdasapp_check_yaml_keys
 
 if (${BUILD_GDASBUNDLE})
   add_subdirectory(snow)      # snow da tests
-  add_subdirectory(gw-ci)   # subset of the global-workflow ci tests
+  if (WORKFLOW_TESTS)
+    add_subdirectory(gw-ci)   # subset of the global-workflow ci tests
+  endif()
 endif()
 
 # gdas atm tests


### PR DESCRIPTION
# Description
This PR:
- enables `gw-ci` tests when `WORKFLOW_TESTS=ON`

# Issues
Resolves #1601 

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmaerosnowDA  <!-- JEDI aero/snow cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [ ] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
