### PR TITLE
Fix NOAA-EMC fork syncing

### DIFF
--- a/ci/stable_driver.sh
+++ b/ci/stable_driver.sh
@@ -80,24 +80,12 @@ BODY=$stableroot/$datestr/stable_nightly
 # ==============================================================================
 # run the automated testing
 
-# Run CI testing
-$my_dir/run_ci.sh -d $stableroot/$datestr/global-workflow -o $stableroot/$datestr/output -w
-ci_status=$?
-
 # Sync NOAA-EMC forks of JCSDA repositories
 $my_dir/sync_forks.sh
 sync_status=$?
 
-total=0
-if [ $ci_status -eq 0 ] && [ $sync_status -eq 0 ]; then
-  # sync NOAA-EMC forks of JCSDA repositories
-  $my_dir/sync_forks.sh
-  rc=$?
-  total=$(($total+$rc))
-  if [ $rc -ne 0 ]; then
-    echo "Unable to sync NOAA-EMC forks of JCSDA repositories" >> $stableroot/$datestr/output
-  fi
-
+if [ $sync_status -eq 0 ]; then
+  total=0
   cd $gdasdir
 
   # checkout feature/stable-nightly
@@ -109,7 +97,9 @@ if [ $ci_status -eq 0 ] && [ $sync_status -eq 0 ]; then
   fi
 
   # merge in develop
-  git merge develop
+  if [ $total -eq 0 ]; then
+    git merge develop
+  fi
   rc=$?
   total=$(($total+$rc))
   if [ $rc -ne 0 ]; then
@@ -117,7 +107,9 @@ if [ $ci_status -eq 0 ] && [ $sync_status -eq 0 ]; then
   fi
 
   # add in submodules
-  $gdasdir/ush/submodules/add_submodules.sh $gdasdir
+  if [ $total -eq 0 ]; then
+    $gdasdir/ush/submodules/add_submodules.sh $gdasdir
+  fi
   rc=$?
   total=$(($total+$rc))
   if [ $rc -ne 0 ]; then
@@ -125,7 +117,9 @@ if [ $ci_status -eq 0 ] && [ $sync_status -eq 0 ]; then
   fi
 
   # commit the changes
-  git diff-index --quiet HEAD || git commit -m "Update to new stable build on $datestr"
+  if [ $total -eq 0 ]; then
+    git diff-index --quiet HEAD || git commit -m "Update to new stable build on $datestr"
+  fi
   rc=$?
   total=$(($total+$rc))
   if [ $rc -ne 0 ]; then
@@ -133,51 +127,47 @@ if [ $ci_status -eq 0 ] && [ $sync_status -eq 0 ]; then
   fi
 
   # push the changes
-  git push --set-upstream origin feature/stable-nightly
+  if [ $total -eq 0 ]; then
+    git push --set-upstream origin feature/stable-nightly
+  fi
   rc=$?
   total=$(($total+$rc))
   if [ $rc -ne 0 ]; then
     echo "Unable to push" >> $stableroot/$datestr/output
   fi
 
+  # run CI testing
+  if [ $total -eq 0 ]; then
+    $my_dir/run_ci.sh -d $stableroot/$datestr/global-workflow -o $stableroot/$datestr/output -w
+  fi
+  rc=$?
+  total=$(($total+$rc))
+  if [ $rc -ne 0 ]; then
+    echo "CI testing failed" >> $stableroot/$datestr/output
+  fi
+
   if [ $total -ne 0 ]; then
-    SUBJECT="Problem updating feature/stable-nightly branch of GDASApp"
+    SUBJECT="Problem updating or testing feature/stable-nightly branch of GDASApp"
     cat > $BODY << EOF
 Problem updating feature/stable-nightly branch of GDASApp. Please check $stableroot/$datestr/global-workflow
 
 EOF
-    echo $SUBJECT
-    mail -r "Darth Vader - NOAA Affiliate <darth.vader@noaa.gov>" -s "$SUBJECT" "$PEOPLE" < $BODY
   else
-    SUBJECT="Success updating feature/stable-nightly branch of GDASApp"
+    SUBJECT="Success updating and testing feature/stable-nightly branch of GDASApp"
     cat > $BODY << EOF
 feature/stable-nightly branch of GDASApp updated successfully. See $stableroot/$datestr/global-workflow for details.
 
 EOF
