### PR TITLE
Renames ensemble statistics files

### DIFF
--- a/ush/soca/marine_recenter.py
+++ b/ush/soca/marine_recenter.py
@@ -271,7 +271,7 @@ class MarineRecenter(Task):
         stats_dir_real = os.path.realpath(stats_dir)
         mem_dir_list.append(stats_dir_real)
         copy_list.append([f'ocn.ensvar.incr.{ensvar_date}.nc',
-                         os.path.join(stats_dir_real, f'enkf{RUN}.t{cyc}z.ocn.bg_ensvar.nc')])
+                         os.path.join(stats_dir_real, f'enkf{RUN}.ocean.t{cyc}z.bg_ensvar.nc')])
         stats_dir = os.path.join(self.task_config.ROTDIR,
                                  f'enkf{RUN}.{PDYstr}',
                                  f'{cyc}',
@@ -281,7 +281,7 @@ class MarineRecenter(Task):
         stats_dir_real = os.path.realpath(stats_dir)
         mem_dir_list.append(stats_dir_real)
         copy_list.append([f'ice.ensvar.incr.{ensvar_date}.nc',
-                         os.path.join(stats_dir_real, f'enkf{RUN}.t{cyc}z.ice.bg_ensvar.nc')])
+                         os.path.join(stats_dir_real, f'enkf{RUN}.ice.t{cyc}z.bg_ensvar.nc')])
         FileHandler({'mkdir': mem_dir_list}).sync()
         FileHandler({'copy': copy_list}).sync()
 


### PR DESCRIPTION
# Description

Renames bg_ensvar files to match global-workflow conventions.

# Issues

https://github.com/NOAA-EMC/GDASApp/issues/1651

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmaerosnowDA  <!-- JEDI aero/snow cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [x] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
