### PR TITLE
Copy var.yaml to COMROOT

### DIFF
--- a/parm/soca/soca_det_finalize.yaml.j2
+++ b/parm/soca/soca_det_finalize.yaml.j2
@@ -40,3 +40,4 @@ copy:
 - ['{{ DATA }}/obsop_name_map.yaml', '{{ COMOUT_OCEAN_ANALYSIS }}/yaml/']
 - ['{{ DATA }}/soca_diag_stats.yaml', '{{ COMOUT_OCEAN_ANALYSIS }}/yaml/']
 - ['{{ DATA }}/soca_incpostproc.yaml', '{{ COMOUT_OCEAN_ANALYSIS }}/yaml/']
+- ['{{ DATA }}/var.yaml', '{{ COMOUT_OCEAN_ANALYSIS }}/yaml/']


### PR DESCRIPTION

# Description

This bugfix PR allows the var.yaml file to be copied from the RUNDIR to the COMROOT /analysis/ocean/yaml/ directory during the marine variational finalize step. The changes here have been tested during the cp4.02d-parallel experiment running on WCOSS2.


# Issues

Resolves #1769 

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmsnowDA <!-- JEDI snow cycled DA !-->
- [ ] C96_gcafs_cycled <!-- JEDI aerosol cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [ ] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
