### PR TITLE
Increment QC part 3

### DIFF
--- a/utils/obsproc/rtofs/util.cc
+++ b/utils/obsproc/rtofs/util.cc
@@ -5,6 +5,8 @@
 #include <fstream>
 using std::ofstream;
 
+#include <cstdint> // for uint32_t
+
 #include <iomanip>
 using std::setprecision;
 

--- a/utils/soca/CMakeLists.txt
+++ b/utils/soca/CMakeLists.txt
@@ -11,6 +11,7 @@ ecbuild_add_executable( TARGET gdas_ens_handler.x
 target_compile_features( gdas_ens_handler.x PUBLIC cxx_std_11)
 target_link_libraries( gdas_ens_handler.x PUBLIC NetCDF::NetCDF_CXX oops atlas soca)
 target_link_libraries( gdas_ens_handler.x PRIVATE stdc++fs)
+target_include_directories(gdas_incr_handler.x PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/incrqc)
 
 # Hybrid-Weight
 ecbuild_add_executable( TARGET gdas_socahybridweights.x

--- a/utils/soca/CMakeLists.txt
+++ b/utils/soca/CMakeLists.txt
@@ -2,6 +2,7 @@
 ecbuild_add_executable( TARGET gdas_incr_handler.x
                         SOURCES gdas_incr_handler.cc gdas_postprocincr.h)
 target_compile_features( gdas_incr_handler.x PUBLIC cxx_std_11)
+target_include_directories(gdas_incr_handler.x PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/incrqc)
 target_link_libraries( gdas_incr_handler.x PUBLIC NetCDF::NetCDF_CXX oops atlas soca)
 target_link_libraries( gdas_incr_handler.x PRIVATE stdc++fs)
 
@@ -11,7 +12,6 @@ ecbuild_add_executable( TARGET gdas_ens_handler.x
 target_compile_features( gdas_ens_handler.x PUBLIC cxx_std_11)
 target_link_libraries( gdas_ens_handler.x PUBLIC NetCDF::NetCDF_CXX oops atlas soca)
 target_link_libraries( gdas_ens_handler.x PRIVATE stdc++fs)
-target_include_directories(gdas_incr_handler.x PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/incrqc)
 
 # Hybrid-Weight
 ecbuild_add_executable( TARGET gdas_socahybridweights.x

--- a/utils/soca/diagb/gdas_soca_diagb.h
+++ b/utils/soca/diagb/gdas_soca_diagb.h
@@ -100,18 +100,13 @@ class SocaDiagB : public oops::Application {
                                                            outputGeometryKey), this->getComm());
 
     // -- Step 5: Build mesh and connectivity --
-    auto originalNodeColumns = atlas::functionspace::NodeColumns(geom.functionSpace());
-    atlas::Mesh mesh = originalNodeColumns.mesh();
-    atlas::mesh::actions::build_edges(mesh);
-    atlas::mesh::actions::build_node_to_edge_connectivity(mesh);
-    atlas::mesh::actions::build_halo(mesh, 1);
-    atlas::functionspace::NodeColumns nodeColumns(mesh, atlas::option::halo(1));
-    const auto & node2edge = mesh.nodes().edge_connectivity();
-    const auto & edge2node = mesh.edges().node_connectivity();
-    const auto ghostView = atlas::array::make_view<int, 1>(geom.functionSpace().ghost());
+    gdasapp::diagb::utils::MeshBundle meshConn = gdasapp::diagb::utils::buildMeshConnectivity(geom);
+    const auto & node2edge = meshConn.node2edge;
+    const auto & edge2node = meshConn.edge2node;
+    const auto ghostView = meshConn.ghostView;
 
     // -- Step 6: Compute depth and bathymetry fields --
-    nodeColumns.haloExchange(xbFs["sea_water_cell_thickness"]);
+    meshConn.nodeColumns.haloExchange(xbFs["sea_water_cell_thickness"]);
     auto viewHocn = atlas::array::make_view<double, 2>(xbFs["sea_water_cell_thickness"]);
     atlas::array::ArrayT<double> depth(viewHocn.shape(0), viewHocn.shape(1));
     auto viewDepth = atlas::array::make_view<double, 2>(depth);
@@ -139,8 +134,8 @@ class SocaDiagB : public oops::Application {
       auto sum2 = atlas::array::make_view<double, 2>(sum2_localFs[var]);
 
       for (int iter = 0; iter < configD.stencilGrowthIterations; ++iter) {
-        nodeColumns.haloExchange(sum_localFs[var]);
-        nodeColumns.haloExchange(sum2_localFs[var]);
+        meshConn.nodeColumns.haloExchange(sum_localFs[var]);
+        meshConn.nodeColumns.haloExchange(sum2_localFs[var]);
         atlas::Field sum_localF = sum_localFs[var].clone();
         atlas::Field sum2_localF = sum2_localFs[var].clone();
         auto sumTmp = atlas::array::make_view<double, 2>(sum_localF);
@@ -148,8 +143,8 @@ class SocaDiagB : public oops::Application {
 
         for (atlas::idx_t level = 0; level < xbFs[var].shape(1); ++level) {
           for (atlas::idx_t jnode = 0; jnode < xbFs[var].shape(0); ++jnode) {
-            if (ghostView(jnode) > 0) continue;
-            auto neighbors = gdasapp::diagb::utils::get_neighbors_of_node(mesh,
+            if (meshConn.ghostView(jnode) > 0) continue;
+            auto neighbors = gdasapp::diagb::utils::get_neighbors_of_node(meshConn.mesh,
                                                                           node2edge,
                                                                           edge2node,
                                                                           jnode);
@@ -219,7 +214,7 @@ class SocaDiagB : public oops::Application {
                          (var == "sea_ice_area_fraction") ? configD.sigSic : 0.0;
 
       for (atlas::idx_t jnode = 0; jnode < xbFs[var].shape(0); ++jnode) {
-        if (ghostView(jnode) > 0) continue;
+        if (meshConn.ghostView(jnode) > 0) continue;
         for (atlas::idx_t level = 0; level < xbFs[var].shape(1); ++level) {
           if (viewBathy(jnode, 0) > 0.0) {
             double z = viewDepth(jnode, level);

--- a/utils/soca/diagb/gdas_soca_diagb_utils.h
+++ b/utils/soca/diagb/gdas_soca_diagb_utils.h
@@ -1,9 +1,22 @@
 #pragma once
 
-#include <atlas/mesh.h>
 #include <algorithm>
 #include <string>
+#include <tuple>
+#include <utility>
 #include <vector>
+
+#include "atlas/field.h"
+#include "atlas/functionspace/NodeColumns.h"
+#include "atlas/mesh.h"
+#include "atlas/mesh/actions/BuildEdges.h"
+#include "atlas/mesh/actions/BuildHalo.h"
+#include "atlas/mesh/Connectivity.h"
+#include "atlas/mesh/Mesh.h"
+#include "atlas/util/Earth.h"
+#include "atlas/util/Geometry.h"
+#include "atlas/util/Point.h"
+
 #include "oops/util/DateTime.h"
 
 namespace gdasapp {
@@ -96,6 +109,61 @@ struct SocaDiagBConfig {
     }
 };
 // -----------------------------------------------------------------------------
+/**
+ * @brief Bundles together Atlas mesh and related components for mesh operations
+ *
+ * MeshBundle provides a convenient way to group an Atlas mesh with its associated
+ * function space, connectivity information, and ghost views. This simplifies
+ * passing mesh-related data between functions.
+ *
+ * @note The constructor takes ownership of the provided mesh via move semantics.
+ *
+ * @member mesh The Atlas mesh
+ * @member nodeColumns Function space for node columns with a halo of 1
+ * @member node2edge Connectivity from nodes to edges
+ * @member edge2node Connectivity from edges to nodes
+ * @member ghostView Array view identifying ghost nodes
+ */
+struct MeshBundle {
+  atlas::Mesh mesh;
+  atlas::functionspace::NodeColumns nodeColumns;
+  atlas::mesh::IrregularConnectivity const& node2edge;
+  atlas::mesh::MultiBlockConnectivity const& edge2node;
+  atlas::array::ArrayView<int, 1> ghostView;
+  atlas::array::ArrayView<double, 2> lonlat;
+
+
+  explicit MeshBundle(atlas::Mesh&& m)
+    : mesh(std::move(m)),
+      nodeColumns(mesh, atlas::option::halo(1)),
+      node2edge(mesh.nodes().edge_connectivity()),
+      edge2node(mesh.edges().node_connectivity()),
+      ghostView(atlas::array::make_view<int, 1>(nodeColumns.ghost())),
+      lonlat(atlas::array::make_view<double, 2>(nodeColumns.lonlat())) {}
+};
+
+/**
+ * @brief Builds mesh connectivity from a SOCA geometry
+ *
+ * This function takes a SOCA geometry object and constructs an enhanced mesh with
+ * the following additional connectivity information:
+ *  - Edges
+ *  - Node-to-edge connectivity
+ *  - Halo of size 1
+ *
+ * @param geom The SOCA geometry object containing the base function space
+ * @return MeshBundle A bundle containing the enhanced mesh with connectivity information
+ */
+inline MeshBundle buildMeshConnectivity(const soca::Geometry & geom) {
+  auto originalNodeColumns = atlas::functionspace::NodeColumns(geom.functionSpace());
+  atlas::Mesh mesh = originalNodeColumns.mesh();
+
+  atlas::mesh::actions::build_edges(mesh);
+  atlas::mesh::actions::build_node_to_edge_connectivity(mesh);
+  atlas::mesh::actions::build_halo(mesh, 1);
+
+  return MeshBundle(std::move(mesh));
+}
 
 /**
  * @brief Gets the neighboring node indices of a given node in an Atlas mesh.

--- a/utils/soca/gdas_incr_handler.h
+++ b/utils/soca/gdas_incr_handler.h
@@ -17,7 +17,6 @@
 
 #include "soca/Geometry/Geometry.h"
 #include "soca/Increment/Increment.h"
-#include "soca/LinearVariableChange/LinearVariableChange.h"
 #include "soca/State/State.h"
 
 #include "gdas_postprocincr.h"

--- a/utils/soca/gdas_postprocincr.h
+++ b/utils/soca/gdas_postprocincr.h
@@ -21,7 +21,7 @@
 #include "soca/LinearVariableChange/LinearVariableChange.h"
 #include "soca/State/State.h"
 
-#include "gdas_incr_qc.h"
+#include "incrqc/gdas_incr_qc.h"
 
 namespace gdasapp {
 
@@ -281,7 +281,7 @@ class PostProcIncr {
     oops::Log::info() << "======      Quality control on increment" << std::endl;
 
     // Perform quality control on the increment
-    gdasapp::qcIncrement::qcIncrement(xb, dx, config, geom);
+    gdasapp::incrqc::qcIncrement(xb, dx, config, geom);
     oops::Log::info() << " in qc increment:" << dx << std::endl;
   }
 

--- a/utils/soca/gdas_soca_utils.h
+++ b/utils/soca/gdas_soca_utils.h
@@ -4,6 +4,10 @@
 #include <cmath>
 #include <vector>
 
+#include "soca/Increment/Increment.h"
+#include "soca/LinearVariableChange/LinearVariableChange.h"
+#include "soca/State/State.h"
+
 namespace gdasapp {
 namespace utils {
 
@@ -11,19 +15,19 @@ namespace utils {
   constexpr double alpha = 2.0e-4;       // Thermal expansion coefficient [1/K]
   constexpr double beta  = 7.6e-4;       // Haline contraction coefficient [1/psu]
 
-  /**
-   * @brief Computes ocean depth and bathymetry from ocean thickness values
-   *
-   * This function calculates:
-   * 1. Depth at of the center of each layers
-   * 2. Bathymetry as the total sum of ocean thickness values at each node
-   *
-   * @param viewHocn 2D array view containing ocean thickness values [nodes × levels]
-   *
-   * @return std::pair of ArrayViews containing:
-   *         - first: Computed depth values at each level [nodes × levels]
-   *         - second: Computed bathymetry values [nodes × 1]
-   */
+/**
+ * @brief Computes ocean depth and bathymetry from ocean thickness values
+ *
+ * This function calculates:
+ * 1. Depth at of the center of each layers
+ * 2. Bathymetry as the total sum of ocean thickness values at each node
+ *
+ * @param viewHocn 2D array view containing ocean thickness values [nodes × levels]
+ *
+ * @return std::pair of ArrayViews containing:
+ *         - first: Computed depth values at each level [nodes × levels]
+ *         - second: Computed bathymetry values [nodes × 1]
+ */
 
 void computeDepthAndBathymetry(
     const atlas::array::ArrayView<double, 2>& viewHocn,
@@ -47,6 +51,63 @@ void computeDepthAndBathymetry(
 }
 
 /**
+ * @brief Calculates seawater density using the UNESCO 1983 equation of state
+ *
+ * This function computes the density of seawater based on the empirical UNESCO 1983
+ * polynomial approximation formula described in Fofonoff & Millard (1983). The formula
+ * uses a polynomial with temperature and salinity as variables.
+ *
+ * The equation takes the form:
+ *   ρ(T,S) = ρw(T) + B(T)*S + C(T)*S^(3/2) + D*S^2
+ * where ρw is the density of pure water as a function of temperature,
+ * and B, C, and D are temperature-dependent coefficients.
+ *
+ * @param temp Temperature in degrees Celsius
+ * @param salt Salinity in practical salinity units (PSU)
+ * @return Seawater density in kg/m³
+ *
+ * @note Reference: Fofonoff, N. P., & Millard, R. C. (1983). Algorithms for
+ * computation of fundamental properties of seawater. UNESCO technical papers
+ * in marine science, 44, 53.
+ */
+inline double computeDensityUNESCO(double temp, double salt) {
+  // Empirical UNESCO 1983 polynomial approximation
+
+  // Coefficients from literature (e.g., Fofonoff & Millard, 1983)
+  constexpr double A0 = 999.842594;
+  constexpr double A1 = 6.793952e-2;
+  constexpr double A2 = -9.095290e-3;
+  constexpr double A3 = 1.001685e-4;
+  constexpr double A4 = -1.120083e-6;
+  constexpr double A5 = 6.536332e-9;
+
+  constexpr double B0 = 0.824493;
+  constexpr double B1 = -4.0899e-3;
+  constexpr double B2 = 7.6438e-5;
+  constexpr double B3 = -8.2467e-7;
+  constexpr double B4 = 5.3875e-9;
+
+  constexpr double C0 = -5.72466e-3;
+  constexpr double C1 = 1.0227e-4;
+  constexpr double C2 = -1.6546e-6;
+
+  constexpr double D0 = 4.8314e-4;
+
+  double sqrtS = std::sqrt(salt);
+
+  double rho_w = A0 + A1 * temp + A2 * temp * temp + A3 * temp * temp * temp
+                     + A4 * std::pow(temp, 4) + A5 * std::pow(temp, 5);
+
+  double rho = rho_w
+             + (B0 + B1 * temp + B2 * temp*temp
+                   + B3 * temp * temp * temp + B4 * std::pow(temp, 4)) * salt
+             + (C0 + C1 * temp + C2 * temp * temp) * salt * sqrtS
+             + D0 * salt * salt;
+
+  return rho;  // kg/m³
+}
+
+/**
  * @brief Compute steric height increment from temperature/salinity increments and layer thickness.
  *
  * @param tempIncr        Temperature increment profile [°C]
@@ -54,20 +115,88 @@ void computeDepthAndBathymetry(
  * @param layerThickness  Layer thickness profile [m]
  * @return approximate steric height increment [m]
  */
-inline double computeStericHeight(const std::vector<double> &tempIncr,
-                                  const std::vector<double> &saltIncr,
-                                  const std::vector<double> &layerThickness) {
-  assert(tempIncr.size() == saltIncr.size());
-  assert(saltIncr.size() == layerThickness.size());
+inline double computeStericHeightIncrement(const std::vector<double> &dTemp,
+                                           const std::vector<double> &dSalt,
+                                           const std::vector<double> &dz) {
+  assert(dTemp.size() == dSalt.size());
+  assert(dSalt.size() == dz.size());
 
   double stericHeightIncr = 0.0;
 
-  for (size_t k = 0; k < tempIncr.size(); ++k) {
+  for (size_t k = 0; k < dTemp.size(); ++k) {
     // dH = (-alpha * dT + beta * dS) * dz
-    stericHeightIncr += (alpha * tempIncr[k] - beta * saltIncr[k]) * layerThickness[k];
+    stericHeightIncr += (alpha * dTemp[k] - beta * dSalt[k]) * dz[k];
   }
 
   return stericHeightIncr;
+}
+
+/**
+ * @brief Computes the steric height increment from temperature and salinity increments
+ *
+ * The steric height increment is estimated by integrating the change in specific volume
+ * (1/density) over the water column after applying the temperature and salinity increments.
+ *
+ * @param tempBkg  Background temperature profile (size N)
+ * @param saltBkg  Background salinity profile (size N)
+ * @param dTemp    Temperature increment profile (size N)
+ * @param dSalt    Salinity increment profile (size N)
+ * @param dz       Thickness of each layer in meters (size N)
+ * @return         Steric height increment in meters
+ */
+inline double computeStericHeightIncrement(const std::vector<double>& tempBkg,
+                                           const std::vector<double>& saltBkg,
+                                           const std::vector<double>& dTemp,
+                                           const std::vector<double>& dSalt,
+                                           const std::vector<double>& dz) {
+  assert(tempBkg.size() == saltBkg.size());
+  assert(dTemp.size() == dSalt.size());
+  assert(tempBkg.size() == dTemp.size());
+  assert(dz.size() == tempBkg.size());
+
+  double stericHeightIncr = 0.0;
+  const size_t N = tempBkg.size();
+
+  for (size_t k = 0; k < N; ++k) {
+    if (dz[k] <= 0.1) continue;
+    double rho_bkg = computeDensityUNESCO(tempBkg[k], saltBkg[k]);
+    double rho_ana = computeDensityUNESCO(tempBkg[k] + dTemp[k], saltBkg[k] + dSalt[k]);
+
+    // Skip if densities are invalid or non-physical
+    if (rho_bkg <= 0.0 || rho_ana <= 0.0) continue;
+
+    double deltaSpecificVolume = (1.0 / rho_ana) - (1.0 / rho_bkg);
+    stericHeightIncr += deltaSpecificVolume * dz[k];
+  }
+  constexpr double rho0 = 1025.0;  // Reference density (kg/m³)
+
+  return rho0 * stericHeightIncr;  // meters
+}
+
+/**
+ * @brief Applies a linear variable change to the increment using GSW.
+ *
+ * Applies a linear transformation to the increment fields using the provided trajectory and configuration.
+ *
+ * @param dx The increment to transform.
+ * @param lvcConfig Configuration for the linear variable change.
+ * @param xTraj The trajectory state for the linearization.
+ */
+void computeStericHeightIncrement(const soca::Geometry& geom,
+                                  soca::Increment& dx,
+                                  const eckit::LocalConfiguration& lvcConfig,
+                                  const soca::State& xTraj,
+                                  oops::Variables dxVariables) {
+  // Set the ssh increment to zero (the soca linear changevar accumulates increments)
+  atlas::FieldSet dxFs;
+  dx.toFieldSet(dxFs);
+  auto viewSshIncr = atlas::array::make_view<double, 2>(dxFs["sea_surface_height_above_geoid"]);
+  viewSshIncr.assign(0.0);
+
+  // Apply the linear variable change
+  soca::LinearVariableChange lvc(geom, lvcConfig);
+  lvc.changeVarTraj(xTraj, dxVariables);
+  lvc.changeVarTL(dx, dxVariables);
 }
 
 }  // namespace utils

--- a/utils/soca/incrqc/README.md
+++ b/utils/soca/incrqc/README.md
@@ -87,12 +87,11 @@ In these cases, a correction factor is applied to the temperature and salinity i
 
 Finally, corrected values are optionally smoothed using neighbor averages:
 \[
-\delta T_k \leftarrow (1 - \alpha) \cdot \delta T_k + \alpha \cdot \overline{\delta T}_k^{\text{neighbors}}
+\delta T_k \leftarrow \overline{\delta T}_k^{\text{neighbors}}
 \]
 \[
-\delta S_k \leftarrow (1 - \alpha) \cdot \delta S_k + \alpha \cdot \overline{\delta S}_k^{\text{neighbors}}
+\delta S_k \leftarrow \overline{\delta S}_k^{\text{neighbors}}
 \]
-where \( \alpha \in [0, 1] \) is a blending factor (typically \( \alpha = 1 \) in the current implementation).
 
 
 #### Notes

--- a/utils/soca/incrqc/README.md
+++ b/utils/soca/incrqc/README.md
@@ -43,17 +43,62 @@ This check ensures that the increment does not introduce **new static instabilit
 
 The check operates iteratively (with a user-defined number of iterations), and for each grid point (node) it:
 
-1. **Computes density** using the UNESCO 1983 equation of state for both the background and the analysis (i.e., `background + increment`) at every vertical level.
+1. **Computes density** using the UNESCO 1983 equation of state (Fofonoff & Millard, 1983) for both the background and the analysis (i.e., `background + increment`) at every vertical level.
 2. **Calculates vertical density gradients** (∂ρ/∂z) for both background and analysis.
 3. **Identifies instability conditions**:
    - The analysis introduces a static instability (∂ρ/∂z < 0) where the background was stable (∂ρ/∂z ≥ 0).
    - The analysis increases the level of instability already present in the background.
-4. **Applies a local correction** by scaling down temperature and salinity increments at affected levels based on the ratio of the analysis gradient to a user-defined minimum stable density gradient (`min stable density gradient`). The correction factor is clamped between 0.1 and 1.0.
+4. **Applies a local correction** by scaling down temperature and salinity increments at affected levels based on the ratio of the analysis gradient to a user-defined minimum stable density gradient (`min stable density gradient`). The unit-less correction factor is clamped between 0.1 and 1.0.
 5. **Smooths corrected values** using neighboring points to reduce grid noise and introduce local consistency.
+6. **back to step 1** until the maximum number of iteration is reached.
+
+#### Stability Correction Details
+
+**Nomenclature:**
+\( \rho^{\text{bkg}}_k = \rho(T^{\text{bkg}}_k, S^{\text{bkg}}_k) \): background density at level \(k\)
+\( \rho^{\text{ana}}_k = \rho(T^{\text{bkg}}_k + \delta T_k, S^{\text{bkg}}_k + \delta S_k) \): analysis (background + increment) density at level \(k\)
+\( z_k \): depth at level \(k\) (positive downward)
+\( \frac{\partial \rho^{\text{bkg}}}{\partial z} \big|_k = \frac{\rho^{\text{bkg}}_k - \rho^{\text{bkg}}_{k-1}}{z_k - z_{k-1}} \)
+\( \frac{\partial \rho^{\text{ana}}}{\partial z} \big|_k = \frac{\rho^{\text{ana}}_k - \rho^{\text{ana}}_{k-1}}{z_k - z_{k-1}} \)
+\( \rho_{z}^{\text{min}} = \frac{\rho_0 N^2}{g}\) where \( N^2 \) is the Brunt–Väisälä frequency for a weakly stratified ocean.
+
+The increment is flagged as **potentially destabilizing** if either:
+
+1. The background is stable:
+   \[
+   \frac{\partial \rho^{\text{bkg}}}{\partial z} \big|_k \geq 0
+   \quad \text{and} \quad
+   \frac{\partial \rho^{\text{ana}}}{\partial z} \big|_k < 0
+   \]
+2. The background is already unstable but the analysis makes it worse:
+   \[
+   \frac{\partial \rho^{\text{bkg}}}{\partial z} \big|_k < 0
+   \quad \text{and} \quad
+   \frac{\partial \rho^{\text{ana}}}{\partial z} \big|_k < \frac{\partial \rho^{\text{bkg}}}{\partial z} \big|_k
+   \]
+
+In these cases, a correction factor is applied to the temperature and salinity increments:
+\[
+\delta T_k \leftarrow \delta T_k \cdot \left(1 - 0.5 \cdot \text{clamp}\left(\frac{|\frac{\partial \rho^{\text{ana}}}{\partial z}|_k}{\rho_{z}^{\text{min}}}, 0.1, 1.0\right)\right)
+\]
+\[
+\delta S_k \leftarrow \delta S_k \cdot \left(1 - 0.5 \cdot \text{clamp}\left(\frac{|\frac{\partial \rho^{\text{ana}}}{\partial z}|_k}{\rho_{z}^{\text{min}}}, 0.1, 1.0\right)\right)
+\]
+
+Finally, corrected values are optionally smoothed using neighbor averages:
+\[
+\delta T_k \leftarrow (1 - \alpha) \cdot \delta T_k + \alpha \cdot \overline{\delta T}_k^{\text{neighbors}}
+\]
+\[
+\delta S_k \leftarrow (1 - \alpha) \cdot \delta S_k + \alpha \cdot \overline{\delta S}_k^{\text{neighbors}}
+\]
+where \( \alpha \in [0, 1] \) is a blending factor (typically \( \alpha = 1 \) in the current implementation).
+
 
 #### Notes
 
-- Corrections are only applied at **non-ghost ocean nodes** (where bathymetry is positive and layer thickness is non-zero).
+- Depth increases positively downward, so stable stratification corresponds to ∂ρ/∂z>0.
+- Corrections are only applied where bathymetry is positive and layer thickness is non-zero.
 - Neighbor information is used to perform **localized smoothing** of the corrected increments for both temperature and salinity.
 - This procedure is intended to maintain hydrostatic stability and avoid introducing artificial density inversions that can degrade the forecast.
 
@@ -104,3 +149,8 @@ steric increment:
   linear variable changes:
   - linear variable change name: BalanceSOCA
 ```
+
+### References
+
+- Pedlosky, J. (1987). *Geophysical Fluid Dynamics*. Springer.
+- Lellouche, J.-M. et al. (2018). Recent updates to the Copernicus Marine Service global ocean... *Ocean Sci.*, 14, 1093–1126.

--- a/utils/soca/incrqc/README.md
+++ b/utils/soca/incrqc/README.md
@@ -1,0 +1,106 @@
+# `gdasapp::incrqc` — Increment Quality Control
+
+🩹🛠️ This module provides quality control (QC) functionality to ensure that the analysis increment remains within physically meaningful bounds.
+
+
+The QC process ensures:
+- The final analysis state stays within user-defined physical bounds.
+- The increment does not add new unstable cells to the background.
+- The steric height increment remains within specified limits.
+
+## Overview
+
+### Functions
+
+#### `double adjustAnalysisBounds(double xB, double dX, double minBound, double maxBound)`
+
+Adjusts a scalar increment so that the analysis value does not exceed the defined bounds.
+
+- **Parameters**:
+  - `xB`: Background value.
+  - `dX`: Proposed increment.
+  - `minBound`: Minimum allowed analysis value.
+  - `maxBound`: Maximum allowed analysis value.
+- **Returns**: A possibly adjusted `dX` such that `xB + dX` is within bounds.
+
+#### `void qcIncrement(const soca::State& xb, soca::Increment& dx, const eckit::Configuration& config, const soca::Geometry& geom)`
+
+Main routine that performs in-place quality control on the increment `dx`.
+
+- **Parameters**:
+  - `xb`: Background ocean state.
+  - `dx`: Increment to be quality-controlled. Modified in place.
+  - `config`: Configuration with QC parameters and bounds.
+  - `geom`: Geometry providing spatial metadata.
+
+## Key Features
+
+### 1. **Water Column Stability**
+
+This check ensures that the increment does not introduce **new static instabilities** into the water column.
+
+#### Method
+
+The check operates iteratively (with a user-defined number of iterations), and for each grid point (node) it:
+
+1. **Computes density** using the UNESCO 1983 equation of state for both the background and the analysis (i.e., `background + increment`) at every vertical level.
+2. **Calculates vertical density gradients** (∂ρ/∂z) for both background and analysis.
+3. **Identifies instability conditions**:
+   - The analysis introduces a static instability (∂ρ/∂z < 0) where the background was stable (∂ρ/∂z ≥ 0).
+   - The analysis increases the level of instability already present in the background.
+4. **Applies a local correction** by scaling down temperature and salinity increments at affected levels based on the ratio of the analysis gradient to a user-defined minimum stable density gradient (`min stable density gradient`). The correction factor is clamped between 0.1 and 1.0.
+5. **Smooths corrected values** using neighboring points to reduce grid noise and introduce local consistency.
+
+#### Notes
+
+- Corrections are only applied at **non-ghost ocean nodes** (where bathymetry is positive and layer thickness is non-zero).
+- Neighbor information is used to perform **localized smoothing** of the corrected increments for both temperature and salinity.
+- This procedure is intended to maintain hydrostatic stability and avoid introducing artificial density inversions that can degrade the forecast.
+
+### 2. **Steric Height Limit**
+
+This check constrains the **sea surface height (SSH) increment** derived from temperature and salinity changes to remain within physically meaningful limits.
+
+#### Method
+
+For each node, the check:
+
+1. **Evaluates the SSH increment** derived from temperature and salinity profiles.
+2. **Checks if the absolute SSH increment exceeds** a configured maximum (`increment max.steric`).
+3. If the threshold is exceeded:
+   - **Computes a rescaling factor** based on the ratio of the maximum allowed SSH increment to the current value.
+   - **Scales down the temperature and salinity increments** by this factor to reduce their effect on SSH.
+4. **Recomputes the steric height increment** using the rescaled temperature and salinity profiles.
+5. **Updates the SSH increment** to match the recomputed steric height.
+
+#### Notes
+
+- Layer thickness is used as a vertical integration weight in computing steric height.
+- The routine supports optional debugging output, including:
+  - Original and rescaled SSH increment
+  - Computed steric height using 3 alternative formulations
+- This constraint ensures the increment does not introduce unrealistically large SSH adjustments that could degrade ocean model balance or lead to unrealistic surface gravity waves.
+
+### 3. **Hard Bounds Enforcement**
+
+- Brute-force check to make sure analysis values of temperature and salinity remain within defined minimum and maximum values.
+- Adjusts the increment field accordingly.
+
+## Required Configuration Parameters
+
+The `eckit::Configuration` object must include:
+
+```yaml
+state bounds:
+  sea_water_potential_temperature: [min_temp, max_temp]
+  sea_water_salinity: [min_salt, max_salt]
+
+increment max:
+  steric: 0.5  # Maximum allowed steric height increment [m]
+
+increment stability iterations: 5
+min stable density gradient: 1e-4
+steric increment:
+  linear variable changes:
+  - linear variable change name: BalanceSOCA
+```

--- a/utils/soca/incrqc/gdas_incr_qc.h
+++ b/utils/soca/incrqc/gdas_incr_qc.h
@@ -1,0 +1,112 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "eckit/config/LocalConfiguration.h"
+
+#include "atlas/array.h"
+#include "atlas/field.h"
+#include "atlas/field/FieldSet.h"
+
+#include "oops/util/Logger.h"
+
+#include "soca/Increment/Increment.h"
+#include "soca/State/State.h"
+
+#include "../diagb/gdas_soca_diagb_utils.h"
+#include "../gdas_soca_utils.h"
+#include "gdas_incr_qc_utils.h"
+
+namespace gdasapp {
+namespace incrqc {
+
+/**
+ * @brief Quality control for increments: ensures that the analysis (xb + dx) remains within physical bounds.
+ *
+ * @param xb The background state.
+ * @param dx The increment to QC. Will be modified in place.
+ * @param config The configuration containing bounds information.
+ */
+void qcIncrement(const soca::State& xb,
+                 soca::Increment& dx,
+                 const eckit::Configuration& config,
+                 const soca::Geometry& geom) {
+  oops::Log::info() << "==========================================" << std::endl;
+  oops::Log::info() << "======      Quality control on increment" << std::endl;
+
+  // Replace the ssh increment with a steric height increment
+  eckit::LocalConfiguration lvcConfig(config, "steric increment");
+  gdasapp::utils::computeStericHeightIncrement(geom, dx, lvcConfig, xb, dx.variables());
+
+  atlas::FieldSet xbFs, dxFs;
+  xb.toFieldSet(xbFs);
+  dx.toFieldSet(dxFs);
+
+  // Compute ocean depth and bathymetry
+  auto viewHocn = atlas::array::make_view<double, 2>(xbFs["sea_water_cell_thickness"]);
+  atlas::array::ArrayT<double> depth(viewHocn.shape(0), viewHocn.shape(1));
+  auto viewDepth = atlas::array::make_view<double, 2>(depth);
+  atlas::array::ArrayT<double> bathy(viewHocn.shape(0), 1);
+  auto viewBathy = atlas::array::make_view<double, 2>(bathy);
+  gdasapp::utils::computeDepthAndBathymetry(viewHocn, viewDepth, viewBathy);
+
+  // Get ghost nodes and lon/lat coordinates
+  gdasapp::diagb::utils::MeshBundle meshConn = gdasapp::diagb::utils::buildMeshConnectivity(geom);
+  const auto & node2edge = meshConn.node2edge;
+  const auto & edge2node = meshConn.edge2node;
+  const auto ghostView = meshConn.ghostView;
+  const auto & lonlat = meshConn.lonlat;
+
+  // Get the physical bounds from configuration
+  std::vector<double> tempBounds(2);
+  config.get("state bounds.sea_water_potential_temperature", tempBounds);
+  std::vector<double> saltBounds(2);
+  config.get("state bounds.sea_water_salinity", saltBounds);
+  const std::unordered_map<std::string, std::pair<double, double>> stateBounds = {
+    {"sea_water_potential_temperature", {tempBounds[0], tempBounds[1]}},
+    {"sea_water_salinity", {saltBounds[0], saltBounds[1]}},
+  };
+
+  // Get increment bounds from configuration
+  double deltaSshMax = config.getDouble("increment max.steric", 10.0);
+  oops::Log::debug() << "QC: max steric height increment: " << deltaSshMax << std::endl;
+
+  // Prepare views for increment and background fields
+  auto viewTempIncr = atlas::array::make_view<double, 2>(dxFs["sea_water_potential_temperature"]);
+  auto viewSaltIncr = atlas::array::make_view<double, 2>(dxFs["sea_water_salinity"]);
+  auto viewSshIncr = atlas::array::make_view<double, 2>(dxFs["sea_surface_height_above_geoid"]);
+  auto viewTempBkg = atlas::array::make_view<double, 2>(xbFs["sea_water_potential_temperature"]);
+  auto viewSaltBkg = atlas::array::make_view<double, 2>(xbFs["sea_water_salinity"]);
+
+  int niterations = config.getInt("increment stability iterations", 10);
+  const double rhoMinGrad = config.getDouble("min stable density gradient", 1e-4);
+
+  // Steric height increment and stability checks
+  applyWaterColumnStabilityCheck(dxFs,
+                                 viewTempBkg, viewSaltBkg,
+                                 viewHocn, viewDepth, lonlat,
+                                 niterations, rhoMinGrad, viewBathy,
+                                 meshConn);
+
+  for (atlas::idx_t jnode = 0; jnode < viewTempIncr.shape(0); ++jnode) {
+    // Skip ghost and land nodes
+    if (ghostView(jnode) > 0) continue;
+    if (viewBathy(jnode, 0) <= 0.0) continue;
+
+    // Limit the steric height incrememnt to deltaSshMax
+    applyStericHeightConstraint(jnode, viewTempIncr, viewSaltIncr, viewSshIncr,
+                            viewTempBkg, viewSaltBkg, viewHocn, deltaSshMax);
+  }
+
+  // Brute force bounds check
+  applyBruteForceBoundsCheck(dxFs, xbFs, ghostView, viewBathy, stateBounds);
+
+  dx.fromFieldSet(dxFs);
+  oops::Log::info() << "======      Finished quality control on increment" << std::endl;
+  }
+
+}  // namespace incrqc
+}  // namespace gdasapp

--- a/utils/soca/incrqc/gdas_incr_qc_utils.h
+++ b/utils/soca/incrqc/gdas_incr_qc_utils.h
@@ -1,0 +1,329 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "eckit/config/LocalConfiguration.h"
+
+#include "atlas/array.h"
+#include "atlas/field.h"
+#include "atlas/field/FieldSet.h"
+
+#include "../diagb/gdas_soca_diagb_utils.h"
+#include "../gdas_soca_utils.h"
+
+#include "oops/util/Logger.h"
+
+#include "soca/Increment/Increment.h"
+#include "soca/State/State.h"
+
+namespace gdasapp {
+namespace incrqc {
+
+/**
+ * @brief Adjusts an analysis increment to ensure the resulting value stays within specified bounds.
+ *
+ * This function takes a background value and an increment, then checks if applying the increment
+ * would result in a value outside the specified bounds. If so, it modifies the increment to
+ * ensure the final analysis value remains within the allowed range.
+ *
+ * @param xB The background or base value
+ * @param dX The proposed increment to apply to the background value
+ * @param minBound The minimum allowed value for the resulting analysis
+ * @param maxBound The maximum allowed value for the resulting analysis
+ * @return The adjusted increment that, when added to xB, will keep the result within [minBound, maxBound]
+ */
+double adjustAnalysisBounds(double xB, double dX, double minBound, double maxBound) {
+  double xA = xB + dX;
+  if (xA < minBound) {
+    return minBound - xB;
+  } else if (xA > maxBound) {
+    return maxBound - xB;
+  }
+  return dX;
+}
+
+/**
+ * @brief Apply water column stability check to temperature and salinity increments
+ *
+ * This function checks and adjusts temperature and salinity increments to maintain
+ * water column stability. It ensures that the analysis (background + increments) will
+ * not introduce unrealistic density inversions that could lead to numerical instabilities
+ * in the ocean model.
+ *
+ * The function performs an iterative adjustment by:
+ * 1. Computing density for both background and analysis states at each level
+ * 2. Calculating vertical density gradients (∂ρ/∂z)
+ * 3. Identifying stability issues where:
+ *    - Analysis shows instability (∂ρ/∂z < 0) where background is stable (∂ρ/∂z ≥ 0), or
+ *    - Analysis has worse instability than an already unstable background
+ * 4. Applying a correction factor to temperature and salinity increments at problematic levels
+ *
+ * @param jnode Node index to process
+ * @param viewTempIncr Temperature increments (modified in-place if corrections are needed)
+ * @param viewSaltIncr Salinity increments (modified in-place if corrections are needed)
+ * @param viewTempBkg Background temperature values
+ * @param viewSaltBkg Background salinity values
+ * @param viewHocn Ocean layer heights
+ * @param viewDepth Depth values at each level
+ * @param lonlat Longitude and latitude coordinates
+ * @param niterations Number of iterations to perform the stability check
+ * @param rhoMinGrad Minimum density gradient used for scaling corrections
+ * @param ghostView Array view indicating ghost nodes (1 for ghost, 0 for real nodes)
+ * @param viewBathy Bathymetry values (positive for water points, negative or zero for land)
+ *
+ * @note The correction factor is determined based on the ratio of the analysis density
+ *       gradient to rhoMinGrad, with values clamped between 0.1 and 1.0
+ */
+void applyWaterColumnStabilityCheck(
+    atlas::FieldSet dxFs,
+    const atlas::array::ArrayView<const double, 2>& viewTempBkg,
+    const atlas::array::ArrayView<const double, 2>& viewSaltBkg,
+    const atlas::array::ArrayView<const double, 2>& viewHocn,
+    const atlas::array::ArrayView<const double, 2>& viewDepth,
+    const atlas::array::ArrayView<const double, 2>& lonlat,
+    const int niterations,
+    const double rhoMinGrad,
+    const atlas::array::ArrayView<const double, 2>& viewBathy,
+    const gdasapp::diagb::utils::MeshBundle& meshConn) {
+
+  auto viewTempIncr = atlas::array::make_view<double, 2>(dxFs["sea_water_potential_temperature"]);
+  auto viewSaltIncr = atlas::array::make_view<double, 2>(dxFs["sea_water_salinity"]);
+
+  // Store (node, level, neighbors) in tuple
+  std::vector<std::tuple<int, int, std::vector<int>>> unstablePoints;
+
+  const auto nlevels = viewTempIncr.shape(1);
+  const auto njnodes = viewTempIncr.shape(0);
+  for (int iter = 0; iter < niterations; ++iter) {
+    // Update halo
+    meshConn.nodeColumns.haloExchange(dxFs["sea_water_potential_temperature"]);
+    meshConn.nodeColumns.haloExchange(dxFs["sea_water_salinity"]);
+
+    // Clone the increment fields
+    auto dTF = dxFs["sea_water_potential_temperature"].clone();
+    auto dSF = dxFs["sea_water_salinity"].clone();
+    auto viewdTF = atlas::array::make_view<double, 2>(dTF);
+    auto viewdSF = atlas::array::make_view<double, 2>(dSF);
+    for (atlas::idx_t jnode = 0; jnode < njnodes; ++jnode) {
+      // Skip ghost and land nodes
+      if (meshConn.ghostView(jnode) > 0) continue;
+      if (viewBathy(jnode, 0) <= 0.0) continue;
+
+      std::vector<double> rhoAna(nlevels), rhoBkg(nlevels);
+      std::vector<double> drhodz_ana(nlevels), drhodz_bkg(nlevels);
+      for (atlas::idx_t level = 0; level < nlevels; ++level) {
+        rhoAna[level] = gdasapp::utils::computeDensityUNESCO(
+            viewTempBkg(jnode, level) + viewdTF(jnode, level),
+            viewSaltBkg(jnode, level) + viewdSF(jnode, level));
+
+        rhoBkg[level] = gdasapp::utils::computeDensityUNESCO(
+            viewTempBkg(jnode, level),
+            viewSaltBkg(jnode, level));
+      }
+
+      for (atlas::idx_t level = 1; level < nlevels; ++level) {
+        if (viewHocn(jnode, level) <= 0.1 && viewHocn(jnode, level - 1) <= 0.1) continue;
+
+        const double dz = viewDepth(jnode, level) - viewDepth(jnode, level - 1);
+        if (std::abs(dz) < 1e-5) continue;
+
+        drhodz_ana[level] = (rhoAna[level] - rhoAna[level - 1]) / dz;
+        drhodz_bkg[level] = (rhoBkg[level] - rhoBkg[level - 1]) / dz;
+
+        // Stability correction condition
+        // Allow existing background instability but damp if increment amplifies it
+        if ((drhodz_ana[level] < 0.0 && drhodz_bkg[level] >= 0.0) ||
+            (drhodz_bkg[level] < 0.0 && drhodz_ana[level] < drhodz_bkg[level])) {
+          // Accumulate the jnode, level and neighbors
+          auto neighbors = gdasapp::diagb::utils::get_neighbors_of_node(meshConn.mesh,
+                                                                        meshConn.node2edge,
+                                                                        meshConn.edge2node,
+                                                                        jnode);
+          unstablePoints.emplace_back(jnode, level, neighbors);
+          double factor = std::clamp(std::abs(drhodz_ana[level]) / rhoMinGrad, 0.1, 1.0);
+          viewTempIncr(jnode, level) *= (1.0 - 0.5 * factor);  // * viewdTF(jnode, level);
+          viewSaltIncr(jnode, level) *= (1.0 - 0.5 * factor);  // * viewdSF(jnode, level);
+          }  // end if
+        }  // end if
+      }  // end for jnode
+    }  // end for level
+    // Iterate through the unstable points and smooth the increment locally
+    for (const auto& [jnode, level, neighbors] : unstablePoints) {
+      oops::Log::debug() << "QC: Node " << jnode << ", Level " << level
+                << " unstable - neighbors: " << neighbors << std::endl;
+      // Compute local mean increments from neighbors
+      double meanTempIncr = 0.0;
+      double meanSaltIncr = 0.0;
+      int validNeighbors = 0;
+
+      // Calculate average increments from valid neighboring nodes
+      for (const auto& neighbor : neighbors) {
+        // Skip ghost nodes or land points
+        if (meshConn.ghostView(neighbor) > 0 || viewBathy(neighbor, 0) <= 0.0) continue;
+
+        // Only include neighbors with valid ocean layer thickness at this level
+        if (viewHocn(neighbor, level) > 0.1) {
+          meanTempIncr += viewTempIncr(neighbor, level);
+          meanSaltIncr += viewSaltIncr(neighbor, level);
+          validNeighbors++;
+        }
+      }
+
+      // Apply smoothing if we have valid neighbors
+      if (validNeighbors > 0) {
+        meanTempIncr /= validNeighbors;
+        meanSaltIncr /= validNeighbors;
+
+        // Blend original increments with neighbor mean (10% from neighbors, 90% original)
+        const double blendFactor = 1.0;
+        viewTempIncr(jnode, level) = (1.0 - blendFactor) * viewTempIncr(jnode, level) +
+                                     blendFactor * meanTempIncr;
+        viewSaltIncr(jnode, level) = (1.0 - blendFactor) * viewSaltIncr(jnode, level) +
+                                     blendFactor * meanSaltIncr;
+      }
+    }
+  }  // end for iter
+
+/**
+ * @brief Applies steric height constraint to sea surface height (SSH) increments
+ *
+ * This function enforces a maximum constraint on sea surface height increments
+ * by rescaling temperature and salinity increments when the SSH increment
+ * exceeds the specified threshold (deltaSshMax).
+ *
+ * The function:
+ * 1) Checks if the SSH increment exceeds the maximum allowed value
+ * 2) If exceeded, calculates a rescaling factor based on the maximum allowed SSH increment
+ * 3) Applies this rescaling factor to temperature and salinity increments
+ * 4) Recomputes the steric height increment using the rescaled values
+ * 5) Updates the SSH increment with the recomputed steric height
+ *
+ * Debug information is logged when rescaling is applied.
+ *
+ * @param jnode        Node index being processed
+ * @param viewTempIncr Temperature increments (modified in-place when constraint is applied)
+ * @param viewSaltIncr Salinity increments (modified in-place when constraint is applied)
+ * @param viewSshIncr  Sea surface height increments (modified in-place when constraint is applied)
+ * @param viewTempBkg  Background temperature values (input only)
+ * @param viewSaltBkg  Background salinity values (input only)
+ * @param viewHocn     Ocean layer thickness values (input only)
+ * @param deltaSshMax  Maximum allowed absolute value for SSH increments
+ */
+void applyStericHeightConstraint(
+    const atlas::idx_t jnode,
+    atlas::array::ArrayView<double, 2>& viewTempIncr,
+    atlas::array::ArrayView<double, 2>& viewSaltIncr,
+    atlas::array::ArrayView<double, 2>& viewSshIncr,
+    const atlas::array::ArrayView<const double, 2>& viewTempBkg,
+    const atlas::array::ArrayView<const double, 2>& viewSaltBkg,
+    const atlas::array::ArrayView<const double, 2>& viewHocn,
+    double deltaSshMax) {
+
+  const atlas::idx_t nlevels = viewTempIncr.shape(1);
+
+  if (std::abs(viewSshIncr(jnode, 0)) <= deltaSshMax) return;
+
+  // Compute rescaling factor
+  double rescale = deltaSshMax / std::abs(viewSshIncr(jnode, 0));
+
+  // Apply rescaling to temp/salt increments
+  std::vector<double> tempIncr(nlevels), saltIncr(nlevels);
+  std::vector<double> tempBkg(nlevels), saltBkg(nlevels);
+  std::vector<double> layerThickness(nlevels);
+
+  for (atlas::idx_t level = 0; level < nlevels; ++level) {
+    viewTempIncr(jnode, level) *= rescale;
+    viewSaltIncr(jnode, level) *= rescale;
+
+    tempIncr[level] = viewTempIncr(jnode, level);
+    saltIncr[level] = viewSaltIncr(jnode, level);
+    tempBkg[level] = viewTempBkg(jnode, level);
+    saltBkg[level] = viewSaltBkg(jnode, level);
+    layerThickness[level] = viewHocn(jnode, level);
+  }
+
+  // Optional debug: recompute steric height increment two ways
+  double steric1 = gdasapp::utils::computeStericHeightIncrement(tempIncr, saltIncr, layerThickness);
+  double steric2 = gdasapp::utils::computeStericHeightIncrement(tempBkg, saltBkg,
+                                                                tempIncr, saltIncr, layerThickness);
+
+  oops::Log::debug() << "QC: node " << jnode
+                     << " - SSH increment " << viewSshIncr(jnode, 0)
+                     << " exceeds max: " << deltaSshMax
+                     << " → Rescaling T/S by " << rescale
+                     << ", steric height ~ " << steric1
+                     << " (method 2: " << steric2 << ")" << std::endl;
+
+  // Reflect rescaled steric height in SSH
+  viewSshIncr(jnode, 0) = steric2;
+}
+
+/**
+ * @brief Applies hard boundary constraints to the analysis by adjusting the increment
+ * to ensure physical bounds are enforced.
+ *
+ * This function enforces minimum and maximum bounds on state variables by modifying increment values
+ * in the dxFs field set. For each field in dxFs that exists in both xbFs and stateBounds, the function
+ * ensures that the resulting analysis value (background + increment) stays within the specified bounds.
+ * If a resulting value would exceed a bound, the increment is adjusted to exactly match the bound.
+ * The function only processes non-ghost points over water (positive bathymetry).
+ *
+ * @param dxFs [in,out] Field set containing increments to be modified to enforce bounds
+ * @param xbFs [in] Field set containing background state values
+ * @param ghostView [in] Array view indicating ghost points (>0 for ghost points)
+ * @param viewBathy [in] Array view containing bathymetry data (positive for water points)
+ * @param stateBounds [in] Map of field names to their valid value ranges (min,max)
+ *
+ * @details The function iterates through fields in dxFs and applies the following logic:
+ *   1. Skip if the field doesn't exist in xbFs or doesn't have bounds defined in stateBounds
+ *   2. For each non-ghost point with positive bathymetry:
+ *      - Calculate the analysis value (xA = xB + dX)
+ *      - If xA < minBound: set dX = minBound - xB
+ *      - If xA > maxBound: set dX = maxBound - xB
+ */
+void applyBruteForceBoundsCheck(
+    atlas::FieldSet& dxFs,
+    const atlas::FieldSet& xbFs,
+    const atlas::array::ArrayView<const int, 1>& ghostView,
+    const atlas::array::ArrayView<const double, 2>& viewBathy,
+    const std::unordered_map<std::string, std::pair<double, double>>& stateBounds) {
+
+  for (auto& field : dxFs) {
+    const std::string name = field.name();
+
+    if (!xbFs.has(name)) continue;
+    if (stateBounds.find(name) == stateBounds.end()) continue;
+
+    auto dxView = atlas::array::make_view<double, 2>(field);
+    auto xbView = atlas::array::make_view<const double, 2>(xbFs.field(name));
+
+    const std::pair<double, double>& bounds = stateBounds.at(name);
+    const double minBound = bounds.first;
+    const double maxBound = bounds.second;
+
+    for (atlas::idx_t jnode = 0; jnode < dxView.shape(0); ++jnode) {
+      if (ghostView(jnode) > 0) continue;
+      if (viewBathy(jnode, 0) <= 0.0) continue;
+
+      for (atlas::idx_t level = 0; level < dxView.shape(1); ++level) {
+        const double xB = xbView(jnode, level);
+        const double dX = dxView(jnode, level);
+        const double xA = xB + dX;
+
+        if (xA < minBound) {
+          dxView(jnode, level) = minBound - xB;
+        } else if (xA > maxBound) {
+          dxView(jnode, level) = maxBound - xB;
+        }
+      }  // end for level
+    }  // end for jnode
+  }  // end for field
+}  // end function
+
+
+}  // namespace incrqc
+}  // namespace gdasapp

--- a/utils/soca/incrqc/gdas_incr_qc_utils.h
+++ b/utils/soca/incrqc/gdas_incr_qc_utils.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <string>
-#include <unordered_map>
 #include <tuple>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 

--- a/utils/soca/incrqc/gdas_incr_qc_utils.h
+++ b/utils/soca/incrqc/gdas_incr_qc_utils.h
@@ -145,8 +145,8 @@ void applyWaterColumnStabilityCheck(
                                                                         jnode);
           unstablePoints.emplace_back(jnode, level, neighbors);
           double factor = std::clamp(std::abs(drhodz_ana[level]) / rhoMinGrad, 0.1, 1.0);
-          viewTempIncr(jnode, level) *= (1.0 - 0.5 * factor);  // * viewdTF(jnode, level);
-          viewSaltIncr(jnode, level) *= (1.0 - 0.5 * factor);  // * viewdSF(jnode, level);
+          viewTempIncr(jnode, level) *= (1.0 - 0.5 * factor);
+          viewSaltIncr(jnode, level) *= (1.0 - 0.5 * factor);
           }  // end if
         }  // end if
       }  // end for jnode
@@ -178,12 +178,8 @@ void applyWaterColumnStabilityCheck(
         meanTempIncr /= validNeighbors;
         meanSaltIncr /= validNeighbors;
 
-        // Blend original increments with neighbor mean (10% from neighbors, 90% original)
-        const double blendFactor = 1.0;
-        viewTempIncr(jnode, level) = (1.0 - blendFactor) * viewTempIncr(jnode, level) +
-                                     blendFactor * meanTempIncr;
-        viewSaltIncr(jnode, level) = (1.0 - blendFactor) * viewSaltIncr(jnode, level) +
-                                     blendFactor * meanSaltIncr;
+        viewTempIncr(jnode, level) = meanTempIncr;
+        viewSaltIncr(jnode, level) = meanSaltIncr;
       }
     }
   }  // end for iter


### PR DESCRIPTION
# Description
Final (?) PR for the analysis/increment QC.
Not very `OO`, but it fixes `OOPS`'s in the analysis/increment ...

As shown below, the adjustment aren't small. Showing Temp increment at level 20, mostly adjusted due to static instabilities:
![incrqc](https://github.com/user-attachments/assets/a277e859-5257-4c85-addc-d65ae6a2810b)



# Companion PRs
- https://github.com/NOAA-EMC/jcb-gdas/pull/134

# Issues
- fixes #1721 

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmaerosnowDA  <!-- JEDI aero/snow cycled DA !-->
- [x] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [x] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