-    echo $SUBJECT
-    mail -r "Darth Vader - NOAA Affiliate <darth.vader@noaa.gov>" -s "$SUBJECT" "$PEOPLE" < $BODY
   fi
 else
-  # do nothing
-  if [ $ci_status -ne 0 ]; then
-    SUBJECT="Testing or building of feature/stable-nightly branch of GDASApp failed"
-    cat > $BODY << EOF
-Testing or building of feature/stable-nightly branch of GDASApp failed. Please check $stableroot/$datestr/global-workflow.
+  SUBJECT="Problem syncing NOAA-EMC forks of JCSDA repositories"
+  cat > $BODY << EOF
+Problem syncing NOAA-EMC forks of JCSDA repositories. Please check $stableroot/$datestr/global-workflow.
 
 EOF
-    echo $SUBJECT
-    mail -r "Darth Vader - NOAA Affiliate <darth.vader@noaa.gov>" -s "$SUBJECT" "$PEOPLE" < $BODY  
-  fi
-  if [ $sync_status -ne 0 ]; then
-    SUBJECT="Syncing of NOAA-EMC forks of JCSDA repositories failed"
-    cat > $BODY << EOF
-Syncing of NOAA-EMC forks of JCSDA repositories failed. Please check $stableroot/$datestr/global-workflow.
-
-EOF
-    echo $SUBJECT
-    mail -r "Darth Vader - NOAA Affiliate <darth.vader@noaa.gov>" -s "$SUBJECT" "$PEOPLE" < $BODY
-  fi
-fi 
+fi
+echo $SUBJECT
+mail -r "Darth Vader - NOAA Affiliate <darth.vader@noaa.gov>" -s "$SUBJECT" "$PEOPLE" < $BODY
 # ==============================================================================
 # publish some information to RZDM for quick viewing
 # THIS IS A TODO FOR NOW

--- a/ci/stable_driver.sh
+++ b/ci/stable_driver.sh
@@ -48,8 +48,6 @@ esac
 
 set -x
 # ==============================================================================
-# Sync NOAA-EMC forks of JCSDA repositories
-$my_dir/sync_forks.sh
 
 datestr="$(date +%Y%m%d)"
 repo_url="https://github.com/NOAA-EMC/GDASApp.git"
@@ -81,11 +79,27 @@ BODY=$stableroot/$datestr/stable_nightly
 
 # ==============================================================================
 # run the automated testing
+
+# Run CI testing
 $my_dir/run_ci.sh -d $stableroot/$datestr/global-workflow -o $stableroot/$datestr/output -w
 ci_status=$?
+
+# Sync NOAA-EMC forks of JCSDA repositories
+$my_dir/sync_forks.sh
+sync_status=$?
+
 total=0
-if [ $ci_status -eq 0 ]; then
+if [ $ci_status -eq 0 ] && [ $sync_status -eq 0 ]; then
+  # sync NOAA-EMC forks of JCSDA repositories
+  $my_dir/sync_forks.sh
+  rc=$?
+  total=$(($total+$rc))
+  if [ $rc -ne 0 ]; then
+    echo "Unable to sync NOAA-EMC forks of JCSDA repositories" >> $stableroot/$datestr/output
+  fi
+
   cd $gdasdir
+
   # checkout feature/stable-nightly
   git checkout feature/stable-nightly
   rc=$?
@@ -93,6 +107,7 @@ if [ $ci_status -eq 0 ]; then
   if [ $rc -ne 0 ]; then
     echo "Unable to checkout feature/stable-nightly" >> $stableroot/$datestr/output
   fi
+
   # merge in develop
   git merge develop
   rc=$?
@@ -100,6 +115,7 @@ if [ $ci_status -eq 0 ]; then
   if [ $rc -ne 0 ]; then
     echo "Unable to merge develop" >> $stableroot/$datestr/output
   fi
+
   # add in submodules
   $gdasdir/ush/submodules/add_submodules.sh $gdasdir
   rc=$?
@@ -107,43 +123,61 @@ if [ $ci_status -eq 0 ]; then
   if [ $rc -ne 0 ]; then
     echo "Unable to add updated submodules to commit" >> $stableroot/$datestr/output
   fi
