### PR TITLE
Add oro file copy to ensure backwards compatibility for land SCF code

### DIFF
--- a/parm/snow/prep/prep_ims.yaml.j2
+++ b/parm/snow/prep/prep_ims.yaml.j2
@@ -3,6 +3,7 @@ calcfims:
     - '{{ DATA }}/obs'
   copy:
     - ['{{ COMIN_OBS }}/{{ OPREFIX }}imssnow96.asc', '{{ DATA }}/obs/ims{{ current_cycle | to_julian }}_4km_v1.3.asc']
+    - ['{{ FIXgfs }}/gdas/obs/ims/IMS_4km_to_{{ CASE }}.mx{{ OCNRES }}.nc', '{{ DATA }}/obs/IMS4km_to_FV3_mapping.{{ CASE }}_oro_data.nc']
     - ['{{ FIXgfs }}/gdas/obs/ims/IMS_4km_to_{{ CASE }}.mx{{ OCNRES }}.nc', '{{ DATA }}/obs/IMS4km_to_FV3_mapping.{{ CASE }}.mx{{ OCNRES }}_oro_data.nc']
 ims2ioda:
   copy:

--- a/parm/snow/prep/prep_ims.yaml.j2
+++ b/parm/snow/prep/prep_ims.yaml.j2
@@ -3,6 +3,7 @@ calcfims:
     - '{{ DATA }}/obs'
   copy:
     - ['{{ COMIN_OBS }}/{{ OPREFIX }}imssnow96.asc', '{{ DATA }}/obs/ims{{ current_cycle | to_julian }}_4km_v1.3.asc']
+# remove the below line later once using the C++ IMS SCF code
     - ['{{ FIXgfs }}/gdas/obs/ims/IMS_4km_to_{{ CASE }}.mx{{ OCNRES }}.nc', '{{ DATA }}/obs/IMS4km_to_FV3_mapping.{{ CASE }}_oro_data.nc']
     - ['{{ FIXgfs }}/gdas/obs/ims/IMS_4km_to_{{ CASE }}.mx{{ OCNRES }}.nc', '{{ DATA }}/obs/IMS4km_to_FV3_mapping.{{ CASE }}.mx{{ OCNRES }}_oro_data.nc']
 ims2ioda:


### PR DESCRIPTION
# Description

A previous PR, preparing for an upcoming workflow change, broke backwards compatibility with the existing IMS SCF preprocessor code. This PR allows the workflow to copy the file needed twice, once to the destination the old code expects and once to the destination for the new code.

# Companion PRs

None

# Issues

None created

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [x] C96C48_hybatmsnowDA <!-- JEDI snow cycled DA !-->
- [ ] C96_gcafs_cycled <!-- JEDI aerosol cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [ ] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
