### PR TITLE
Add marine ensemble variance output to recentering task

### DIFF
--- a/parm/soca/berror/soca_ensrecenter.yaml
+++ b/parm/soca/berror/soca_ensrecenter.yaml
@@ -117,3 +117,9 @@ output increment:
   type: incr
   output file: 'recenter.incr.%mem%.nc'
   pattern: '%mem%'
+
+ensemble variance output:
+  datadir: ./
+  date: '{{ MARINE_WINDOW_BEGIN_ISO }}'
+  exp: ensvar
+  type: incr

--- a/parm/soca/berror/soca_ensrecenter.yaml
+++ b/parm/soca/berror/soca_ensrecenter.yaml
@@ -120,6 +120,6 @@ output increment:
 
 ensemble variance output:
   datadir: ./
-  date: '{{ MARINE_WINDOW_BEGIN_ISO }}'
+  date: '{{ MARINE_WINDOW_END_ISO }}'
   exp: ensvar
   type: incr

--- a/ush/soca/marine_recenter.py
+++ b/ush/soca/marine_recenter.py
@@ -263,7 +263,28 @@ class MarineRecenter(Task):
             mem_dir_list.append(mem_dir_real)
             copy_list.append([f'ocn.recenter.incr.{str(mem)}.nc',
                               os.path.join(mem_dir_real, incr_file)])
-
+        # Copy the ensemble variance
+        ensvar_date = self.task_config.MARINE_WINDOW_END.strftime('%Y-%m-%dT%H:%M:%SZ')
+        stats_dir = os.path.join(self.task_config.ROTDIR,
+                                 f'enkf{RUN}.{PDYstr}',
+                                 f'{cyc}',
+                                 'ensstat',
+                                 'analysis',
+                                 'ocean')
+        stats_dir_real = os.path.realpath(stats_dir)
+        mem_dir_list.append(stats_dir_real)
+        copy_list.append([f'ocn.ensvar.incr.{ensvar_date}.nc',
+                         os.path.join(stats_dir_real, f'enkf{RUN}.t{cyc}z.ocn.bg_ensvar.nc')])
+        stats_dir = os.path.join(self.task_config.ROTDIR,
+                                 f'enkf{RUN}.{PDYstr}',
+                                 f'{cyc}',
+                                 'ensstat',
+                                 'analysis',
+                                 'ice')
+        stats_dir_real = os.path.realpath(stats_dir)
+        mem_dir_list.append(stats_dir_real)
+        copy_list.append([f'ice.ensvar.incr.{ensvar_date}.nc',
+                         os.path.join(stats_dir_real, f'enkf{RUN}.t{cyc}z.ice.bg_ensvar.nc')])
         FileHandler({'mkdir': mem_dir_list}).sync()
         FileHandler({'copy': copy_list}).sync()
 

--- a/utils/soca/gdas_ens_handler.h
+++ b/utils/soca/gdas_ens_handler.h
@@ -125,7 +125,10 @@ namespace gdasapp {
         const eckit::LocalConfiguration ensMeanOutputConfig(fullConfig, "ensemble mean output");
         ensMean.write(ensMeanOutputConfig);
       }
-
+      if ( fullConfig.has("ensemble variance output") ) {
+        const eckit::LocalConfiguration ensVarianceOutputConfig(fullConfig, "ensemble variance output");
+        ensVariance.write(ensVarianceOutputConfig);
+      }
       // Remove mean from ensemble members
       for (size_t i = 0; i < postProcIncr.ensSize_; ++i) {
         oops::Log::info() << " demean member " << i << std::endl;

--- a/utils/soca/gdas_ens_handler.h
+++ b/utils/soca/gdas_ens_handler.h
@@ -126,7 +126,8 @@ namespace gdasapp {
         ensMean.write(ensMeanOutputConfig);
       }
       if ( fullConfig.has("ensemble variance output") ) {
-        const eckit::LocalConfiguration ensVarianceOutputConfig(fullConfig, "ensemble variance output");
+        const eckit::LocalConfiguration ensVarianceOutputConfig(fullConfig,
+                                                                "ensemble variance output");
         ensVariance.write(ensVarianceOutputConfig);
       }
       // Remove mean from ensemble members


### PR DESCRIPTION
# Description

Adds marine ensemble variance output to the recentering task, so we can monitor ensemble spread even in the ensemble experiments without LETKF.

The background ensemble variance for the ?? cycle is saved in `enkfgdas.*/??/ensstat/analysis/ocean/` and `enkfgdas.*/??/ensstat/analysis/ice/` directories.

# Issues

Resolves #1540 

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmaerosnowDA  <!-- JEDI aero/snow cycled DA !-->
- [x] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [x] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