+
+  # commit the changes
   git diff-index --quiet HEAD || git commit -m "Update to new stable build on $datestr"
   rc=$?
   total=$(($total+$rc))
   if [ $rc -ne 0 ]; then
     echo "Unable to commit" >> $stableroot/$datestr/output
   fi
+
+  # push the changes
   git push --set-upstream origin feature/stable-nightly
   rc=$?
   total=$(($total+$rc))
   if [ $rc -ne 0 ]; then
     echo "Unable to push" >> $stableroot/$datestr/output
   fi
+
   if [ $total -ne 0 ]; then
     SUBJECT="Problem updating feature/stable-nightly branch of GDASApp"
     cat > $BODY << EOF
 Problem updating feature/stable-nightly branch of GDASApp. Please check $stableroot/$datestr/global-workflow
 
 EOF
-
+    echo $SUBJECT
+    mail -r "Darth Vader - NOAA Affiliate <darth.vader@noaa.gov>" -s "$SUBJECT" "$PEOPLE" < $BODY
   else
     SUBJECT="Success updating feature/stable-nightly branch of GDASApp"
     cat > $BODY << EOF
 feature/stable-nightly branch of GDASApp updated successfully. See $stableroot/$datestr/global-workflow for details.
 
 EOF
-
+    echo $SUBJECT
+    mail -r "Darth Vader - NOAA Affiliate <darth.vader@noaa.gov>" -s "$SUBJECT" "$PEOPLE" < $BODY
   fi
 else
   # do nothing
-  SUBJECT="Testing or building of feature/stable-nightly branch of GDASApp failed"
-  cat > $BODY << EOF
+  if [ $ci_status -ne 0 ]; then
+    SUBJECT="Testing or building of feature/stable-nightly branch of GDASApp failed"
+    cat > $BODY << EOF
 Testing or building of feature/stable-nightly branch of GDASApp failed. Please check $stableroot/$datestr/global-workflow.
 
 EOF
-fi
-echo $SUBJECT
-mail -r "Darth Vader - NOAA Affiliate <darth.vader@noaa.gov>" -s "$SUBJECT" "$PEOPLE" < $BODY  
+    echo $SUBJECT
+    mail -r "Darth Vader - NOAA Affiliate <darth.vader@noaa.gov>" -s "$SUBJECT" "$PEOPLE" < $BODY  
+  fi
+  if [ $sync_status -ne 0 ]; then
+    SUBJECT="Syncing of NOAA-EMC forks of JCSDA repositories failed"
+    cat > $BODY << EOF
+Syncing of NOAA-EMC forks of JCSDA repositories failed. Please check $stableroot/$datestr/global-workflow.
+
+EOF
+    echo $SUBJECT
+    mail -r "Darth Vader - NOAA Affiliate <darth.vader@noaa.gov>" -s "$SUBJECT" "$PEOPLE" < $BODY
+  fi
+fi 
 # ==============================================================================
 # publish some information to RZDM for quick viewing
 # THIS IS A TODO FOR NOW

--- a/ci/stable_driver.sh
+++ b/ci/stable_driver.sh
@@ -62,15 +62,11 @@ cd $stableroot/$datestr
 git clone --recursive $workflow_url
 
 # checkout develop
-cd $stableroot/$datestr/global-workflow/sorc/gdas.cd
+gdasdir=$stableroot/$datestr/global-workflow/sorc/gdas.cd
+cd "$gdasdir"
 git checkout develop
 git pull
 git submodule update --init --recursive
-
-# ==============================================================================
-# update the hashes to the most recent
-gdasdir=$stableroot/$datestr/global-workflow/sorc/gdas.cd
-$gdasdir/ush/submodules/update_develop.sh $gdasdir
 
 # ==============================================================================
 # email information
@@ -86,10 +82,20 @@ sync_status=$?
 
 if [ $sync_status -eq 0 ]; then
   total=0
-  cd $gdasdir
+  cd "$gdasdir"
+
+  # update develop branch
+  $gdasdir/ush/submodules/update_develop.sh "$gdasdir"
+  rc=$?
+  total=$(($total+$rc))
+  if [ $rc -ne 0 ]; then
+    echo "Unable to update develop branch" >> $stableroot/$datestr/output
+  fi
 
   # checkout feature/stable-nightly
