### PR TITLE
Make nens per MPI in parallel recentering configurable

### DIFF
--- a/parm/marine/jcb-base.yaml.j2
+++ b/parm/marine/jcb-base.yaml.j2
@@ -65,6 +65,7 @@ marine_forecast_timestep: PT3H
 # Background error model
 background_error_file: '{{berror_model}}'
 marine_number_ensemble_members: '{{NMEM_ENS}}'
+marine_number_ensemble_members_per_mpi: '{{NMEM_ENS_PER_MPI}}'
 marine_stddev_time: '{{ MARINE_WINDOW_MIDDLE  | to_isotime }}'
 
 # Observations


### PR DESCRIPTION
# Description

This is needed to configure the resources correctly for marine ensemble recentering

# Companion PRs

https://github.com/NOAA-EMC/jcb-gdas/pull/168
https://github.com/NOAA-EMC/global-workflow/pull/4048

# Issues

Resolves #https://github.com/NOAA-EMC/GDASApp/issues/1871

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmsnowDA <!-- JEDI snow cycled DA !-->
- [ ] C96_gcafs_cycled <!-- JEDI aerosol cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [x] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
