### PR TITLE
Have propoceanobs create dummy obs file if there are otherwise no obs files

### DIFF
--- a/parm/marine/marine_prepobs_dummyobs.cdl
+++ b/parm/marine/marine_prepobs_dummyobs.cdl
@@ -1,4 +1,4 @@
-netcdf gdas.t00z.sst_avhrr_ma_l3u {
+netcdf ncgen-replaces-this-str-with-filename {
 dimensions:
 	Location = 1 ;
 variables:
@@ -8,7 +8,7 @@ variables:
 // global attributes:
 		:_ioda_layout = "ObsGroup" ;
 		:_ioda_layout_version = 0LL ;
-		:obs_source_files = "dummy-sst-file-with-one-dummy-observation.nc" ;
+		:obs_source_files = "global-workflow/sorc/gdas.cd/parm/marine/marine_prepobs_dummyobs.cdl" ;
 data:
 
  Location = 0 ;

--- a/parm/marine/marine_prepobs_dummyobs.cdl.j2
+++ b/parm/marine/marine_prepobs_dummyobs.cdl.j2
@@ -1,0 +1,64 @@
+netcdf gdas.t00z.sst_avhrr_ma_l3u {
+dimensions:
+	Location = 1 ;
+variables:
+	int Location(Location) ;
+		Location:suggested_chunk_dim = 103050LL ;
+
+// global attributes:
+		:_ioda_layout = "ObsGroup" ;
+		:_ioda_layout_version = 0LL ;
+		:obs_source_files = "dummy-sst-file-with-one-dummy-observation.nc" ;
+data:
+
+ Location = 0 ;
+
+group: MetaData {
+  variables:
+  	int64 dateTime(Location) ;
+  		dateTime:_FillValue = -9223372036854775801LL ;
+  		dateTime:units = "seconds since 1981-01-01T00:00:00Z" ;
+  	float latitude(Location) ;
+  		latitude:_FillValue = -3.368795e+38f ;
+  	float longitude(Location) ;
+  		longitude:_FillValue = -3.368795e+38f ;
+  	int oceanBasin(Location) ;
+  		oceanBasin:_FillValue = -2147483643 ;
+  data:
+
+   dateTime = 0 ;
+
+   latitude = 0 ;
+
+   longitude = 0 ;
+
+   oceanBasin = 0 ;
+  } // group MetaData
+
+group: ObsError {
+  variables:
+  	float seaSurfaceTemperature(Location) ;
+  		seaSurfaceTemperature:_FillValue = -3.368795e+38f ;
+  data:
+
+   seaSurfaceTemperature = 0 ;
+  } // group ObsError
+
+group: ObsValue {
+  variables:
+  	float seaSurfaceTemperature(Location) ;
+  		seaSurfaceTemperature:_FillValue = -3.368795e+38f ;
+  data:
+
+   seaSurfaceTemperature = 100000 ;
+  } // group ObsValue
+
+group: PreQC {
+  variables:
+  	int seaSurfaceTemperature(Location) ;
+  		seaSurfaceTemperature:_FillValue = -2147483643 ;
+  data:
+
+   seaSurfaceTemperature = 0 ;
+  } // group PreQC
+}

--- a/ush/soca/prep_ocean_obs.py
+++ b/ush/soca/prep_ocean_obs.py
@@ -4,15 +4,14 @@ from datetime import datetime, timedelta
 from logging import getLogger
 import os
 import glob
-import tempfile
 from typing import Dict
 from wxflow import (Executable,
                     FileHandler,
-                    Jinja,
                     logit,
                     Task)
 
 logger = getLogger(__name__.split('.')[-1])
+
 
 class PrepOceanObs(Task):
     """
@@ -130,11 +129,11 @@ class PrepOceanObs(Task):
             converter.add_default_arg(output_nc)
             converter.add_default_arg(dummy_cdl)
             try:
-               logger.debug(f"Executing {converter}")
-               converter()
+                logger.debug(f"Executing {converter}")
+                converter()
             except Exception as e:
-               logger.warning(f"Execution failed for {converter}: {e}")
-               logger.debug("Exception details", exc_info=True)
-               exit(1)
+                logger.warning(f"Execution failed for {converter}: {e}")
+                logger.debug("Exception details", exc_info=True)
+                exit(1)
 
             FileHandler({'copy': [[output_nc, os.path.join(comout_obs, output_nc)]] }).sync()

--- a/ush/soca/prep_ocean_obs.py
+++ b/ush/soca/prep_ocean_obs.py
@@ -136,4 +136,4 @@ class PrepOceanObs(Task):
                 logger.debug("Exception details", exc_info=True)
                 exit(1)
 
-            FileHandler({'copy': [[output_nc, os.path.join(comout_obs, output_nc)]] }).sync()
+            FileHandler({'copy': [[output_nc, os.path.join(comout_obs, output_nc)]]}).sync()

--- a/ush/soca/prep_ocean_obs.py
+++ b/ush/soca/prep_ocean_obs.py
@@ -134,6 +134,6 @@ class PrepOceanObs(Task):
             except Exception as e:
                 logger.warning(f"Execution failed for {converter}: {e}")
                 logger.debug("Exception details", exc_info=True)
-                exit(1)
+                raise RuntimeError(f"Execution failed for {converter}: {e}")
 
             FileHandler({'copy': [[output_nc, os.path.join(comout_obs, output_nc)]]}).sync()

--- a/ush/soca/prep_ocean_obs.py
+++ b/ush/soca/prep_ocean_obs.py
@@ -121,21 +121,14 @@ class PrepOceanObs(Task):
             logger.warning("***** No files found to copy, generating dummy sst obs file.")
             # source is arbitrary sst
             dummy_source = "sst_avhrr_ma_l3u"
-            filename_body = f"{run}.t{cycle}z.{dummy_source}"
-            output_nc = os.path.join(comout_obs, f"{filename_body}.nc")
-            tmp_cdl = f"{filename_body}.cdl"
+            output_nc = f"{run}.t{cycle}z.{dummy_source}.nc"
             # TODO (AFE) replace this with something set in a config file
-            dummy_template = os.path.join(PARMgfs, 'gdas', 'marine', 'marine_prepobs_dummyobs.cdl.j2')
-            print(f"dummy_template: {dummy_template}")
-            cdl_text = Jinja(dummy_template, data=dict(), allow_missing=True).render
-
-            with open(tmp_cdl, "w", encoding="utf-8") as f:
-               f.write(cdl_text)
+            dummy_cdl = os.path.join(PARMgfs, 'gdas', 'marine', 'marine_prepobs_dummyobs.cdl')
 
             converter = Executable('ncgen')
             converter.add_default_arg('-o')
             converter.add_default_arg(output_nc)
-            converter.add_default_arg(tmp_cdl)
+            converter.add_default_arg(dummy_cdl)
             try:
                logger.debug(f"Executing {converter}")
                converter()
@@ -143,3 +136,5 @@ class PrepOceanObs(Task):
                logger.warning(f"Execution failed for {converter}: {e}")
                logger.debug("Exception details", exc_info=True)
                exit(1)
+
+            FileHandler({'copy': [[output_nc, os.path.join(comout_obs, output_nc)]] }).sync()

--- a/ush/soca/prep_ocean_obs.py
+++ b/ush/soca/prep_ocean_obs.py
@@ -4,13 +4,15 @@ from datetime import datetime, timedelta
 from logging import getLogger
 import os
 import glob
+import tempfile
 from typing import Dict
-from wxflow import (FileHandler,
+from wxflow import (Executable,
+                    FileHandler,
+                    Jinja,
                     logit,
                     Task)
 
 logger = getLogger(__name__.split('.')[-1])
-
 
 class PrepOceanObs(Task):
     """
@@ -88,6 +90,7 @@ class PrepOceanObs(Task):
         run_date = self.task_config['PDY'].strftime('%Y%m%d')
         cycle = str(self.task_config['cyc']).zfill(2)  # ensures '00', '06', etc.
         run = self.task_config['RUN']
+        PARMgfs = self.task_config['PARMgfs']
 
         # Ensure output directory exists
         os.makedirs(comout_obs, exist_ok=True)
@@ -115,4 +118,28 @@ class PrepOceanObs(Task):
         if obsfiles_src_dst:
             FileHandler({'copy': obsfiles_src_dst}).sync()
         else:
-            logger.warning("***** No files found to copy.")
+            logger.warning("***** No files found to copy, generating dummy sst obs file.")
+            # source is arbitrary sst
+            dummy_source = "sst_avhrr_ma_l3u"
+            filename_body = f"{run}.t{cycle}z.{dummy_source}"
+            output_nc = os.path.join(comout_obs, f"{filename_body}.nc")
+            tmp_cdl = f"{filename_body}.cdl"
+            # TODO (AFE) replace this with something set in a config file
+            dummy_template = os.path.join(PARMgfs, 'gdas', 'marine', 'marine_prepobs_dummyobs.cdl.j2')
+            print(f"dummy_template: {dummy_template}")
+            cdl_text = Jinja(dummy_template, data=dict(), allow_missing=True).render
+
+            with open(tmp_cdl, "w", encoding="utf-8") as f:
+               f.write(cdl_text)
+
+            converter = Executable('ncgen')
+            converter.add_default_arg('-o')
+            converter.add_default_arg(output_nc)
+            converter.add_default_arg(tmp_cdl)
+            try:
+               logger.debug(f"Executing {converter}")
+               converter()
+            except Exception as e:
+               logger.warning(f"Execution failed for {converter}: {e}")
+               logger.debug("Exception details", exc_info=True)
+               exit(1)


### PR DESCRIPTION
# Description

If prepoceanobs finds no ocean obs files in DMPDIR, it generates an sst IODA file from an existing CDL file in order to provide something for the analysis (which otherwise fails).

Tested by running `C48mx500_3DVarAOWCDA` and `C48mx500_hybAOWCDA` while pointing to an empty DMPDIR for the marine analysis, producing increments of 0. ~~Shold probably be tested on a multicycle experiment.~~ Also similarly tested with for five complete cycles with `C96C48mx500_S2SW_cyc_gfs`

# Companion PRs

NA

# Issues

Resolves https://github.com/NOAA-EMC/GDASApp/issues/1910

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmsnowDA <!-- JEDI snow cycled DA !-->
- [ ] C96_gcafs_cycled <!-- JEDI aerosol cycled DA !-->
- [x] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [x] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
