### PR TITLE
QC ocean increment (part 2)

### DIFF
--- a/utils/soca/diagb/gdas_soca_diagb.h
+++ b/utils/soca/diagb/gdas_soca_diagb.h
@@ -34,6 +34,7 @@
 #include "soca/State/State.h"
 
 #include "gdas_soca_diagb_utils.h"
+#include "../gdas_soca_utils.h"
 
 namespace gdasapp {
 
@@ -114,24 +115,9 @@ class SocaDiagB : public oops::Application {
     auto viewHocn = atlas::array::make_view<double, 2>(xbFs["sea_water_cell_thickness"]);
     atlas::array::ArrayT<double> depth(viewHocn.shape(0), viewHocn.shape(1));
     auto viewDepth = atlas::array::make_view<double, 2>(depth);
-
-    for (atlas::idx_t jnode = 0; jnode < depth.shape(0); ++jnode) {
-      viewDepth(jnode, 0) = 0.5 * viewHocn(jnode, 0);
-      for (atlas::idx_t level = 1; level < depth.shape(1); ++level) {
-        viewDepth(jnode, level) = viewDepth(jnode, level - 1)
-                                  + 0.5 * (viewHocn(jnode, level - 1) + viewHocn(jnode, level));
-      }
-    }
-
     atlas::array::ArrayT<double> bathy(viewHocn.shape(0), 1);
     auto viewBathy = atlas::array::make_view<double, 2>(bathy);
-    for (atlas::idx_t jnode = 0; jnode < viewHocn.shape(0); ++jnode) {
-      viewBathy(jnode, 0) = std::accumulate(&viewHocn(jnode, 0),
-                                            &viewHocn(jnode, 0) + viewHocn.shape(1), 0.0);
-    }
-
-    // Update the layer thickness halo
-    nodeColumns.haloExchange(xbFs["sea_water_cell_thickness"]);
+    gdasapp::utils::computeDepthAndBathymetry(viewHocn, viewDepth, viewBathy);
 
     // -- Step 7: Iterative stencil-based variance computation --
     soca::Increment dynaBkgErr(xb);

--- a/utils/soca/diagb/gdas_soca_diagb.h
+++ b/utils/soca/diagb/gdas_soca_diagb.h
@@ -33,8 +33,8 @@
 #include "soca/Increment/Increment.h"
 #include "soca/State/State.h"
 
-#include "gdas_soca_diagb_utils.h"
 #include "../gdas_soca_utils.h"
+#include "gdas_soca_diagb_utils.h"
 
 namespace gdasapp {
 

--- a/utils/soca/gdas_incr_handler.h
+++ b/utils/soca/gdas_incr_handler.h
@@ -77,7 +77,7 @@ namespace gdasapp {
           fullConfig.get("qc increment", qcConfig);
           qcConfig.get("background", xbConfig);
           soca::State xb(geom, xbConfig);
-          gdasapp::qcIncrement(xb, incr_mom6, qcConfig);
+          postProcIncr.qcIncrement(xb, incr_mom6, qcConfig, geom);
           oops::Log::debug() << "========= after QC:" << std::endl;
           oops::Log::debug() << incr_mom6 << std::endl;
         }

--- a/utils/soca/gdas_incr_qc.h
+++ b/utils/soca/gdas_incr_qc.h
@@ -14,7 +14,33 @@
 #include "soca/Increment/Increment.h"
 #include "soca/State/State.h"
 
+#include "gdas_soca_utils.h"
+
 namespace gdasapp {
+namespace qcIncrement {
+
+/**
+ * @brief Adjusts an analysis increment to ensure the resulting value stays within specified bounds.
+ *
+ * This function takes a background value and an increment, then checks if applying the increment
+ * would result in a value outside the specified bounds. If so, it modifies the increment to
+ * ensure the final analysis value remains within the allowed range.
+ *
+ * @param xB The background or base value
+ * @param dX The proposed increment to apply to the background value
+ * @param minBound The minimum allowed value for the resulting analysis
+ * @param maxBound The maximum allowed value for the resulting analysis
+ * @return The adjusted increment that, when added to xB, will keep the result within [minBound, maxBound]
+ */
+double adjustAnalysisBounds(double xB, double dX, double minBound, double maxBound) {
+  double xA = xB + dX;
+  if (xA < minBound) {
+    return minBound - xB;
+  } else if (xA > maxBound) {
+    return maxBound - xB;
+  }
+  return dX;
+}
 
 /**
  * @brief Quality control for increments: ensures that the analysis (xb + dx) remains within physical bounds.
@@ -25,7 +51,8 @@ namespace gdasapp {
  */
 void qcIncrement(const soca::State& xb,
                  soca::Increment& dx,
-                 const eckit::Configuration& config) {
+                 const eckit::Configuration& config,
+                 const soca::Geometry& geom) {
   oops::Log::info() << "==========================================" << std::endl;
   oops::Log::info() << "======      Quality control on increment" << std::endl;
 
@@ -33,7 +60,18 @@ void qcIncrement(const soca::State& xb,
   xb.toFieldSet(xbFs);
   dx.toFieldSet(dxFs);
 
-  // Define physical bounds per state variable
+  // Compute ocean depth and bathymetry
+  auto viewHocn = atlas::array::make_view<double, 2>(xbFs["sea_water_cell_thickness"]);
+  atlas::array::ArrayT<double> depth(viewHocn.shape(0), viewHocn.shape(1));
+  auto viewDepth = atlas::array::make_view<double, 2>(depth);
+  atlas::array::ArrayT<double> bathy(viewHocn.shape(0), 1);
+  auto viewBathy = atlas::array::make_view<double, 2>(bathy);
+  gdasapp::utils::computeDepthAndBathymetry(viewHocn, viewDepth, viewBathy);
+
+  // Get ghost nodes
+  const auto ghostView = atlas::array::make_view<int, 1>(geom.functionSpace().ghost());
+
+  // Get the physical bounds from configuration
   std::vector<double> tempBounds(2);
   config.get("state bounds.sea_water_potential_temperature", tempBounds);
   std::vector<double> saltBounds(2);
@@ -42,6 +80,52 @@ void qcIncrement(const soca::State& xb,
     {"sea_water_potential_temperature", {tempBounds[0], tempBounds[1]}},
     {"sea_water_salinity", {saltBounds[0], saltBounds[1]}},
   };
+
+  // Get increment bounds from configuration
+  double deltaSshMax = config.getDouble("increment max.steric", 10.0);
+  oops::Log::debug() << "QC: max steric height increment: " << deltaSshMax << std::endl;
+
+  // Limit the steric height incrememnt to deltaSshMax
+  auto viewTempIncr = atlas::array::make_view<double, 2>(dxFs["sea_water_potential_temperature"]);
+  auto viewSaltIncr = atlas::array::make_view<double, 2>(dxFs["sea_water_salinity"]);
+  auto viewSshIncr = atlas::array::make_view<double, 2>(dxFs["sea_surface_height_above_geoid"]);
+  for (atlas::idx_t jnode = 0; jnode < viewTempIncr.shape(0); ++jnode) {
+    // Skip ghost and land nodes
+    if (ghostView(jnode) > 0) continue;
+    if (viewBathy(jnode, 0) <= 0.0) continue;
+
+    // Extract temp and salt profiles at this node
+    const atlas::idx_t nlevels = viewTempIncr.shape(1);
+    std::vector<double> tempIncr(nlevels);
+    std::vector<double> saltIncr(nlevels);
+    std::vector<double> layerThickness(nlevels);
+
+    if (std::abs(viewSshIncr(jnode, 0)) > deltaSshMax) {
+      // Linearity assumption for steric height increment
+      double rescale = deltaSshMax / std::abs(viewSshIncr(jnode, 0));
+      for (atlas::idx_t level = 0; level < nlevels; ++level) {
+        viewTempIncr(jnode, level) *= rescale;
+        viewSaltIncr(jnode, level) *= rescale;
+        tempIncr[level] = viewTempIncr(jnode, level);
+        saltIncr[level] = viewSaltIncr(jnode, level);
+        layerThickness[level] = viewHocn(jnode, level);
+      }
+
+      // Compute the approximate steric height increment
+      double stericHeight = gdasapp::utils::computeStericHeight(tempIncr,
+                                                                saltIncr,
+                                                                layerThickness);
+      double sshIncr = viewSshIncr(jnode, 0);
+      oops::Log::debug() << "QC: steric height increment at node " << jnode << ": "
+                         << stericHeight << " ssh incr: " << viewSshIncr(jnode, 0) << std::endl;
+      oops::Log::debug() << "QC: ssh increment at node " << jnode << ": " << viewSshIncr(jnode, 0)
+                         << " rescaling Temp/Salt by: " << rescale
+                         << " steric height ~ " << stericHeight << std::endl;
+
+      // Refelct the changes in the ssh increment
+      viewSshIncr(jnode, 0) = deltaSshMax;
+    }
+  }
 
   // Brute force bounds check
   for (auto& field : dxFs) {
@@ -56,20 +140,31 @@ void qcIncrement(const soca::State& xb,
     const double maxBound = stateBounds.at(name).second;
 
     for (atlas::idx_t jnode = 0; jnode < dxView.shape(0); ++jnode) {
+      // Skip ghost and land nodes
+      if (ghostView(jnode) > 0) continue;
+      if (viewBathy(jnode, 0) <= 0.0) continue;
+
       for (atlas::idx_t level = 0; level < dxView.shape(1); ++level) {
+        // Check if the analysis is within bounds
         double xB = xbView(jnode, level);
         double dX = dxView(jnode, level);
-        double xA = xB + dX;
-        if (xA < minBound) {
-          dxView(jnode, level) = minBound - xB;
-        } else if (xA > maxBound) {
-          dxView(jnode, level) = maxBound - xB;
+
+        // Adust the increment to keep analysis within bounds
+        dxView(jnode, level) = adjustAnalysisBounds(xbView(jnode, level), dX, minBound, maxBound);
+
+        // Log if the increment was adjusted
+        if (dxView(jnode, level) != dX) {
+          oops::Log::debug() << "QC: " << name << " at node " << jnode
+                            << ", level " << level << ": "
+                            << "original increment " << dX
+                            << ", adjusted increment " << dxView(jnode, level)
+                            << std::endl;
         }
       }
     }
   }
-
   dx.fromFieldSet(dxFs);
-}
-
+  oops::Log::info() << "======      Finished quality control on increment" << std::endl;
+  }
+}  // namespace qcIncrement
 }  // namespace gdasapp

--- a/utils/soca/gdas_incr_qc.h
+++ b/utils/soca/gdas_incr_qc.h
@@ -122,7 +122,7 @@ void qcIncrement(const soca::State& xb,
                          << " rescaling Temp/Salt by: " << rescale
                          << " steric height ~ " << stericHeight << std::endl;
 
-      // Refelct the changes in the ssh increment
+      // Reflect the changes in the ssh increment
       viewSshIncr(jnode, 0) = deltaSshMax;
     }
   }

--- a/utils/soca/gdas_postprocincr.h
+++ b/utils/soca/gdas_postprocincr.h
@@ -271,15 +271,17 @@ class PostProcIncr {
    * @param xb The background state.
    * @param dx The increment to QC. Will be modified in place.
    * @param config The configuration containing bounds information.
+   * @param geom The soca geometry
    */
   void qcIncrement(const soca::State& xb,
                    soca::Increment& dx,
-                   const eckit::Configuration& config) const {
+                   const eckit::Configuration& config,
+                   const soca::Geometry& geom) const {
     oops::Log::info() << "==========================================" << std::endl;
     oops::Log::info() << "======      Quality control on increment" << std::endl;
 
     // Perform quality control on the increment
-    gdasapp::qcIncrement(xb, dx, config);
+    gdasapp::qcIncrement::qcIncrement(xb, dx, config, geom);
     oops::Log::info() << " in qc increment:" << dx << std::endl;
   }
 

--- a/utils/soca/gdas_soca_utils.h
+++ b/utils/soca/gdas_soca_utils.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <cassert>
+#include <cmath>
+#include <vector>
+
+namespace gdasapp {
+namespace utils {
+
+  // Constants
+  constexpr double alpha = 2.0e-4;       // Thermal expansion coefficient [1/K]
+  constexpr double beta  = 7.6e-4;       // Haline contraction coefficient [1/psu]
+
+  /**
+   * @brief Computes ocean depth and bathymetry from ocean thickness values
+   *
+   * This function calculates:
+   * 1. Depth at of the center of each layers
+   * 2. Bathymetry as the total sum of ocean thickness values at each node
+   *
+   * @param viewHocn 2D array view containing ocean thickness values [nodes × levels]
+   *
+   * @return std::pair of ArrayViews containing:
+   *         - first: Computed depth values at each level [nodes × levels]
+   *         - second: Computed bathymetry values [nodes × 1]
+   */
+
+void computeDepthAndBathymetry(
+    const atlas::array::ArrayView<double, 2>& viewHocn,
+    atlas::array::ArrayView<double, 2>& viewDepth,
+    atlas::array::ArrayView<double, 2>& viewBathy) {
+
+    // Compute depth values
+    for (atlas::idx_t jnode = 0; jnode < viewDepth.shape(0); ++jnode) {
+        viewDepth(jnode, 0) = 0.5 * viewHocn(jnode, 0);
+        for (atlas::idx_t level = 1; level < viewDepth.shape(1); ++level) {
+            viewDepth(jnode, level) = viewDepth(jnode, level - 1)
+                                    + 0.5 * (viewHocn(jnode, level - 1) + viewHocn(jnode, level));
+        }
+    }
+
+    // Compute bathymetry values
+    for (atlas::idx_t jnode = 0; jnode < viewHocn.shape(0); ++jnode) {
+        viewBathy(jnode, 0) = std::accumulate(&viewHocn(jnode, 0),
+                                          &viewHocn(jnode, 0) + viewHocn.shape(1), 0.0);
+    }
+}
+
+/**
+ * @brief Compute steric height increment from temperature/salinity increments and layer thickness.
+ *
+ * @param tempIncr        Temperature increment profile [°C]
+ * @param saltIncr        Salinity increment profile [psu]
+ * @param layerThickness  Layer thickness profile [m]
+ * @return approximate steric height increment [m]
+ */
+inline double computeStericHeight(const std::vector<double> &tempIncr,
+                                  const std::vector<double> &saltIncr,
+                                  const std::vector<double> &layerThickness) {
+  assert(tempIncr.size() == saltIncr.size());
+  assert(saltIncr.size() == layerThickness.size());
+
+  double stericHeightIncr = 0.0;
+
+  for (size_t k = 0; k < tempIncr.size(); ++k) {
+    // dH = (-alpha * dT + beta * dS) * dz
+    stericHeightIncr += (alpha * tempIncr[k] - beta * saltIncr[k]) * layerThickness[k];
+  }
+
+  return stericHeightIncr;
+}
+
+}  // namespace utils
+}  // namespace gdasapp


### PR DESCRIPTION
# Description
Re-scale T & S if the ssh incr is larger than a specified value.

# Issues
- fixes #1720 

# Automated CI tests to run in Global Workflow
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmaerosnowDA  <!-- JEDI aero/snow cycled DA !-->
- [x] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [ ] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
