### PR TITLE
Changes to fix anlstat job

### DIFF
--- a/parm/soca/jcb-base.yaml.j2
+++ b/parm/soca/jcb-base.yaml.j2
@@ -75,10 +75,10 @@ marine_obsdatastats_path: '{{COMOUT_OCEAN_ANALYSIS}}/diags'
 
 marine_obsdatain_path: '{{DATA}}/obs'
 marine_obsdatain_prefix: '{{OPREFIX}}'
-marine_obsdatain_suffix: '.{{ PDY | to_YMD }}{{ "%02d"| format(cyc) }}.nc4'
+marine_obsdatain_suffix: '.{{ current_cycle | to_YMDH }}.nc4'
 marine_obsdataout_path: '{{DATA}}/diags'
 marine_obsdataout_prefix: ''
-marine_obsdataout_suffix: '.{{ PDY | to_YMD }}{{ "%02d"| format(cyc) }}.nc4'
+marine_obsdataout_suffix: '.{{ current_cycle | to_YMDH }}.nc4'
 
 # Outer loops
 marine_ninner_1: '{{SOCA_NINNER}}'


### PR DESCRIPTION
# Description

Make required changes for https://github.com/NOAA-EMC/global-workflow/pull/3642 to work.

1. Small change to the marine JCB base yaml to be consistent with the other domain's JCB base yamls.
2. Update jcb-gdas hash in order to have more templates available for snow for the `anlstat` job.

# Companion PRs

https://github.com/NOAA-EMC/global-workflow/pull/3642

# Issues

https://github.com/NOAA-EMC/global-workflow/issues/2931

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmaerosnowDA  <!-- JEDI aero/snow cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [ ] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
