### PR TITLE
add ursa GDASApp CI scripts

### DIFF
--- a/ci/driver.sh
+++ b/ci/driver.sh
@@ -41,7 +41,7 @@ done
 echo "Running automated testing on $TARGET"
 
 case ${TARGET} in
-  hera | orion | hercules)
+  hera | ursa | orion | hercules)
     source $MODULESHOME/init/sh
     source $my_dir/${TARGET}.sh
     module purge

--- a/ci/run_ci.sh
+++ b/ci/run_ci.sh
@@ -94,11 +94,16 @@ fi
 # run ctests
 
 # PATCH START
-# HERA role.jedipara can not use /scratch1/NCEPDEV/global. MSU role-da
-# can not use /work2/noaa/global. The logic below modifies the paths so
+# HERA role.jedipara can not use /scratch1/NCEPDEV/global.
+# URSA role.jedipara can not use /scratch3/NCEPDEV/global.
+# MSU role-da can not use /work2/noaa/global. The logic below modifies the paths so
 # role.jedipara and role-da can run g-w based ctests.
 if [[ $TEST_WORKFLOW == 1 ]]; then
   if [[ "${TARGET}" = "hera" ]]; then
+    echo "***WARNING*** apply ${TARGET} global-->da patch to $workflow_dir/dev/workflow/hosts/${TARGET}.yaml"
+    sed -i "s|/scratch1/NCEPDEV/global/\${USER}|/scratch1/NCEPDEV/da/\${USER}|g" $workflow_dir/dev/workflow/hosts/${TARGET}.yaml
+  fi
+  if [[ "${TARGET}" = "ursa" ]]; then
     echo "***WARNING*** apply ${TARGET} global-->da patch to $workflow_dir/dev/workflow/hosts/${TARGET}.yaml"
     sed -i "s|/scratch1/NCEPDEV/global/\${USER}|/scratch1/NCEPDEV/da/\${USER}|g" $workflow_dir/dev/workflow/hosts/${TARGET}.yaml
   fi

--- a/ci/stable_driver.sh
+++ b/ci/stable_driver.sh
@@ -31,7 +31,7 @@ while getopts "t:h" opt; do
 done
 
 case ${TARGET} in
-  hera | orion)
+  hera | ursa | orion)
     echo "Running stability check on $TARGET"
     source $MODULESHOME/init/sh
     source $my_dir/${TARGET}.sh

--- a/ci/ursa.sh
+++ b/ci/ursa.sh
@@ -1,0 +1,10 @@
+export GDAS_CI_ROOT=/scratch3/NCEPDEV/da/role.jedipara/CI/GDASApp
+export GDAS_CI_HOST='ursa'
+export GDAS_MODULE_USE=$GDAS_CI_ROOT/repo/modulefiles
+export SLURM_ACCOUNT=da-cpu
+export SALLOC_ACCOUNT=$SLURM_ACCOUNT
+export SBATCH_ACCOUNT=$SLURM_ACCOUNT
+export SLURM_QOS=debug
+export PATH=$PATH:/home/role.jedipara/bin
+export NTASKS_TESTS=12
+export AUTHORIZED_USERS_FILE=/scratch3/NCEPDEV/da/role.jedipara/CI/GDASApp/authorized_users

--- a/ci/validation/validation_driver.sh
+++ b/ci/validation/validation_driver.sh
@@ -31,7 +31,7 @@ while getopts "t:h" opt; do
 done
 
 case ${TARGET} in
-  hera | orion)
+  hera | ursa | orion)
     echo "Running Automated Testing on $TARGET"
     source $MODULESHOME/init/sh
     source $my_dir/../${TARGET}.sh
@@ -60,7 +60,7 @@ cd GDASApp
 
 # load modules
 case ${TARGET} in
-  hera | orion)
+  hera | ursa | orion)
     echo "Loading modules on $TARGET"
     module purge
     module use $GDAS_CI_ROOT/validation/$today/GDASApp/modulefiles


### PR DESCRIPTION
# Description

This PR adds ursa to the list of GDASApp CI machines.  This is required given the decommissioning of Hera.

# Companion PRs

None

# Issues

Resolves #1795

# Automated CI tests to run in Global Workflow
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmsnowDA <!-- JEDI snow cycled DA !-->
- [ ] C96_gcafs_cycled <!-- JEDI aerosol cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [ ] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
