### PR TITLE
replace parm/soca with parm/marine in soca generate scripts

### DIFF
--- a/utils/soca/test/generate_coupled_resources.py
+++ b/utils/soca/test/generate_coupled_resources.py
@@ -42,7 +42,7 @@ def main(project_src_dir):
     subprocess.run(["ncgen", "-4", "-o", "soca/soca_gridspec.nc", f"{project_src_dir}/soca/test/testdata/soca_gridspec.cdl"], check=True)
     subprocess.run(["ncgen", "-4", "-o", "ocn.nc", f"{project_src_dir}/soca/test/testdata/ocn.cdl"], check=True)
     subprocess.run(["ncgen", "-4", "-o", "ice.nc", f"{project_src_dir}/soca/test/testdata/ice.cdl"], check=True)
-    yaml_src_path = f"{project_src_dir}/../parm/soca/fields_metadata.yaml"
+    yaml_src_path = f"{project_src_dir}/../parm/marine/fields_metadata.yaml"
     shutil.copy(yaml_src_path, os.path.join(gdas_test_dir, "soca"))
 
 if __name__ == "__main__":

--- a/utils/soca/test/generate_soca_resources.py
+++ b/utils/soca/test/generate_soca_resources.py
@@ -195,7 +195,7 @@ def main(project_src_dir):
     subprocess.run(["ncgen", "-4", "-o", "ice.nc", f"{project_src_dir}/soca/test/testdata/ice.cdl"], check=True)
 
     # Copy YAML file
-    yaml_src_path = f"{project_src_dir}/../parm/soca/fields_metadata.yaml"
+    yaml_src_path = f"{project_src_dir}/../parm/marine/fields_metadata.yaml"
     shutil.copy(yaml_src_path, gdas_test_dir)
 
     # Generate increment file


### PR DESCRIPTION
# Description

This PR replaces `parm/soca` with `parm/marine` in two `utils/soca/test` python scripts.  This change is necessiated by GDASApp PR #1878.

# Companion PRs

None

# Issues

Resolves #1885


# Automated CI tests to run in Global Workflow
- [x] atm_jjob <!-- JEDI atm single cycle DA !-->
- [x] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [x] C96C48_hybatmsnowDA <!-- JEDI snow cycled DA !-->
- [x] C96_gcafs_cycled <!-- JEDI aerosol cycled DA !-->
- [x] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [x] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [x] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
