### PR TITLE
Quick fix for the stationElevation data type issues

### DIFF
--- a/parm/snow/obs/config/bufr_sfcsno_mapping.yaml
+++ b/parm/snow/obs/config/bufr_sfcsno_mapping.yaml
@@ -20,6 +20,7 @@ bufr:
 
     stationElevation:
       query: "[*/SELV, */HSMSL]"
+      type: float
 
     # ObsValue
     totalSnowDepth:


### PR DESCRIPTION
# Description

This PR adds the data type (float) for Meta data `stationElevation` to fix the issue of different data type between tac and bufr format. 

# Companion PRs

<!-- Enter links to any companion PRs here. -->

# Issues

Resolves #1710


# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmaerosnowDA  <!-- JEDI aero/snow cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [ ] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
