### PR TITLE
Make IMS C++ preprocessing code use real MPI

### DIFF
--- a/parm/snow/snow_det_jedi_config.yaml.j2
+++ b/parm/snow/snow_det_jedi_config.yaml.j2
@@ -8,6 +8,6 @@ snowanlvar:
 scf_to_ioda:
   rundir: '{{ DATA }}'
   exe_src: '{{ EXECgfs }}/gdas_fv3jedi_scf_to_ioda.x'
-  mpi_cmd: '{{ APRUN_APPLY_INCR }}' # only use 6 tasks
+  mpi_cmd: '{{ APRUN_SNOWANL }}'
   jcb_base_yaml: '{{ PARMgfs }}/gdas/snow/jcb-base.yaml.j2'
   jcb_algo: snow_ims_scf_preprocess

--- a/parm/snow/snow_ens_jedi_config.yaml.j2
+++ b/parm/snow/snow_ens_jedi_config.yaml.j2
@@ -15,6 +15,6 @@ snowanlvar:
 scf_to_ioda:
   rundir: '{{ DATA }}'
   exe_src: '{{ EXECgfs }}/gdas_fv3jedi_scf_to_ioda.x'
-  mpi_cmd: '{{ APRUN_APPLY_INCR }}' # only use 6 tasks
+  mpi_cmd: '{{ APRUN_ESNOWANL }}'
   jcb_base_yaml: '{{ PARMgfs }}/gdas/snow/jcb-base.yaml.j2'
   jcb_algo: snow_ims_scf_preprocess

