### PR TITLE
Print computed standard deviations in chem diag B code

### DIFF
--- a/utils/chem/chem_diagb.h
+++ b/utils/chem/chem_diagb.h
@@ -311,6 +311,8 @@ namespace gdasapp {
       }
 
       // Save the background error
+      oops::Log::info() << "Output Standard Deviations:" << std::endl;
+      oops::Log::info() << bkgErr << std::endl;
       const eckit::LocalConfiguration bkgErrorConfig(fullConfig, "background error");
       bkgErr.write(bkgErrorConfig);
 


### PR DESCRIPTION
# Description

This PR adds a print statement to print out the FV3JEDI Increment of the standard deviations that are being written to disk, purely for logging/diagnostic purposes.

# Companion PRs

None

# Issues

I didn't make one

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmsnowDA <!-- JEDI snow cycled DA !-->
- [ ] C96_gcafs_cycled <!-- JEDI aerosol cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [ ] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