-  git checkout feature/stable-nightly
+  if [ $total -eq 0 ]; then
+    git checkout feature/stable-nightly
+  fi
   rc=$?
   total=$(($total+$rc))
   if [ $rc -ne 0 ]; then

--- a/ci/stable_driver.sh
+++ b/ci/stable_driver.sh
@@ -106,6 +106,16 @@ if [ $sync_status -eq 0 ]; then
     echo "Unable to merge develop" >> $stableroot/$datestr/output
   fi
 
+  # run CI testing
+  if [ $total -eq 0 ]; then
+    $my_dir/run_ci.sh -d $stableroot/$datestr/global-workflow -o $stableroot/$datestr/output -w
+  fi
+  rc=$?
+  total=$(($total+$rc))
+  if [ $rc -ne 0 ]; then
+    echo "CI testing failed" >> $stableroot/$datestr/output
+  fi
+
   # add in submodules
   if [ $total -eq 0 ]; then
     $gdasdir/ush/submodules/add_submodules.sh $gdasdir
@@ -134,16 +144,6 @@ if [ $sync_status -eq 0 ]; then
   total=$(($total+$rc))
   if [ $rc -ne 0 ]; then
     echo "Unable to push" >> $stableroot/$datestr/output
-  fi
-
-  # run CI testing
-  if [ $total -eq 0 ]; then
-    $my_dir/run_ci.sh -d $stableroot/$datestr/global-workflow -o $stableroot/$datestr/output -w
-  fi
-  rc=$?
-  total=$(($total+$rc))
-  if [ $rc -ne 0 ]; then
-    echo "CI testing failed" >> $stableroot/$datestr/output
   fi
 
   if [ $total -ne 0 ]; then

--- a/ci/stable_driver.sh
+++ b/ci/stable_driver.sh
@@ -92,6 +92,16 @@ if [ $sync_status -eq 0 ]; then
     echo "Unable to update develop branch" >> $stableroot/$datestr/output
   fi
 
+  # run CI testing
+  if [ $total -eq 0 ]; then
+    $my_dir/run_ci.sh -d $stableroot/$datestr/global-workflow -o $stableroot/$datestr/output -w
+  fi
+  rc=$?
+  total=$(($total+$rc))
+  if [ $rc -ne 0 ]; then
+    echo "CI testing failed" >> $stableroot/$datestr/output
+  fi
+
   # checkout feature/stable-nightly
   if [ $total -eq 0 ]; then
     git checkout feature/stable-nightly
@@ -110,16 +120,6 @@ if [ $sync_status -eq 0 ]; then
   total=$(($total+$rc))
   if [ $rc -ne 0 ]; then
     echo "Unable to merge develop" >> $stableroot/$datestr/output
-  fi
-
-  # run CI testing
-  if [ $total -eq 0 ]; then
-    $my_dir/run_ci.sh -d $stableroot/$datestr/global-workflow -o $stableroot/$datestr/output -w
-  fi
-  rc=$?
-  total=$(($total+$rc))
-  if [ $rc -ne 0 ]; then
-    echo "CI testing failed" >> $stableroot/$datestr/output
   fi
 
   # add in submodules

--- a/ci/stable_driver.sh
+++ b/ci/stable_driver.sh
@@ -149,7 +149,7 @@ if [ $sync_status -eq 0 ]; then
   if [ $total -ne 0 ]; then
     SUBJECT="Problem updating or testing feature/stable-nightly branch of GDASApp"
     cat > $BODY << EOF
-Problem updating feature/stable-nightly branch of GDASApp. Please check $stableroot/$datestr/global-workflow
+Problem updating feature/stable-nightly branch of GDASApp. Please check $stableroot/$datestr/global-workflow and $stableroot/$datestr/output
 
 EOF
   else
@@ -162,7 +162,7 @@ EOF
 else
   SUBJECT="Problem syncing NOAA-EMC forks of JCSDA repositories"
   cat > $BODY << EOF
-Problem syncing NOAA-EMC forks of JCSDA repositories. Please check $stableroot/$datestr/global-workflow.
+Problem syncing NOAA-EMC forks of JCSDA repositories. Please check $stableroot/$datestr/global-workflow and $stableroot/$datestr/output
 
 EOF
 fi