--- a/utils/land/gdas_fv3jedi_calc_scf_to_ioda.cc
+++ b/utils/land/gdas_fv3jedi_calc_scf_to_ioda.cc
@@ -36,12 +36,6 @@ void gdasapp::CalcSCFtoIODA::run() {
   const eckit::LocalConfiguration geomConfig(config_, "geometry");
   const fv3jedi::Geometry geom(geomConfig, comm_);
 
-  // Exit with error if rank size is not equal to 6,
-  // this simplifies our MPI, we can fix/make more flexible later
-  if (comm_.size() != 6) {
-    throw eckit::BadValue("MPI rank size must be 6", Here());
-  }
-
   // Get the valid time
   std::string validTime;
   config_.get("date", validTime);
@@ -179,23 +173,11 @@ void gdasapp::CalcSCFtoIODA::calc_fcst_snow_cover_fraction(fv3jedi::State & bkgS
 gdasapp::CalcSCFtoIODA::IMSscf::IMSscf(const std::string &imspath, const std::string &weightspath,
                                        const fv3jedi::Geometry & geom)
   : imspath_(imspath), weightspath_(weightspath), geom_(geom) {
-  this->latFV3.resize(6,
-                      std::vector<std::vector<float>>(geom_.npy()-1,
-                      std::vector<float>(geom_.npx()-1)));
-  this->lonFV3.resize(6,
-                      std::vector<std::vector<float>>(geom_.npy()-1,
-                      std::vector<float>(geom_.npx()-1)));
-  this->oroFV3.resize(6,
-                      std::vector<std::vector<float>>(geom_.npy()-1,
-                      std::vector<float>(geom_.npx()-1)));
-  this->scfIMS.resize(6,
-                      std::vector<std::vector<float>>(geom_.npy()-1,
-                      std::vector<float>(geom_.npx()-1,
-                      nodata_float)));
-  this->sndIMS.resize(6,
-                      std::vector<std::vector<float>>(geom_.npy()-1,
-                      std::vector<float>(geom_.npx()-1,
-                      nodata_float)));
+  this->latFV3.resize(geom_.npy()-1, std::vector<float>(geom_.npx()-1));
+  this->lonFV3.resize(geom_.npy()-1, std::vector<float>(geom_.npx()-1));
+  this->oroFV3.resize(geom_.npy()-1, std::vector<float>(geom_.npx()-1));
+  this->scfIMS.resize(geom_.npy()-1, std::vector<float>(geom_.npx()-1, nodata_float));
+  this->sndIMS.resize(geom_.npy()-1, std::vector<float>(geom_.npx()-1, nodata_float));
   oops::Log::info() << "IMSscf object created with IMS path: "
                     << imspath_ << " and weights path: " << weightspath_ << std::endl;
 }
@@ -209,6 +191,7 @@ void gdasapp::CalcSCFtoIODA::writeToIoda(const std::string & outputpath,
   // This would involve creating an IODA file, populating it with the calculated
   // observations, and saving it to disk.
   oops::Log::info() << "Writing observations to IODA format..." << std::endl;
+  oops::mpi::world().barrier();  // Ensure all ranks finish before proceeding
   // get the fieldset from the geometry
   atlas::FunctionSpace fs = geom.functionSpace();
   // convert the state to an atlas fieldset
@@ -224,10 +207,11 @@ void gdasapp::CalcSCFtoIODA::writeToIoda(const std::string & outputpath,
   atlas::Field latLocal = fs.createField<double>(atlas::option::name("latitude"));
   local_fields.add(latLocal);
   local_fields.add(xBfs["filtered_orography"]);
+  local_fields.add(xBfs["surface_snow_area_fraction"]);
+  local_fields.add(xBfs["totalSnowDepth"]);
   const auto lonLatView = atlas::array::make_view<double, 2>(fs.lonlat());
   auto lonViewLocal = atlas::array::make_view<double, 1>(local_fields.field("longitude"));
   auto latViewLocal = atlas::array::make_view<double, 1>(local_fields.field("latitude"));
-  const auto orogViewLocal = atlas::array::make_view<double, 2>(xBfs["filtered_orography"]);
   for (atlas::idx_t jnode = 0; jnode < fs.lonlat().shape(0); ++jnode) {
     lonViewLocal(jnode) = lonLatView(jnode, 0);
     latViewLocal(jnode) = lonLatView(jnode, 1);
@@ -241,6 +225,16 @@ void gdasapp::CalcSCFtoIODA::writeToIoda(const std::string & outputpath,
   atlas::Field orogGlobal = fs.createField<double>(atlas::option::name("filtered_orography") |
       atlas::option::levels(xBfs["filtered_orography"].shape(1)) | atlas::option::global());
   global_fields.add(orogGlobal);
+  // now get the IMS data from the modified state
+  atlas::Field scfGlobal = fs.createField<double>(
+      atlas::option::name("surface_snow_area_fraction") |
+      atlas::option::levels(xBfs["surface_snow_area_fraction"].shape(1)) |
+      atlas::option::global());
+  global_fields.add(scfGlobal);
+  atlas::Field sndGlobal = fs.createField<double>(
+      atlas::option::name("totalSnowDepth") |
+      atlas::option::levels(xBfs["totalSnowDepth"].shape(1)) | atlas::option::global());
+  global_fields.add(sndGlobal);
   // gather the local fields to global fields
   atlas::functionspace::StructuredColumns fs_new(fs);
   fs_new.gather(local_fields, global_fields);
@@ -248,29 +242,9 @@ void gdasapp::CalcSCFtoIODA::writeToIoda(const std::string & outputpath,
   auto lon = atlas::array::make_view<double, 1>(global_fields["longitude"]);
   auto lat = atlas::array::make_view<double, 1>(global_fields["latitude"]);
   auto orog = atlas::array::make_view<double, 2>(global_fields["filtered_orography"]);
-  // the IMS data are not in atlas, so we need to do other things to gather with MPI
-  int ngrid = (geom.npx()-1) * (geom.npy()-1);
-  std::vector<float> snd_mytile(ngrid);
-  std::vector<float> scf_mytile(ngrid);
-  // loop over the IMS data and gather
-  for (size_t i=0; i < geom.npx()-1; ++i) {
-    for (size_t j=0; j < geom.npy()-1; ++j) {
-      size_t idx = (j * (geom.npx()-1)) + i;
-      snd_mytile[idx] = imsscf.sndIMS[oops::mpi::world().rank()][j][i];
-      scf_mytile[idx] = imsscf.scfIMS[oops::mpi::world().rank()][j][i];
-    }
-  }
-  // gather the IMS data to all ranks
-  oops::Log::info() << "Gathering IMS data across all MPI ranks..." << std::endl;
-  std::vector<float> snd_global(ngrid * 6, 9999.0f);
-  std::vector<float> scf_global(ngrid * 6, 9999.0f);
-  std::vector<int> counts(6, ngrid);
-  std::vector<int> gdispls(6, 0);
-  for (int i = 1; i < 6; ++i) {
-    gdispls[i] = gdispls[i-1] + counts[i-1];
-  }
-  oops::mpi::world().gatherv(snd_mytile, snd_global, counts, gdispls, 0);
-  oops::mpi::world().gatherv(scf_mytile, scf_global, counts, gdispls, 0);
+  auto scf = atlas::array::make_view<double, 2>(global_fields["surface_snow_area_fraction"]);
+  auto snd = atlas::array::make_view<double, 2>(global_fields["totalSnowDepth"]);
+
   // Create empty group backed by HDF file
   if (oops::mpi::world().rank() == 0) {
     // Create the observations, Latitude, Longitude, and Elevation vectors
@@ -281,13 +255,13 @@ void gdasapp::CalcSCFtoIODA::writeToIoda(const std::string & outputpath,
       for (size_t i=0; i < geom.npx()-1; ++i) {
         for (size_t j=0; j < geom.npy()-1; ++j) {
           atlas::idx_t jnode = ((geom.npx()-1)*(geom.npy()-1)*(k) + (j)*(geom.npx()-1) + (i));
-          if (abs(scf_global[jnode] - nodata_float) > nodata_tol) {
-            if (abs(snd_global[jnode] - nodata_float) > nodata_tol) {
-              snd_var.push_back(snd_global[jnode]);
+          if (abs(scf(jnode, 0) - nodata_float) > nodata_tol) {
+            if (abs(snd(jnode, 0) - nodata_float) > nodata_tol) {
+              snd_var.push_back(snd(jnode, 0));
             } else {
               snd_var.push_back(util::missingValue<float>());
             }
-            scf_var.push_back(scf_global[jnode]);
+            scf_var.push_back(scf(jnode, 0));
             lat_var.push_back(lat(jnode));
             lon_var.push_back(lon(jnode));
             orog_var.push_back(orog(jnode, 0));
@@ -555,48 +529,43 @@ void gdasapp::CalcSCFtoIODA::IMSscf::readMapping() {
     }
   }
   // create float buffer for lonFV3, latFV3, oroFV3
-  size_t ntile = this->latFV3.size();
-  size_t npy = (ntile > 0) ? this->latFV3[0].size() : 0;
-  size_t npx = (ntile > 0 && npy > 0) ? this->latFV3[0][0].size() : 0;
-  std::vector<float> cube_buffer(ntile * npy * npx);
+  int tilenum = this->geom_.tileNum()-1;
+  size_t npy = this->latFV3.size();
+  size_t npx = this->latFV3[0].size();
+  std::vector<float> cube_buffer(6 * npy * npx);
   // Read lat_fv3 into latFV3
   netCDF::NcVar latVar = ncfile.getVar("lat_fv3");
   netcdf_err(latVar.isNull() ? -1 : NC_NOERR, "error reading latFV3 variable from mapping file");
   latVar.getVar(cube_buffer.data());
-  for (size_t i = 0; i < ntile; ++i) {
-    for (size_t j = 0; j < npy; ++j) {
-      for (size_t k = 0; k < npx; ++k) {
-        this->latFV3[i][j][k] = cube_buffer[i * npy * npx + j * npx + k];
-      }
+  for (size_t j = 0; j < npy; ++j) {
+    for (size_t i = 0; i < npx; ++i) {
+      this->latFV3[j][i] = cube_buffer[tilenum * npy * npx + j * npx + i];
     }
   }
+  
   // Read lon_fv3 into lonFV3
   netCDF::NcVar lonVar = ncfile.getVar("lon_fv3");
   netcdf_err(lonVar.isNull() ? -1 : NC_NOERR, "error reading lonFV3 variable from mapping file");
   lonVar.getVar(cube_buffer.data());
-  for (size_t i = 0; i < ntile; ++i) {
-    for (size_t j = 0; j < npy; ++j) {
-      for (size_t k = 0; k < npx; ++k) {
-        this->lonFV3[i][j][k] = cube_buffer[i * npy * npx + j * npx + k];
-      }
+  for (size_t j = 0; j < npy; ++j) {
+    for (size_t i = 0; i < npx; ++i) {
+      this->lonFV3[j][i] = cube_buffer[tilenum * npy * npx + j * npx + i];
     }
   }
   // Read oro_fv3 into oroFV3
   netCDF::NcVar oroVar = ncfile.getVar("oro_fv3");
   netcdf_err(oroVar.isNull() ? -1 : NC_NOERR, "error reading oroFV3 variable from mapping file");
   oroVar.getVar(cube_buffer.data());
-  for (size_t i = 0; i < ntile; ++i) {
-    for (size_t j = 0; j < npy; ++j) {
-      for (size_t k = 0; k < npx; ++k) {
-        this->oroFV3[i][j][k] = cube_buffer[i * npy * npx + j * npx + k];
-      }
+  for (size_t j = 0; j < npy; ++j) {
+    for (size_t i = 0; i < npx; ++i) {
+      this->oroFV3[j][i] = cube_buffer[tilenum * npy * npx + j * npx + i];
     }
   }
   oops::mpi::world().barrier();  // Ensure all ranks finish before proceeding
   // Now let us calculate things
-  std::vector<std::vector<std::vector<float>>> land_points(ntile,
+  std::vector<std::vector<std::vector<float>>> land_points(6,
     std::vector<std::vector<float>>(npy, std::vector<float>(npx, 0.0f)));
-  std::vector<std::vector<std::vector<float>>> snow_points(ntile,
+  std::vector<std::vector<std::vector<float>>> snow_points(6,
     std::vector<std::vector<float>>(npy, std::vector<float>(npx, 0.0f)));
   for (size_t i = 0; i < i_ims; ++i) {
     for (size_t j = 0; j < j_ims; ++j) {
@@ -611,14 +580,12 @@ void gdasapp::CalcSCFtoIODA::IMSscf::readMapping() {
   }
   oops::mpi::world().barrier();  // Ensure all ranks finish before proceeding
   // compute scfIMS based on where land_points are greater than 0
-  for (size_t k = 0; k < ntile; ++k) {
-    for (size_t j = 0; j < npy; ++j) {
-      for (size_t i = 0; i < npx; ++i) {
-        if (land_points[k][j][i] > 0) {
-          this->scfIMS[k][j][i] = snow_points[k][j][i] / land_points[k][j][i];
-        } else {
-          this->scfIMS[k][j][i] = nodata_float;
-        }
+  for (size_t j = 0; j < npy; ++j) {
+    for (size_t i = 0; i < npx; ++i) {
+      if (land_points[tilenum][j][i] > 0) {
+        this->scfIMS[j][i] = snow_points[tilenum][j][i] / land_points[tilenum][j][i];
+      } else {
+        this->scfIMS[j][i] = nodata_float;
       }
     }
   }
@@ -645,19 +612,19 @@ void gdasapp::CalcSCFtoIODA::IMSscf::calcIMSsd(fv3jedi::State &state,
       atlas::array::make_view<atlas::gidx_t, 1>(geom.functionSpace().global_index());
   std::vector<int> indices = geom.get_indices();
   int tilenum = geom.tileNum()-1;
-  int npx = geom.npx()-1;
-  int npy = geom.npy()-1;
+  int npx = indices[1] - indices[0] + 1;
   for (size_t fv3_i=indices[0]-1; fv3_i < indices[1]; ++fv3_i) {
     for (size_t fv3_j=indices[2]-1; fv3_j < indices[3]; ++fv3_j) {
-      // force tile to be 0 because of local arrays
-      atlas::idx_t jnode = ((fv3_j)*(npx) + (fv3_i + 1)) - 1;
-      if (abs(this->scfIMS[tilenum][fv3_j][fv3_i] - nodata_float) > nodata_tol) {
+      size_t local_j = fv3_j - (indices[2] - 1);
+      size_t local_i = fv3_i - (indices[0] - 1);
+      atlas::idx_t jnode = ((local_j)*(npx) + (local_i + 1)) - 1;
+      if (abs(this->scfIMS[fv3_j][fv3_i] - nodata_float) > nodata_tol) {
         // if we have IMS data at this point
         if (bkg_vtype(jnode, 0) > 0) {
           // if the model has land at this point
-          if (this->scfIMS[tilenum][fv3_j][fv3_i] < 0.5f) {
+          if (this->scfIMS[fv3_j][fv3_i] < 0.5f) {
             // if the IMS SCF is less than 0.5, set snow depth to 0
-            this->sndIMS[tilenum][fv3_j][fv3_i] = 0.0f;
+            this->sndIMS[fv3_j][fv3_i] = 0.0f;
           } else {
             // if the IMS SCF is greater than or equal to 0.5, calculate snow depth
             float bdsno =
@@ -665,13 +632,13 @@ void gdasapp::CalcSCFtoIODA::IMSscf::calcIMSsd(fv3jedi::State &state,
                                          static_cast<float>(bkg_snow_den(jnode, 0)) * 1000.0f));
             float fmelt = std::pow(bdsno/100.0f,
                                    mfsno_table[static_cast<int>(bkg_vtype(jnode, 0))-1]);
-            this->sndIMS[tilenum][fv3_j][fv3_i] =
+            this->sndIMS[fv3_j][fv3_i] =
                 (scffac_table[static_cast<int>(bkg_vtype(jnode, 0))-1] * fmelt)
                 * atanh(trunc_scf) * 1000.0f;  // x1000 into mm
           }
         } else {
           // if the model has no land at this point, set scf to nodata
-          this->scfIMS[tilenum][fv3_j][fv3_i] = nodata_float;
+          this->scfIMS[fv3_j][fv3_i] = nodata_float;
         }
       }
     }
@@ -694,27 +661,39 @@ void gdasapp::CalcSCFtoIODA::IMSscf::updateIMSsd(fv3jedi::State &state,
       atlas::array::make_view<atlas::gidx_t, 1>(geom.functionSpace().global_index());
   std::vector<int> indices = geom.get_indices();
   int tilenum = geom.tileNum()-1;
-  int npx = geom.npx()-1;
-  int npy = geom.npy()-1;
+  int npx = indices[1] - indices[0] + 1;
 
   for (size_t fv3_i=indices[0]-1; fv3_i < indices[1]; ++fv3_i) {
     for (size_t fv3_j=indices[2]-1; fv3_j < indices[3]; ++fv3_j) {
-      // force tile num to 0 for local array size
-      atlas::idx_t jnode = ((fv3_j)*(npx) + (fv3_i + 1)) - 1;
-      if ((this->scfIMS[tilenum][fv3_j][fv3_i] >= 0.5) &&
+      size_t local_j = fv3_j - (indices[2] - 1);
+      size_t local_i = fv3_i - (indices[0] - 1);
+      atlas::idx_t jnode = ((local_j)*(npx) + (local_i + 1)) - 1;
+      if ((this->scfIMS[fv3_j][fv3_i] >= 0.5) &&
          ((bkg_scf(jnode, 0) > trunc_scf) ||
-         (bkg_snd(jnode, 0) > this->sndIMS[tilenum][fv3_j][fv3_i]))) {
+         (bkg_snd(jnode, 0) > this->sndIMS[fv3_j][fv3_i]))) {
          // if obs and model both indicate full snow,
          // set the IMS snow depth to a fixed value to QC in JEDI
-        this->sndIMS[tilenum][fv3_j][fv3_i] = -10.0f;
+        this->sndIMS[fv3_j][fv3_i] = -10.0f;
       }
-      if (this->sndIMS[tilenum][fv3_j][fv3_i] > sndIMS_max) {
+      if (this->sndIMS[fv3_j][fv3_i] > sndIMS_max) {
         // if the IMS snow depth is greater than the maximum, set to nodata
-        this->sndIMS[tilenum][fv3_j][fv3_i] = nodata_float;
+        this->sndIMS[fv3_j][fv3_i] = nodata_float;
       }
     }
   }
-  oops::mpi::world().barrier();  // Ensure all ranks finish before proceeding
+  // Replace the background values with the IMS values to be written to IODA
+  // This allows us to use Atlas to do the heavy lifting for MPI
+  for (size_t fv3_i=indices[0]-1; fv3_i < indices[1]; ++fv3_i) {
+    for (size_t fv3_j=indices[2]-1; fv3_j < indices[3]; ++fv3_j) {
+      size_t local_j = fv3_j - (indices[2] - 1);
+      size_t local_i = fv3_i - (indices[0] - 1);
+      atlas::idx_t jnode = ((local_j)*(npx) + (local_i + 1)) - 1;
+      bkg_scf(jnode, 0) = static_cast<double>(this->scfIMS[fv3_j][fv3_i]);
+      bkg_snd(jnode, 0) = static_cast<double>(this->sndIMS[fv3_j][fv3_i]);
+    }
+  }
+  // put the new snow cover fraction and snow depth values back in the state
+  state.fromFieldSet(xBfs);
 }
 
 // Helper function for error handling

--- a/utils/land/gdas_fv3jedi_calc_scf_to_ioda.h
+++ b/utils/land/gdas_fv3jedi_calc_scf_to_ioda.h
@@ -24,7 +24,7 @@ namespace gdasapp {
       void readMapping();
       void calcIMSsd(fv3jedi::State &state, const fv3jedi::Geometry &geom);
       void updateIMSsd(fv3jedi::State &state, const fv3jedi::Geometry &geom);
-      std::vector<std::vector<std::vector<float>>> scfIMS, sndIMS;
+      std::vector<std::vector<float>> scfIMS, sndIMS;
 
 
      private:
@@ -33,7 +33,7 @@ namespace gdasapp {
       std::string weightspath_;
       std::vector<std::vector<int>> IMS_flag;
       std::vector<std::vector<std::vector<int>>> IMS_index;
-      std::vector<std::vector<std::vector<float>>> lonFV3, latFV3, oroFV3;
+      std::vector<std::vector<float>> lonFV3, latFV3, oroFV3;
       static constexpr int nodata_int = -999;
       static constexpr float nodata_float = -999.0f;
       static constexpr float nodata_tol = 0.1f;  // Tolerance for nodata checks


### PR DESCRIPTION
# Description

The initial implementation of the C++ SCF preprocessor was developed in a way that cut corners and only worked for one MPI task per FV3 tile. This is okay for low resolution, but does not work for C1152 (GFSv17 target). This PR introduces real MPI capabilities by leveraging the magic of Atlas. Note that further improvements can still occur, particularly in the input of the IMS dataset being done N number of times instead of properly parallelized.

I have confirmed that the output looks the same for 96 and 24 tasks at C1152, and appears to be the same as the old code at C96 when using 24 and 96 tasks.

For example:
<img width="1500" height="1000" alt="image" src="https://github.com/user-attachments/assets/4c9c32ae-06de-497b-8141-3ee79ab4a2f9" />


# Companion PRs

[JCB-GDAS](https://github.com/NOAA-EMC/jcb-gdas/pull/179)

# Issues

Closes #1899 

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmsnowDA <!-- JEDI snow cycled DA !-->
- [ ] C96_gcafs_cycled <!-- JEDI aerosol cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [ ] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
