### PR TITLE
fixes bug

### DIFF
--- a/ush/ioda/bufr2ioda/marine/b2i/b2iconverter/ocean.py
+++ b/ush/ioda/bufr2ioda/marine/b2i/b2iconverter/ocean.py
@@ -61,10 +61,10 @@ class OceanBasin:
         dlon = self.__longitudes[1] - self.__longitudes[0]
 
         # the data may be a masked array
-        ocean_basin = []
+        ocean_basin = ma.array([0]*lat.size, mask=lat.mask, dtype=np.int32)
         for i in range(n):
-            if not ma.is_masked(lat[i]):
+            if not ma.is_masked(lat[i]) and not ma.is_masked(lon[i]):
                 i1 = round((lat[i] - lat0) / dlat)
                 i2 = round((lon[i] - lon0) / dlon)
-                ocean_basin.append(self.__basin_array[i1][i2])
+                ocean_basin[i] = self.__basin_array[i1][i2]
         return ocean_basin


### PR DESCRIPTION
# Description
fixes the bug where ocean basin array may be of incorrect size. 
<!-- -->

# Companion PRs

<!-- Enter links to any companion PRs here. -->

# Issues

<!-- Enter any issues referenced or resolved by this PR here. Use keywords "Resolves" or "Refs".
Resolves #1234
Refs #4321
Refs NOAA-EMC/repo#5678
-->

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmaerosnowDA  <!-- JEDI aero/snow cycled DA !-->
- [x] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [ ] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
