### PR TITLE
change TEST_AERO_LAND default to OFF for gw-ci

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,7 +18,6 @@ Refs NOAA-EMC/repo#5678
 <!-- Which Global Workflow CI tests are required to adequately test this PR? -->
 - [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
 - [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
-- [ ] C96C48_hybatmaerosnowDA  <!-- JEDI aero/snow cycled DA !-->
 - [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
 - [ ] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
 - [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->

--- a/test/gw-ci/CMakeLists.txt
+++ b/test/gw-ci/CMakeLists.txt
@@ -251,7 +251,7 @@ if (WORKFLOW_TESTS)
   # List of tests to run
   option(TEST_GSI "Enable the GFSv17 GSI tests" ON)
   option(TEST_GFS18 "Enable the GFSv18 Atmos JEDI tests" ON)
-  option(TEST_AERO_LAND "Enable the GFSv17 Aero-Land JEDI tests" ON)
+  option(TEST_AERO_LAND "Enable the GFSv17 Aero-Land JEDI tests" OFF)
   option(TEST_MARINE_VAR "Enable the GFSv17 Marine JEDI 3D VAR FGAT tests" ON)
   option(TEST_MARINE_HYB "Enable the GFSv17 Marine JEDI 3d HYB VAR tests" ON)
   option(TEST_GFS17 "Enable the GFSv17 WCDA tests" OFF)


### PR DESCRIPTION
# Description

This PR removes `C96C48_hybatmaerosnowDA` from the GDASApp build when `WORKFLOW_TESTS="ON"`.  It also removes `C96C48_hybatmaerosnowDA` from the list of g-w CI to run when creating GDASApp PRs.  It does not remove all references to `C96C48_hybatmaerosnowDA` from GDASApp.  This can be done as part of GDASApp issues #1734 or #1735.

This simplified PR is opened to allow the daily stable-nightly job to continue running.

See GDASApp issue #1733 for additional information.



# Companion PRs

none

# Issues

Resolves #1733


# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [ ] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
