### PR TITLE
Reactivate assimilation of select observation types in test_gdasapp_C96C48_ufs_hybatmDA

### DIFF
--- a/test/gw-ci/atm/jcb-prototype_3dvar_ufs_hybatmDA.yaml.j2
+++ b/test/gw-ci/atm/jcb-prototype_3dvar_ufs_hybatmDA.yaml.j2
@@ -5,7 +5,7 @@ algorithm: 3dvar
 # Observation things
 # ------------------
 observations:
-##  - scatwnd.ascat_metop-b
+  - scatwnd.ascat_metop-b
   - atms_n20
   - conventional_ps
   - gnssro_cosmic2

--- a/test/gw-ci/atm/jcb-prototype_lgetkf_observer_ufs_hybatmDA.yaml.j2
+++ b/test/gw-ci/atm/jcb-prototype_lgetkf_observer_ufs_hybatmDA.yaml.j2
@@ -14,12 +14,12 @@ atmosphere_background_ensemble_path: ./bkg/mem%mem%
 # Observation things
 # ------------------
 observations:
-##- scatwnd.ascat_metop-b
+  - scatwnd.ascat_metop-b
   - atms_n20
   - conventional_ps
-##  - gnssro_cosmic2
-##  - ozone.ompsnp_npp
-##  - ozone.ompstc_npp
+  - gnssro_cosmic2
+  - ozone.ompsnp_npp
+  - ozone.ompstc_npp
   - satwnd.abi_goes-16
 
 # Naming conventions for observation files

--- a/test/gw-ci/atm/jcb-prototype_lgetkf_solver_ufs_hybatmDA.yaml.j2
+++ b/test/gw-ci/atm/jcb-prototype_lgetkf_solver_ufs_hybatmDA.yaml.j2
@@ -14,12 +14,12 @@ atmosphere_background_ensemble_path: ./bkg/mem%mem%
 # Observation things
 # ------------------
 observations:
-##- scatwnd.ascat_metop-b
+  - scatwnd.ascat_metop-b
   - atms_n20
   - conventional_ps
-##- gnssro_cosmic2
-##- ozone.ompsnp_npp
-##- ozone.ompstc_npp
+  - gnssro_cosmic2
+  - ozone.ompsnp_npp
+  - ozone.ompstc_npp
   - satwnd.abi_goes-16
 
 # Naming conventions for observation files

--- a/test/gw-ci/atm/jcb-prototype_lgetkf_ufs_hybatmDA.yaml.j2
+++ b/test/gw-ci/atm/jcb-prototype_lgetkf_ufs_hybatmDA.yaml.j2
@@ -14,11 +14,11 @@ atmosphere_background_ensemble_path: ./bkg/mem%mem%
 # Observation things
 # ------------------
 observations:
-##- scatwnd.ascat_metop-b
+  - scatwnd.ascat_metop-b
   - atms_n20
   - atms_npp
   - conventional_ps
-##- gnssro_cosmic2
+  - gnssro_cosmic2
   - ozone.ompsnp_npp
   - ozone.ompstc_npp
   - satwnd.abi_goes-16

--- a/ush/ioda/bufr2ioda/bufr2ioda_satwind_scat.py
+++ b/ush/ioda/bufr2ioda/bufr2ioda_satwind_scat.py
@@ -49,6 +49,7 @@ def bufr_to_ioda(config, logger):
     cycle_type = config["cycle_type"]
     dump_dir = config["dump_directory"]
     ioda_dir = config["ioda_directory"]
+    ioda_type = config["ioda_type"]
     cycle = config["cycle_datetime"]
     yyyymmdd = cycle[0:8]
     hh = cycle[8:10]
@@ -246,7 +247,7 @@ def bufr_to_ioda(config, logger):
             }
 
             # Create IODA ObsSpace
-            iodafile = f"{cycle_type}.t{hh}z.{data_type}.{satinst}.tm00.nc"
+            iodafile = f"{cycle_type}.t{hh}z.{ioda_type}.{satinst}.tm00.nc"
             OUTPUT_PATH = os.path.join(ioda_dir, iodafile)
             logger.info(f"Create output file : {OUTPUT_PATH}")
             obsspace = ioda_ospace.ObsSpace(OUTPUT_PATH, mode='w', dim_dict=dims)


### PR DESCRIPTION
# Description

This PR updates the `parm/jcb-gdas` hash along with `test/gw-ci/atm` yamls and `ush/ioda/bufr2ioda/bufr2ioda_satwind_scat.py` to restore the following observations types 

- scatwnd.ascat_metop-b
- gnssro_cosmic2
- ozone.ompsnp_npp
- ozone.ompstc_npp

to the `test_gdasapp_C96C48_ufs_hybatmDA` suite of GDASApp ctests.

# Companion PRs

None

# Issues

Resolves  #1892

# Automated CI tests to run in Global Workflow
- [x] atm_jjob <!-- JEDI atm single cycle DA !-->
- [x] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [x] C96C48_hybatmsnowDA <!-- JEDI snow cycled DA !-->
- [x] C96_gcafs_cycled <!-- JEDI aerosol cycled DA !-->
- [x] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [x] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [x] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
