### PR TITLE
Weekly update of JEDI hashes (20250819)

### DIFF
--- a/bundle/CMakeLists.txt
+++ b/bundle/CMakeLists.txt
@@ -128,7 +128,7 @@ if(BUILD_GDASBUNDLE)
 # Install jcb (JEDI Configuration Builder) Python package
   message(STATUS "Installing jcb (JEDI Configuration Builder)")
   execute_process(
-    COMMAND ${Python3_EXECUTABLE} -m pip install --prefix ${CMAKE_INSTALL_PREFIX} .
+    COMMAND ${Python3_EXECUTABLE} -m pip install --no-deps --prefix ${CMAKE_INSTALL_PREFIX} .
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../sorc/jcb
     RESULT_VARIABLE jcb_install_result
   )

--- a/modulefiles/GDAS/gaeac5.intel.lua
+++ b/modulefiles/GDAS/gaeac5.intel.lua
@@ -76,6 +76,7 @@ load("py-scipy/1.11.3")
 load("py-xarray/2023.7.0")
 load("py-f90nml/1.4.3")
 load("py-pip/23.1.2")
+load("py-click/8.1.7")
 
 setenv("CC","cc")
 setenv("CXX","CC")

--- a/modulefiles/GDAS/gaeac6.intel.lua
+++ b/modulefiles/GDAS/gaeac6.intel.lua
@@ -69,6 +69,7 @@ load("py-scipy/1.13.1")
 load("py-xarray/2024.7.0")
 load("py-f90nml/1.4.3")
 load("py-pip/23.1.2")
+load("py-click/8.1.7")
 
 unload("cray-libsci")
 

--- a/modulefiles/GDAS/hera.intel.lua
+++ b/modulefiles/GDAS/hera.intel.lua
@@ -69,7 +69,6 @@ load("py-xarray/2024.7.0")
 load("py-f90nml/1.4.3")
 load("py-pip/23.1.2")
 load("py-click/8.1.7")
-load("py-wheel/0.41.2")
 
 setenv("CC","mpiicc")
 setenv("CXX","mpiicpc")

--- a/modulefiles/GDAS/hera.intel.lua
+++ b/modulefiles/GDAS/hera.intel.lua
@@ -69,6 +69,7 @@ load("py-xarray/2024.7.0")
 load("py-f90nml/1.4.3")
 load("py-pip/23.1.2")
 load("py-click/8.1.7")
+load("py-wheel/0.41.2")
 
 setenv("CC","mpiicc")
 setenv("CXX","mpiicpc")

--- a/modulefiles/GDAS/hercules.intel.lua
+++ b/modulefiles/GDAS/hercules.intel.lua
@@ -75,6 +75,7 @@ load("py-xarray/2024.7.0")
 load("py-f90nml/1.4.3")
 load("py-pip/23.1.2")
 load("py-click/8.1.7")
+load("py-wheel/0.41.2")
 
 setenv("CC","mpiicc")
 setenv("CXX","mpiicpc")

--- a/modulefiles/GDAS/hercules.intel.lua
+++ b/modulefiles/GDAS/hercules.intel.lua
@@ -75,7 +75,6 @@ load("py-xarray/2024.7.0")
 load("py-f90nml/1.4.3")
 load("py-pip/23.1.2")
 load("py-click/8.1.7")
-load("py-wheel/0.41.2")
 
 setenv("CC","mpiicc")
 setenv("CXX","mpiicpc")

--- a/modulefiles/GDAS/orion.intel.lua
+++ b/modulefiles/GDAS/orion.intel.lua
@@ -74,6 +74,7 @@ load("py-xarray/2024.7.0")
 load("py-f90nml/1.4.3")
 load("py-pip/23.1.2")
 load("py-click/8.1.7")
+load("py-wheel/0.41.2")
 
 setenv("CC","mpiicc")
 setenv("CXX","mpiicpc")

--- a/modulefiles/GDAS/orion.intel.lua
+++ b/modulefiles/GDAS/orion.intel.lua
@@ -74,7 +74,6 @@ load("py-xarray/2024.7.0")
 load("py-f90nml/1.4.3")
 load("py-pip/23.1.2")
 load("py-click/8.1.7")
-load("py-wheel/0.41.2")
 
 setenv("CC","mpiicc")
 setenv("CXX","mpiicpc")

--- a/modulefiles/GDAS/ursa.intel.lua
+++ b/modulefiles/GDAS/ursa.intel.lua
@@ -71,6 +71,7 @@ load("py-xarray/2024.7.0")
 load("py-f90nml/1.4.3")
 load("py-pip/23.1.2")
 load("py-click/8.1.7")
+load("py-wheel/0.41.2")
 
 setenv("CC","mpiicx")
 setenv("CXX","mpiicpx")

--- a/modulefiles/GDAS/ursa.intel.lua
+++ b/modulefiles/GDAS/ursa.intel.lua
@@ -71,7 +71,6 @@ load("py-xarray/2024.7.0")
 load("py-f90nml/1.4.3")
 load("py-pip/23.1.2")
 load("py-click/8.1.7")
-load("py-wheel/0.41.2")
 
 setenv("CC","mpiicx")
 setenv("CXX","mpiicpx")

--- a/modulefiles/GDAS/wcoss2.intel.lua
+++ b/modulefiles/GDAS/wcoss2.intel.lua
@@ -91,6 +91,7 @@ load("py-xarray/2024.7.0")
 load("py-f90nml/1.4.3")
 load("py-pip/23.1.2")
 load("py-click/8.1.7")
+load("py-wheel/0.41.2")
 
 append_path("MODULEPATH", "/apps/ops/test/nco/modulefiles/core")
 load("rocoto/1.3.5")

--- a/modulefiles/GDAS/wcoss2.intel.lua
+++ b/modulefiles/GDAS/wcoss2.intel.lua
@@ -91,7 +91,6 @@ load("py-xarray/2024.7.0")
 load("py-f90nml/1.4.3")
 load("py-pip/23.1.2")
 load("py-click/8.1.7")
-load("py-wheel/0.41.2")
 
 append_path("MODULEPATH", "/apps/ops/test/nco/modulefiles/core")
 load("rocoto/1.3.5")


### PR DESCRIPTION
# Description

This PR includes two sets of changes:
1. weekly update of JEDI hashes
2. updates that allow jcb to be built and installed from compute nodes

# Companion PRs

g-w PR [#3951](https://github.com/NOAA-EMC/global-workflow/pull/3951) depends upon closure of this PR.   Once this PR is merged into GDASApp `develop`, the `sorc/gdas.cd` hash in g-w R [#3951](https://github.com/NOAA-EMC/global-workflow/pull/3951) will be updated to the new GDASApp `develop` hash.

# Issues

Resolves #1849
Resolves #1852
Resolves #1862
Partially addresses #1851 - this PR does not address the external `fetch` dependency added by the updated ioda-converters hash.

# Automated CI tests to run in Global Workflow
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmsnowDA <!-- JEDI snow cycled DA !-->
- [ ] C96_gcafs_cycled <!-- JEDI aerosol cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [ ] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->

Note:  The updated `sorc/soca` hash in this PR requires an updated `ufs_model` hash in g-w.  The updated `ufs_model` hash is in g-w PR [#3951](https://github.com/NOAA-EMC/global-workflow/pull/3951).

As such, we cannot run automated GDASApp CI on this PR.  Automated GDASApp g-w CI clones g-w `develop`.  g-w `develop` does not, at present, point at a `ufs_model` hash which works with the updated `sorc/soca` hash in `feature/stable-nightly`.