--- a/ci/sync_forks.sh
+++ b/ci/sync_forks.sh
@@ -27,7 +27,7 @@ for repo_name in "${fork_repos[@]}"; do
     # Update develop branch
     git branch -D develop || { echo "$repo_name: Failed to delete develop branch"; exit 1; }
     git checkout -b develop || { echo "$repo_name: Failed to create develop branch"; exit 1; }
-    git push --set-upstream origin develop || { echo "$repo_name: Failed to push develop branch"; exit 1; }
+    #git push --set-upstream origin develop || { echo "$repo_name: Failed to push develop branch"; exit 1; }
 
     # Update dev/emc branch
     git checkout -b dev/emc origin/dev/emc || { echo "$repo_name: Failed to create dev/emc branch"; exit 1; }
@@ -42,12 +42,12 @@ for repo_name in "${fork_repos[@]}"; do
         git commit --no-edit 2>/dev/null || git merge --continue 2>/dev/null
 
         # If merge is still in progress (conflicts remain), then fail
-        if ! git merge --abort 2>/dev/null; then
+        if git merge --abort 2>/dev/null; then
             echo "$repo_name: Failed to merge jcsda/develop into dev/emc"
             exit 1
         fi
     }
-    git push --set-upstream origin dev/emc || { echo "$repo_name: Failed to push dev/emc branch"; exit 1; }
+    #git push --set-upstream origin dev/emc || { echo "$repo_name: Failed to push dev/emc branch"; exit 1; }
 
     # Change directory back to sync root and delete the cloned repo
     cd "$syncroot"

--- a/ci/sync_forks.sh
+++ b/ci/sync_forks.sh
@@ -14,6 +14,7 @@ cd "$syncroot"
 
 for repo_name in "${fork_repos[@]}"; do
     # Clone fork develop branch
+    [ -d "$syncroot/$repo_name" ] && rm -rf "$syncroot/$repo_name" # delete repo directory if it already exists
     repo_url="https://github.com/NOAA-EMC/${repo_name}.git"
     git clone -b develop $repo_url || { echo "Failed to clone $repo_name develop branch"; exit 1; }
     mkdir -p "$syncroot/$repo_name" # make sure the directory exists
@@ -27,12 +28,24 @@ for repo_name in "${fork_repos[@]}"; do
     # Update develop branch
     git branch -D develop || { echo "$repo_name: Failed to delete develop branch"; exit 1; }
     git checkout -b develop || { echo "$repo_name: Failed to create develop branch"; exit 1; }
-    git push --set-upstream origin develop || { echo "$repo_name: Failed to push develop branch"; exit 1; }
+    #git push --set-upstream origin develop || { echo "$repo_name: Failed to push develop branch"; exit 1; }
 
     # Update dev/emc branch
     git checkout -b dev/emc origin/dev/emc || { echo "$repo_name: Failed to create dev/emc branch"; exit 1; }
-    git merge jcsda/develop --no-edit || { echo "$repo_name: Failed to merge jcsda/develop into dev/emc"; exit 1; }
-    git push --set-upstream origin dev/emc || { echo "$repo_name: Failed to push dev/emc branch"; exit 1; }
+    git merge jcsda/develop --no-edit || {
+        # Try to resolve deleted submodule conflicts automatically
+        git status --porcelain | grep '^DU ' | awk '{print $2}' | xargs -r git rm -f
+
+        # Try to complete the merge
+        git commit --no-edit 2>/dev/null || git merge --continue 2>/dev/null
+
+        # If merge is still in progress (conflicts remain), then fail
+        if git merge --abort 2>/dev/null; then
+            echo "$repo_name: Failed to merge jcsda/develop into dev/emc"
+            exit 1
+        fi
+    }
+    #git push --set-upstream origin dev/emc || { echo "$repo_name: Failed to push dev/emc branch"; exit 1; }
 
     # Change directory back to sync root and delete the cloned repo
     cd "$syncroot"

--- a/ci/sync_forks.sh
+++ b/ci/sync_forks.sh
@@ -17,7 +17,6 @@ for repo_name in "${fork_repos[@]}"; do
     [ -d "$syncroot/$repo_name" ] && rm -rf "$syncroot/$repo_name" # delete repo directory if it already exists
     repo_url="https://github.com/NOAA-EMC/${repo_name}.git"
     git clone -b develop $repo_url || { echo "Failed to clone $repo_name develop branch"; exit 1; }
