### PR TITLE
Use parallel ensemble recentering for soca

### DIFF
--- a/mains/CMakeLists.txt
+++ b/mains/CMakeLists.txt
@@ -22,6 +22,11 @@ ecbuild_add_executable( TARGET  gdas_soca_setcorscales.x
                         LIBS    soca
                       )
 
+ecbuild_add_executable( TARGET  gdas_soca_anpproc.x
+	                SOURCES ${CMAKE_SOURCE_DIR}/soca/src/mains/AnalysisPostproc.cc
+			LIBS    soca
+		      )
+
 ecbuild_add_executable( TARGET  gdas_fv3jedi_error_covariance_toolbox.x
                         SOURCES ${CMAKE_SOURCE_DIR}/fv3-jedi/src/mains/fv3jediErrorCovarianceToolbox.cc
                         LIBS    fv3jedi saber

--- a/parm/soca/soca_ecen_finalize.yaml.j2
+++ b/parm/soca/soca_ecen_finalize.yaml.j2
@@ -18,13 +18,16 @@ mkdir:
 {% endfor %}
 copy:
 {% for imem in range(1,NMEM_ENS+1) %}
+    {% set imem0 = imem-1 %}
     {% set memchar = 'mem%03d' | format(imem) %}
     {% set tmpl_dict = ({ '${ROTDIR}': ROTDIR,
                           '${RUN}': RUN,
                           '${YMD}': current_cycle | to_YMD,
                           '${HH}': current_cycle | strftime('%H'),
                           '${MEMDIR}': memchar }) %}
-- ['{{ DATA }}/ocn.recenter.incr.{{ MARINE_WINDOW_END_ISO }}.nc', '{{ COM_OCEAN_ANALYSIS_TMPL | replace_tmpl(tmpl_dict) }}/{{ RUN }}.t{{ "%02d" | format(cyc) }}z.ocninc.nc']
+# ocean increments are saved as 0..n-1
+- ['{{ DATA }}/ocn.recenter.ens.{{ imem0 | string}}.{{ MARINE_WINDOW_END_ISO }}.PT0S.nc', '{{ COM_OCEAN_ANALYSIS_TMPL | replace_tmpl(tmpl_dict) }}/{{ RUN }}.t{{ "%02d" | format(cyc) }}z.ocninc.nc']
+# ice restarts are saved as 1..n
 - ['{{ DATA }}/ens/cice_model.res.{{ imem | string }}.nc', '{{ COM_ICE_ANALYSIS_TMPL | replace_tmpl(tmpl_dict) }}/{{ cice_rst_date }}.cice_model_anl.res.nc']
 {% endfor %}
 {% set tmpl_dict = ({ '${ROTDIR}': ROTDIR,

--- a/parm/soca/soca_ecen_jedi_config.yaml.j2
+++ b/parm/soca/soca_ecen_jedi_config.yaml.j2
@@ -6,7 +6,7 @@ gridgen:
   jcb_algo: soca_gridgen
 ens_handler:
   rundir: '{{ DATA }}'
-  exe_src: '{{ EXECgfs }}/gdas_soca_ens_handler.x'
+  exe_src: '{{ EXECgfs }}/gdas_soca_anpproc.x'
   mpi_cmd: '{{ APRUN_MARINEANLECEN }}'
   jcb_base_yaml: '{{ PARMgfs }}/gdas/soca/jcb-base.yaml.j2'
   jcb_algo: soca_ens_handler


### PR DESCRIPTION
# Description

Uses parallel ensemble recentering from https://github.com/JCSDA-internal/soca/pull/1183.

Runtimes for the application (30 members, 150 MPI tasks, hera with intel):
- prior to https://github.com/NOAA-EMC/GDASApp/pull/1829: ~600s
- develop now after https://github.com/NOAA-EMC/GDASApp/pull/1829 (not applicable once we need ensemble inflation): ~230s
- parallel recentering with 1 ensemble member per task: ~120s
- parallel recentering with 2 or 3 ensemble members per task: ~60s.

~~Keeping as draft until https://github.com/JCSDA-internal/oops/pull/2970 and https://github.com/JCSDA-internal/soca/pull/1183 are merged and propagated to GDASApp~~

# Companion PRs

https://github.com/JCSDA-internal/oops/pull/2970
https://github.com/JCSDA-internal/soca/pull/1183
https://github.com/NOAA-EMC/jcb-gdas/pull/160

# Issues

Resolves #1813, resolves #1828 

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmsnowDA <!-- JEDI snow cycled DA !-->
- [ ] C96_gcafs_cycled <!-- JEDI aerosol cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [x] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
