### PR TITLE
Make IMS SCF input files optional when copying

### DIFF
--- a/parm/snow/snow_stage_ims_scf2ioda.yaml.j2
+++ b/parm/snow/snow_stage_ims_scf2ioda.yaml.j2
@@ -1,3 +1,3 @@
-copy:
+copy_opt:
 - ['{{ COMIN_OBS }}/{{OPREFIX}}imssnow96.asc', '{{ DATA }}/obs/ims{{ current_cycle | to_julian }}_4km_v1.3.asc']
 - ['{{ FIXgfs }}/gdas/obs/ims/IMS_4km_to_{{ CASE }}.mx{{ OCNRES }}.nc', '{{ DATA }}/obs/IMS4km_to_FV3_mapping.{{ CASE }}.mx{{ OCNRES }}_oro_data.nc']


### PR DESCRIPTION
# Description

First step towards the workflow being smarter about when IMS SCF input data is missing. It should be a copy optional, and then the workflow checks if the file exists before proceeding with processing.

# Companion PRs

None

# Issues

None

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmsnowDA <!-- JEDI snow cycled DA !-->
- [ ] C96_gcafs_cycled <!-- JEDI aerosol cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [ ] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
