### PR TITLE
Bugfix for marine ensemble var and stddev computation

### DIFF
--- a/utils/soca/gdas_ens_handler.h
+++ b/utils/soca/gdas_ens_handler.h
@@ -53,7 +53,7 @@ namespace gdasapp_ens_utils {
         pert.schur_product_with(pert);
         ensVar += pert;
       }
-      ensVar.axpy(rk, ensStd);
+      ensVar *= rk;
 
       // Standard deviation
       ensStd = ensVar;


### PR DESCRIPTION
# Description

Fixes the computation of ensemble variance (output in the file for diagnostics) and stddev (output in the log for diagnostics).
Tested by comparing with parallel ensemble recenter that uses different code to compute variance and stddev. The results on this branch are correct.

# Issues

Resolves #1856

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmsnowDA <!-- JEDI snow cycled DA !-->
- [ ] C96_gcafs_cycled <!-- JEDI aerosol cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [x] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
