### PR TITLE
Update aerosol parm to use viirs aod n21

### DIFF
--- a/parm/aero/jcb-prototype_3dvar.yaml.j2
+++ b/parm/aero/jcb-prototype_3dvar.yaml.j2
@@ -7,4 +7,4 @@ algorithm: 3dfgat
 observations:
 - viirs_n20_aod
 - viirs_npp_aod
-#- viirs_n21_aod
+- viirs_n21_aod


### PR DESCRIPTION
# Description

This PR updates 1) obs parm file to use viirs n21 aod, 2) jcb-gdas hash.

# Companion PRs
https://github.com/NOAA-EMC/jcb-gdas/pull/181

# Issues

# Automated CI tests to run in Global Workflow
- [ ] C96_gcafs_cycled <!-- JEDI aerosol cycled DA !-->
