### PR TITLE
Change the throw exception to a warning to prevent the job from crashing

### DIFF
--- a/utils/land/gdas_fv3jedi_calc_scf_to_ioda.cc
+++ b/utils/land/gdas_fv3jedi_calc_scf_to_ioda.cc
@@ -407,9 +407,10 @@ void gdasapp::CalcSCFtoIODA::IMSscf::readIMS() {
   // Check if the file exists
   std::ifstream infile(imspath_);
   if (!infile.good()) {
-    throw eckit::UserError("IMS file does not exist: " + imspath_, Here());
+    eckit::Log::warning() << "IMS file does not exist: " << imspath_ << std::endl;
+  } else {
+    infile.close();
   }
-  infile.close();
 
   // Try to open as netCDF
   bool isNetCDF = false;
@@ -429,9 +430,10 @@ void gdasapp::CalcSCFtoIODA::IMSscf::readIMS() {
     // Try to open as ASCII
     std::ifstream asciifile(imspath_);
     if (!asciifile.is_open()) {
-      throw eckit::UserError("Failed to open IMS file as ASCII: " + imspath_, Here());
+        eckit::Log::warning() << "Failed to open IMS file as ASCII: " << imspath_ << std::endl;
+    } else {
+        oops::Log::info() << "Opened IMS file as ASCII: " << imspath_ << std::endl;
     }
-    oops::Log::info() << "Opened IMS file as ASCII: " << imspath_ << std::endl;
     int i_ims, j_ims;
     // skip some of the header lines
     std::string dummyLine;


### PR DESCRIPTION
# Description

Change the thrown exception to a warning to prevent the job from crashing when the IMS SFC input data is missing.

# Companion PRs

<!-- Enter links to any companion PRs here. -->

# Issues

<!-- Enter any issues referenced or resolved by this PR here. Use keywords "Resolves" or "Refs".
Resolves #1234
Refs #4321
Refs NOAA-EMC/repo#5678
-->

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmsnowDA <!-- JEDI snow cycled DA !-->
- [ ] C96_gcafs_cycled <!-- JEDI aerosol cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [ ] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
