### PR TITLE
update parm/config path 

### DIFF
--- a/prototypes/gen_prototype.sh
+++ b/prototypes/gen_prototype.sh
@@ -93,7 +93,7 @@ cd $GWDIR/global-workflow/workflow
                            --resensatmos $resensatmos \
                            --nens $nens \
                            --pslot $PSLOT \
-                           --configdir $GWDIR/global-workflow/parm/config/gfs \
+                           --configdir $GWDIR/global-workflow/dev/parm/config/gfs \
                            --comrot $comrot \
                            --expdir $expdir \
                            --icsdir $ICSDIR \

--- a/test/aero/global-workflow/jjob_var_init.sh
+++ b/test/aero/global-workflow/jjob_var_init.sh
@@ -27,7 +27,7 @@ export COM_TOP=$ROTDIR
 
 # Set GFS COM paths
 source "${HOMEgfs}/ush/preamble.sh"
-source "${HOMEgfs}/parm/config/gfs/config.com"
+source "${HOMEgfs}/dev/parm/config/gfs/config.com"
 
 # Set python path for workflow utilities and tasks
 wxflowPATH="${HOMEgfs}/ush/python"

--- a/test/aero/global-workflow/setup_workflow_exp.sh
+++ b/test/aero/global-workflow/setup_workflow_exp.sh
@@ -14,7 +14,7 @@ resdetatmos='48'
 resensatmos='48'
 nens=0
 pslot='gdas_test'
-configdir=$srcdir/../../parm/config/gfs
+configdir=$srcdir/../../dev/parm/config/gfs
 comroot=$bindir/test/aero/global-workflow/testrun/ROTDIRS
 expdir=$bindir/test/aero/global-workflow/testrun/experiments
 

--- a/test/atm/global-workflow/jjob_ens_init.sh
+++ b/test/atm/global-workflow/jjob_ens_init.sh
@@ -27,7 +27,7 @@ export ACCOUNT=da-cpu
 # Set GFS COM paths
 export STRICT="NO"
 source "${HOMEgfs}/ush/preamble.sh"
-source "${HOMEgfs}/parm/config/gfs/config.com"
+source "${HOMEgfs}/dev/parm/config/gfs/config.com"
 
 # Set python path for workflow utilities and tasks
 wxflowPATH="${HOMEgfs}/ush/python"

--- a/test/atm/global-workflow/jjob_ens_init_split.sh
+++ b/test/atm/global-workflow/jjob_ens_init_split.sh
@@ -27,7 +27,7 @@ export ACCOUNT=da-cpu
 # Set GFS COM paths
 export STRICT="NO"
 source "${HOMEgfs}/ush/preamble.sh"
-source "${HOMEgfs}/parm/config/gfs/config.com"
+source "${HOMEgfs}/dev/parm/config/gfs/config.com"
 
 # Set python path for workflow utilities and tasks
 wxflowPATH="${HOMEgfs}/ush/python"

--- a/test/atm/global-workflow/jjob_var_init.sh
+++ b/test/atm/global-workflow/jjob_var_init.sh
@@ -27,7 +27,7 @@ export ACCOUNT=da-cpu
 # Set GFS COM paths
 export STRICT="NO"
 source "${HOMEgfs}/ush/preamble.sh"
-source "${HOMEgfs}/parm/config/gfs/config.com"
+source "${HOMEgfs}/dev/parm/config/gfs/config.com"
 
 # Set python path for workflow utilities and tasks
 wxflowPATH="${HOMEgfs}/ush/python"

--- a/test/atm/global-workflow/setup_workflow_exp.sh
+++ b/test/atm/global-workflow/setup_workflow_exp.sh
@@ -15,7 +15,7 @@ resdetatmos='48'
 resensatmos='48'
 nens=3
 pslot='gdas_test'
-configdir=$srcdir/../../parm/config/gfs
+configdir=$srcdir/../../dev/parm/config/gfs
 comroot=$bindir/test/atm/global-workflow/testrun/ROTDIRS
 expdir=$bindir/test/atm/global-workflow/testrun/experiments
 

--- a/test/setup_workflow_exp.sh
+++ b/test/setup_workflow_exp.sh
@@ -13,7 +13,7 @@ resdetatmos='48'
 resensatmos='48'
 nens=0
 pslot='gdas_test'
-configdir=$srcdir/../../parm/config/gfs
+configdir=$srcdir/../../dev/parm/config/gfs
 comroot=$bindir/test/testrun/ROTDIRS
 expdir=$bindir/test/testrun/experiments
 

--- a/ush/soca/run_jjobs.py
+++ b/ush/soca/run_jjobs.py
@@ -103,7 +103,7 @@ class JobCard:
         """
 
         # Make a copy of the configs
-        origconfig = "${HOMEgfs}/parm/config/gfs"
+        origconfig = "${HOMEgfs}/dev/parm/config/gfs"
         self.f.write("\n")
         self.f.write("# Make a copy of config\n")
         self.f.write(f"mkdir -p config\n")
@@ -175,7 +175,7 @@ class JobCard:
         print(f"RUN: {self.RUN}")
 
         # setup COM variables
-        self.f.write("source ${HOMEgfs}/parm/config/gfs/config.com\n")
+        self.f.write("source ${HOMEgfs}/dev/parm/config/gfs/config.com\n")
         self.f.write("source ${HOMEgfs}/ush/preamble.sh\n")
         self.precom('COM_OCEAN_HISTORY_PREV', 'COM_OCEAN_HISTORY_TMPL')
         self.precom('COM_ICE_HISTORY_PREV', 'COM_ICE_HISTORY_TMPL')


### PR DESCRIPTION
# Description

This PR updates the path to g-w `parm/config` files from `$HOMEgfs/parm/config` to `$HOMEgfs/dev/parm/config`.  g-w PR [#3684](https://github.com/NOAA-EMC/global-workflow/pull/3684) changed the path.  This PR updates GDASApp to be consistent with g-w.

# Companion PRs

none

# Issues

Resolves #1692


# Automated CI tests to run in Global Workflow
- [x] atm_jjob <!-- JEDI atm single cycle DA !-->
- [x] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [x] C96C48_hybatmaerosnowDA  <!-- JEDI aero/snow cycled DA !-->
- [x] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [x] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [x] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
