### PR TITLE
Changes to aerosol parm files to make DA work.

### DIFF
--- a/parm/aero/aero_crtm_coeff.yaml.j2
+++ b/parm/aero/aero_crtm_coeff.yaml.j2
@@ -7,6 +7,8 @@ copy:
 - ['{{ CRTM_FIX }}/v.viirs-m_npp.TauCoeff.bin', '{{ DATA }}/crtm/']
 - ['{{ CRTM_FIX }}/v.viirs-m_j1.SpcCoeff.bin', '{{ DATA }}/crtm/']
 - ['{{ CRTM_FIX }}/v.viirs-m_j1.TauCoeff.bin', '{{ DATA }}/crtm/']
+- ['{{ CRTM_FIX }}/v.viirs-m_j2.SpcCoeff.bin', '{{ DATA }}/crtm/']
+- ['{{ CRTM_FIX }}/v.viirs-m_j2.TauCoeff.bin', '{{ DATA }}/crtm/']
 - ['{{ CRTM_FIX }}/NPOESS.VISice.EmisCoeff.bin', '{{ DATA }}/crtm/']
 - ['{{ CRTM_FIX }}/NPOESS.VISland.EmisCoeff.bin', '{{ DATA }}/crtm/']
 - ['{{ CRTM_FIX }}/NPOESS.VISsnow.EmisCoeff.bin', '{{ DATA }}/crtm/']

--- a/parm/aero/aero_stage_crtm_coeff.yaml.j2
+++ b/parm/aero/aero_stage_crtm_coeff.yaml.j2
@@ -7,6 +7,8 @@ copy:
 - ['{{ CRTM_FIX }}/v.viirs-m_npp.TauCoeff.bin', '{{ DATA }}/crtm/']
 - ['{{ CRTM_FIX }}/v.viirs-m_j1.SpcCoeff.bin', '{{ DATA }}/crtm/']
 - ['{{ CRTM_FIX }}/v.viirs-m_j1.TauCoeff.bin', '{{ DATA }}/crtm/']
+- ['{{ CRTM_FIX }}/v.viirs-m_j2.SpcCoeff.bin', '{{ DATA }}/crtm/']
+- ['{{ CRTM_FIX }}/v.viirs-m_j2.TauCoeff.bin', '{{ DATA }}/crtm/']
 - ['{{ CRTM_FIX }}/NPOESS.VISice.EmisCoeff.bin', '{{ DATA }}/crtm/']
 - ['{{ CRTM_FIX }}/NPOESS.VISland.EmisCoeff.bin', '{{ DATA }}/crtm/']
 - ['{{ CRTM_FIX }}/NPOESS.VISsnow.EmisCoeff.bin', '{{ DATA }}/crtm/']

--- a/parm/aero/jcb-base.yaml.j2
+++ b/parm/aero/jcb-base.yaml.j2
@@ -23,7 +23,7 @@ bound_to_include: begin
 minimizer: DRPCG
 final_diagnostics_departures: anlmob
 final_prints_frequency: PT3H
-number_of_outer_loops: 2
+number_of_outer_loops: 1
 analysis_variables: [mass_fraction_of_sulfate_in_air,
                        mass_fraction_of_hydrophobic_black_carbon_in_air,
                        mass_fraction_of_hydrophilic_black_carbon_in_air,

--- a/parm/aero/jcb-prototype_3dvar.yaml.j2
+++ b/parm/aero/jcb-prototype_3dvar.yaml.j2
@@ -7,4 +7,4 @@ algorithm: 3dfgat
 observations:
 - viirs_n20_aod
 - viirs_npp_aod
-# - viirs_n21_aod
+- viirs_n21_aod

--- a/parm/aero/obs/config/viirs_n20_aod.yaml.j2
+++ b/parm/aero/obs/config/viirs_n20_aod.yaml.j2
@@ -4,12 +4,13 @@
       engine:
         type: H5File
         obsfile: "{{ DATA }}/obs/{{ OPREFIX }}viirs_n20_aod.tm00.nc"
+        missing file action: warn 
     obsdataout:
       engine:
         type: H5File
         obsfile: "{{ DATA }}/diags/diag_viirs_n20_{{ current_cycle | to_YMDH }}.nc4"
     io pool:
-      max pool size: 1
+      max pool size: 2 
     simulated variables: [aerosolOpticalDepth]
     channels: 4
   get values:

--- a/parm/aero/obs/config/viirs_n21_aod.yaml.j2
+++ b/parm/aero/obs/config/viirs_n21_aod.yaml.j2
@@ -4,12 +4,13 @@
       engine:
         type: H5File
         obsfile: "{{ DATA }}/obs/{{ OPREFIX }}viirs_n21_aod.tm00.nc"
+        missing file action: warn
     obsdataout:
       engine:
         type: H5File
         obsfile: "{{ DATA }}/diags/diag_viirs_n21_{{ current_cycle | to_YMDH }}.nc4"
     io pool:
-      max pool size: 1
+      max pool size: 2
     simulated variables: [aerosolOpticalDepth]
     channels: 4
   get values:

--- a/parm/aero/obs/config/viirs_npp_aod.yaml.j2
+++ b/parm/aero/obs/config/viirs_npp_aod.yaml.j2
@@ -9,7 +9,7 @@
         type: H5File
         obsfile: "{{ DATA }}/diags/diag_viirs_npp_{{ current_cycle | to_YMDH }}.nc4"
     io pool:
-      max pool size: 1
+      max pool size: 2 
     simulated variables: [aerosolOpticalDepth]
     channels: 4
   get values:


### PR DESCRIPTION
# Description

These changes to aerosol parm files fix 
1. missing crtm coefficients for n21, 
2. one outer loop instead of two, 
3. change diagb weight to 1.0
4. uncomment n21 obs from obs parm file.
5. change aero obs files to warn instead of fail for missing obs files.

# Companion PRs

None

# Issues

None
-->

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->

- [x] C96_gcafs_cycled <!-- JEDI aerosol cycled DA !-->

