### PR TITLE
Remove duplicate copying of ensemble members from marine recenter task

### DIFF
--- a/ush/soca/marine_recenter.py
+++ b/ush/soca/marine_recenter.py
@@ -127,9 +127,6 @@ class MarineRecenter(Task):
         # stage backgrounds
         bkg_list = parse_j2yaml(self.task_config.MARINE_DET_STAGE_BKG_YAML_TMPL, self.task_config)
         FileHandler(bkg_list).sync()
-        # stage ensemble backgrounds for soca2cice
-        ens_bkg_list = parse_j2yaml(self.task_config.MARINE_ENSDA_STAGE_BKG_YAML_TMPL, self.task_config)
-        FileHandler(ens_bkg_list).sync()
 
         ################################################################################
         # stage ensemble members


### PR DESCRIPTION
# Description

In https://github.com/NOAA-EMC/GDASApp/pull/1479 I introduced a duplicate copy of ensemble members to marine recentering task by mistake. This PR removes that.

I didn't test this as thoroughly as I normally would. Below is what I ran to test (for both of the low-res tests I made sure that both rundir and comdir were completely wiped out before I started the tests):
- all tests in C48mx500_hybAOWCDA up to and including ocnanalecen -- tests passed
- all tests in C48mx500_hybAOWCDA up to and including ocnanalecen except for the letkf one (to mimic retro runs) -- tests passed
- introduced this change in my high-res 30-member ensemble experiment that runs LETKF -- task completed successfully, 33 min instead of 38 min for the previous cycle.

# Issues

Resolves #1613 

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmaerosnowDA  <!-- JEDI aero/snow cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [x] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
