### PR TITLE
Update aircraft yaml templates

### DIFF
--- a/parm/atm/jcb-prototype_3dvar.yaml.j2
+++ b/parm/atm/jcb-prototype_3dvar.yaml.j2
@@ -8,7 +8,9 @@ observations:
 #  - ADPSFC
 #  - ADPUPA
 #  - SFCSHP
-  - aircraft
+#  - aircraft_humidity
+#  - aircraft_temperature
+#  - aircraft_wind
   - ascatw.ascat_metop-b
 #  - ascatw.ascat_metop-c
   - atms_n20

--- a/parm/atm/jcb-prototype_4d.yaml.j2
+++ b/parm/atm/jcb-prototype_4d.yaml.j2
@@ -8,7 +8,9 @@ observations:
   - amsua_n19
   - sondes
   - atms_n20
-  - aircraft
+#  - aircraft_humidity
+#  - aircraft_temperature
+#  - aircraft_wind
   - satwind
   - omi_aura
   - ompsnp_npp

--- a/parm/atm/jcb-prototype_lgetkf.yaml.j2
+++ b/parm/atm/jcb-prototype_lgetkf.yaml.j2
@@ -17,7 +17,9 @@ observations:
 #  - ADPSFC
 #  - ADPUPA
 #  - SFCSHP
-  - aircraft
+#  - aircraft_humidity
+#  - aircraft_temperature
+#  - aircraft_wind
   - ascatw.ascat_metop-b
 #  - ascatw.ascat_metop-c
   - atms_n20

--- a/parm/atm/jcb-prototype_lgetkf_observer.yaml.j2
+++ b/parm/atm/jcb-prototype_lgetkf_observer.yaml.j2
@@ -17,7 +17,9 @@ observations:
 #  - ADPSFC
 #  - ADPUPA
 #  - SFCSHP
-  - aircraft
+#  - aircraft_humidity
+#  - aircraft_temperature
+#  - aircraft_wind
   - ascatw.ascat_metop-b
 #  - ascatw.ascat_metop-c
   - atms_n20

--- a/parm/atm/jcb-prototype_lgetkf_solver.yaml.j2
+++ b/parm/atm/jcb-prototype_lgetkf_solver.yaml.j2
@@ -17,7 +17,9 @@ observations:
 #  - ADPSFC
 #  - ADPUPA
 #  - SFCSHP
-  - aircraft
+#  - aircraft_humidity
+#  - aircraft_temperature
+#  - aircraft_wind
   - ascatw.ascat_metop-b
 #  - ascatw.ascat_metop-c
   - atms_n20

--- a/test/gw-ci/atm/jcb-prototype_3dvar_ufs_hybatmDA.yaml.j2
+++ b/test/gw-ci/atm/jcb-prototype_3dvar_ufs_hybatmDA.yaml.j2
@@ -8,7 +8,9 @@ observations:
 #  - ADPSFC
 #  - ADPUPA
 #  - SFCSHP
-  - aircraft
+#  - aircraft_humidity
+#  - aircraft_temperature
+#  - aircraft_wind
   - ascatw.ascat_metop-b
 #  - ascatw.ascat_metop-c
   - atms_n20

--- a/test/gw-ci/atm/jcb-prototype_lgetkf_observer_ufs_hybatmDA.yaml.j2
+++ b/test/gw-ci/atm/jcb-prototype_lgetkf_observer_ufs_hybatmDA.yaml.j2
@@ -17,7 +17,9 @@ observations:
 #  - ADPSFC
 #  - ADPUPA
 #  - SFCSHP
-  - aircraft
+#  - aircraft_humidity
+#  - aircraft_temperature
+#  - aircraft_wind
   - ascatw.ascat_metop-b
 #  - ascatw.ascat_metop-c
   - atms_n20

--- a/test/gw-ci/atm/jcb-prototype_lgetkf_solver_ufs_hybatmDA.yaml.j2
+++ b/test/gw-ci/atm/jcb-prototype_lgetkf_solver_ufs_hybatmDA.yaml.j2
@@ -17,7 +17,9 @@ observations:
 #  - ADPSFC
 #  - ADPUPA
 #  - SFCSHP
-  - aircraft
+#  - aircraft_humidity
+#  - aircraft_temperature
+#  - aircraft_wind
   - ascatw.ascat_metop-b
 #  - ascatw.ascat_metop-c
   - atms_n20

--- a/test/gw-ci/atm/jcb-prototype_lgetkf_ufs_hybatmDA.yaml.j2
+++ b/test/gw-ci/atm/jcb-prototype_lgetkf_ufs_hybatmDA.yaml.j2
@@ -17,7 +17,9 @@ observations:
 #  - ADPSFC
 #  - ADPUPA
 #  - SFCSHP
-  - aircraft
+#  - aircraft_humidity
+#  - aircraft_temperature
+#  - aircraft_wind
   - ascatw.ascat_metop-b
 #  - ascatw.ascat_metop-c
   - atms_n20


### PR DESCRIPTION
# Description

This PR replaces `aircraft` in observation yaml templates with observation specific aircraft profiles:  `aircraft_humidity`, `aircraft_temperature`, `aircraft_wind`.

Note that while observation types `aicraft_humidity`, `aircraft_temperature`, and `aircraft_wind` are added to the affected templates, these observation types are commented out.  No aircraft data will be assimilated.

# Companion PRs

None

# Issues

Resolves #1779 

# Automated CI tests to run in Global Workflow

- [x] atm_jjob <!-- JEDI atm single cycle DA !-->
- [x] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [x] C96C48_hybatmsnowDA <!-- JEDI snow cycled DA !-->
- [x] C96_gcafs_cycled <!-- JEDI aerosol cycled DA !-->
- [x] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [x] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [x] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
