### PR TITLE
apply updates to Gdapapp/land-jediincr to limit max snow increments

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -59,7 +59,7 @@
   branch = develop
 [submodule "sorc/land-jediincr"]
   path = sorc/land-jediincr
-  url = https://github.com/NOAA-PSL/land-apply_jedi_incr.git
+  url = https://github.com/NOAA-EMC/land-apply_jedi_incr.git
   branch = develop
 [submodule "sorc/crtm"]
   path = sorc/crtm

--- a/test/snow/apply_jedi_incr.sh
+++ b/test/snow/apply_jedi_incr.sh
@@ -34,12 +34,17 @@ fi
 
 GFSv17=${GFSv17:-"NO"}
 
+frac_grid=.false.
+if [[ $GFSv17 == "YES" ]]; then
+    frac_grid=.true.
+fi
+
 cat << EOF > apply_incr_nml
 &noahmp_snow
  date_str=${YY}${MM}${DD}
  hour_str=$HH
  res=$RES
- frac_grid=$GFSv17
+ frac_grid=$frac_grid
  rst_path="$WORKDIR",
  inc_path="$WORKDIR",
  orog_path="$TPATH"


### PR DESCRIPTION
# Description

This PR updates GDASApp/land-jediincr to limit positive snow depth increments when background SND exceeds a threshod value. Also enables running the add increment code on more than 6 procs.

# Companion PRs

[GW#3645](https://github.com/NOAA-EMC/global-workflow/pull/3645)

# Issues
Resolves [PSL#8](https://github.com/NOAA-PSL/land-apply_jedi_incr/issues/8)

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [x] C96C48_hybatmaerosnowDA  <!-- JEDI aero/snow cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [ ] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
