### PR TITLE
Combine soca increment postprocessing in one step

### DIFF
--- a/parm/soca/soca_det_finalize.yaml.j2
+++ b/parm/soca/soca_det_finalize.yaml.j2
@@ -23,12 +23,8 @@ copy:
 # Recentering error
 #- ['{{ DATA }}/static_ens/{{ domain }}.ssh_recentering_error.incr.{{ MARINE_WINDOW_BEGIN_ISO }}.nc', '{{ COMOUT_OCEAN_ANALYSIS }}/{{ APREFIX }}{{ domain }}.recentering_error.nc']
 {% endfor %}
-# soca2cice ice increment
-{% if DOIAU %}
-- ['{{ DATA }}/Data/ice.soca2cice.incr.{{ MARINE_WINDOW_BEGIN_ISO }}.nc', '{{ COMOUT_OCEAN_ANALYSIS }}/{{ APREFIX }}ice.incr.postproc.nc']
-{% else %}
-- ['{{ DATA }}/Data/ice.soca2cice.incr.{{ MARINE_WINDOW_MIDDLE_ISO }}.nc', '{{ COMOUT_OCEAN_ANALYSIS }}/{{ APREFIX }}ice.incr.postproc.nc']
-{% endif %}
+# Postprocessed ice increment
+- ['{{ DATA }}/ice.inc.nc', '{{ COMOUT_OCEAN_ANALYSIS }}/{{ APREFIX }}ice.incr.postproc.nc']
 # ssh diagnostics
 {% if NMEM_ENS > 2 %}
 {% for string in ['ssh_steric_stddev', 'ssh_unbal_stddev', 'ssh_total_stddev', 'steric_explained_variance'] %}
@@ -42,6 +38,5 @@ copy:
 # YAML files
 - ['{{ DATA }}/fields_metadata.yaml', '{{ COMOUT_OCEAN_ANALYSIS }}/yaml/']
 - ['{{ DATA }}/obsop_name_map.yaml', '{{ COMOUT_OCEAN_ANALYSIS }}/yaml/']
-- ['{{ DATA }}/soca_2cice_global.yaml', '{{ COMOUT_OCEAN_ANALYSIS }}/yaml/']
 - ['{{ DATA }}/soca_diag_stats.yaml', '{{ COMOUT_OCEAN_ANALYSIS }}/yaml/']
-- ['{{ DATA }}/socaincr2mom6.yaml', '{{ COMOUT_OCEAN_ANALYSIS }}/yaml/']
+- ['{{ DATA }}/soca_incpostproc.yaml', '{{ COMOUT_OCEAN_ANALYSIS }}/yaml/']

--- a/utils/soca/gdas_incr_handler.h
+++ b/utils/soca/gdas_incr_handler.h
@@ -19,6 +19,7 @@
 #include "soca/Increment/Increment.h"
 #include "soca/LinearVariableChange/LinearVariableChange.h"
 #include "soca/State/State.h"
+#include "soca/VariableChange/VariableChange.h"
 
 #include "gdas_postprocincr.h"
 
@@ -71,16 +72,39 @@ namespace gdasapp {
         oops::Log::debug() << "========= after appending variables:" << std::endl;
         oops::Log::debug() << incr_mom6 << std::endl;
 
+        eckit::LocalConfiguration xbConfig(fullConfig, "soca background");
+        // Here xx is the background
+        soca::State xx(geom, xbConfig);
         // QC the increment
         if (fullConfig.has("qc increment")) {
-          eckit::LocalConfiguration qcConfig, xbConfig;
+          eckit::LocalConfiguration qcConfig;
           fullConfig.get("qc increment", qcConfig);
-          qcConfig.get("background", xbConfig);
-          soca::State xb(geom, xbConfig);
-          postProcIncr.qcIncrement(xb, incr_mom6, qcConfig, geom);
+          postProcIncr.qcIncrement(xx, incr_mom6, qcConfig, geom);
           oops::Log::debug() << "========= after QC:" << std::endl;
           oops::Log::debug() << incr_mom6 << std::endl;
         }
+
+        // Postprocess the sea ice: get analysis
+        // xx and xa are now the analysis
+        xx += incr_mom6;
+        soca::State xa(xx);
+        oops::Log::debug() << "========= analysis before sea ice postprocessing:" << std::endl;
+        oops::Log::debug() << xa << std::endl;
+        eckit::LocalConfiguration vcConfig(fullConfig, "ice analysis postprocessing");
+        soca::VariableChange vc(vcConfig, geom);
+        oops::Variables varout(vcConfig, "output variables");
+        vc.changeVar(xa, varout);
+        // xa is now the postprocessed analysis
+        oops::Log::debug() << "========= analysis after sea ice postprocessing:" << std::endl;
+        oops::Log::debug() << xa << std::endl;
+        soca::Increment dx(xa.geometry(), xa.variables(), xa.validTime());
+        dx.diff(xa, xx);
+        oops::Log::debug() << "========= sea ice postprocessing difference:" << std::endl;
+        oops::Log::debug() << dx << std::endl;
+        // Bring in the SST adjustment from ice postprocessing to MOM6 increment
+        incr_mom6 += dx;
+        oops::Log::debug() << "========= increment after adding sea ice postprocessing:" << std::endl;
+        oops::Log::debug() << incr_mom6 << std::endl;
 
         // Save final increment
         result = postProcIncr.save(incr_mom6, i, domains);

--- a/utils/soca/gdas_incr_handler.h
+++ b/utils/soca/gdas_incr_handler.h
@@ -103,7 +103,8 @@ namespace gdasapp {
         oops::Log::debug() << dx << std::endl;
         // Bring in the SST adjustment from ice postprocessing to MOM6 increment
         incr_mom6 += dx;
-        oops::Log::debug() << "========= increment after adding sea ice postprocessing:" << std::endl;
+        oops::Log::debug() << "========= increment after adding sea ice postprocessing:"
+                           << std::endl;
         oops::Log::debug() << incr_mom6 << std::endl;
 
         // Save final increment


### PR DESCRIPTION
# Description

Reopening of https://github.com/NOAA-EMC/GDASApp/pull/1729 with correct branch name.

Combines ocean increment and CICE restart postprocessing in one executable. Instead of running separate convertstate for soca->cice, it's now incorporated in the gdas_incr_handler.
This in general simplifies the workflow and will also make it much easier to update ocean increment based on ice postprocessing.

# Companion PRs

https://github.com/NOAA-EMC/global-workflow/pull/3768

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [x] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [x] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