-    mkdir -p "$syncroot/$repo_name" # make sure the directory exists
     cd "$syncroot/$repo_name"
 
     # Fetch JCSDA remote
@@ -33,14 +32,17 @@ for repo_name in "${fork_repos[@]}"; do
     # Update dev/emc branch
     git checkout -b dev/emc origin/dev/emc || { echo "$repo_name: Failed to create dev/emc branch"; exit 1; }
     git merge jcsda/develop --no-edit || {
-        # Try to resolve deleted submodule conflicts automatically
-        git status --porcelain | grep '^DU ' | awk '{print $2}' | xargs -r git rm -f
+        # Try to resolve deleted file/submodule conflicts automatically
+        deleted_files=$(git status --porcelain | grep '^DU ' | awk '{print $2}')
+        if [ -n "$deleted_files" ]; then
+            echo "$deleted_files" | xargs git rm -f
+        fi
 
         # Try to complete the merge
         git commit --no-edit 2>/dev/null || git merge --continue 2>/dev/null
 
         # If merge is still in progress (conflicts remain), then fail
-        if git merge --abort 2>/dev/null; then
+        if ! git merge --abort 2>/dev/null; then
             echo "$repo_name: Failed to merge jcsda/develop into dev/emc"
             exit 1
         fi

--- a/ci/sync_forks.sh
+++ b/ci/sync_forks.sh
@@ -27,7 +27,7 @@ for repo_name in "${fork_repos[@]}"; do
     # Update develop branch
     git branch -D develop || { echo "$repo_name: Failed to delete develop branch"; exit 1; }
     git checkout -b develop || { echo "$repo_name: Failed to create develop branch"; exit 1; }
-    #git push --set-upstream origin develop || { echo "$repo_name: Failed to push develop branch"; exit 1; }
+    git push --set-upstream origin develop || { echo "$repo_name: Failed to push develop branch"; exit 1; }
 
     # Update dev/emc branch
     git checkout -b dev/emc origin/dev/emc || { echo "$repo_name: Failed to create dev/emc branch"; exit 1; }
@@ -47,7 +47,7 @@ for repo_name in "${fork_repos[@]}"; do
             exit 1
         fi
     }
-    #git push --set-upstream origin dev/emc || { echo "$repo_name: Failed to push dev/emc branch"; exit 1; }
+    git push --set-upstream origin dev/emc || { echo "$repo_name: Failed to push dev/emc branch"; exit 1; }
 
     # Change directory back to sync root and delete the cloned repo
     cd "$syncroot"

--- a/ci/sync_forks.sh
+++ b/ci/sync_forks.sh
@@ -28,7 +28,7 @@ for repo_name in "${fork_repos[@]}"; do
     # Update develop branch
     git branch -D develop || { echo "$repo_name: Failed to delete develop branch"; exit 1; }
     git checkout -b develop || { echo "$repo_name: Failed to create develop branch"; exit 1; }
-    #git push --set-upstream origin develop || { echo "$repo_name: Failed to push develop branch"; exit 1; }
+    git push --set-upstream origin develop || { echo "$repo_name: Failed to push develop branch"; exit 1; }
 
     # Update dev/emc branch
     git checkout -b dev/emc origin/dev/emc || { echo "$repo_name: Failed to create dev/emc branch"; exit 1; }
@@ -45,7 +45,7 @@ for repo_name in "${fork_repos[@]}"; do
             exit 1
         fi
     }
-    #git push --set-upstream origin dev/emc || { echo "$repo_name: Failed to push dev/emc branch"; exit 1; }
+    git push --set-upstream origin dev/emc || { echo "$repo_name: Failed to push dev/emc branch"; exit 1; }
 
     # Change directory back to sync root and delete the cloned repo
     cd "$syncroot"


### PR DESCRIPTION
# Description

This PR fixes the failure that occurred while syncing the NOAA-EMC soca fork due to merge conflicts after MOM6 or Icepack submodules are updated. `sync_forks.sh` now checks `git status` for the `Deleted by Us` conflicts that arise and automatically resolves them with `git rm`.

Also, now if syncing fails, `stable_driver.sh` sends and email to Darth Vader, alerting us so (probably due to additional conflicts).