### PR TITLE
Resurrect solo build of GDASApp

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -108,6 +108,10 @@ if [[ $WORKFLOW_BUILD == 'ON' ]]; then
   rm -rf $dir_root/sorc/soca/external/icepack/Icepack
   ln -sf $HOMEgfs/sorc/ufs_model.fd/MOM6-interface/MOM6/ $dir_root/sorc/soca/external/mom6/MOM6
   ln -sf $HOMEgfs/sorc/ufs_model.fd/CICE-interface/CICE/icepack/ $dir_root/sorc/soca/external/icepack/Icepack
+else
+  # Delete forked SOCA NOAA-EMC dev/emc repo and clone the original JCSDA develop repo
+  rm -rf "$dir_root/sorc/soca/"
+  git clone https://github.com/jcsda/soca "$dir_root/sorc/soca" --recurse-submodules
 fi
 
 # Set INSTALL_PREFIX as CMake option


### PR DESCRIPTION
# Description

The PR once again allows users to build GDASApp alone and outside of the Global Workflow. It simply deletes the forked soca NOAA-EMC dev/emc repo and clones soca develop from the original JCSDA repo. The caveat here is that JCSDA develop may be ahead of NOAA-EMC dev/emc by a number of commits and may break GDASApp.

# Companion PRs

N/A

# Issues

N/A

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmsnowDA <!-- JEDI snow cycled DA !-->
- [ ] C96_gcafs_cycled <!-- JEDI aerosol cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [ ] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
