### PR TITLE
break out ens and parametric bkgerr stats

### DIFF
--- a/parm/marine/marine_bmat_save.yaml.j2
+++ b/parm/marine/marine_bmat_save.yaml.j2
@@ -6,7 +6,7 @@ copy:
 - ['{{ DATAstaticb }}/{{ diff_type }}_ocean.nc', '{{ COMOUT_OCEAN_BMATRIX }}/{{ APREFIX }}{{ diff_type }}_ocean.nc']
 {% endfor %}
 # diag B
-- ['{{ DATAstaticb }}/ocn.bkgerr_parametric_stddev.nc', '{{ COMOUT_OCEAN_BMATRIX }}/{{ APREFIX }}ocean.bkgerr_parametric_sstddev.nc']
+- ['{{ DATAstaticb }}/ocn.bkgerr_parametric_stddev.nc', '{{ COMOUT_OCEAN_BMATRIX }}/{{ APREFIX }}ocean.bkgerr_parametric_stddev.nc']
 - ['{{ DATAstaticb }}/ice.bkgerr_parametric_stddev.nc', '{{ COMOUT_ICE_BMATRIX }}/{{ APREFIX }}ice.bkgerr_parametric_stddev.nc']
 {% if DOHYBVAR_OCN == "YES" or NMEM_ENS >= 2 %}
 - ['{{ DATAstaticb }}/ocn.bkgerr_ens_stddev.nc', '{{ COMOUT_OCEAN_BMATRIX }}/{{ APREFIX }}ocean.bkgerr_ens_stddev.nc']

--- a/parm/marine/marine_bmat_save.yaml.j2
+++ b/parm/marine/marine_bmat_save.yaml.j2
@@ -6,9 +6,11 @@ copy:
 - ['{{ DATAstaticb }}/{{ diff_type }}_ocean.nc', '{{ COMOUT_OCEAN_BMATRIX }}/{{ APREFIX }}{{ diff_type }}_ocean.nc']
 {% endfor %}
 # diag B
-- ['{{ DATAstaticb }}/ocn.bkgerr_stddev.nc', '{{ COMOUT_OCEAN_BMATRIX }}/{{ APREFIX }}ocean.bkgerr_ens_stddev.nc']
-- ['{{ DATAstaticb }}/ice.bkgerr_stddev.nc', '{{ COMOUT_ICE_BMATRIX }}/{{ APREFIX }}ice.bkgerr_ens_stddev.nc']
+- ['{{ DATAstaticb }}/ocn.bkgerr_parametric_stddev.nc', '{{ COMOUT_OCEAN_BMATRIX }}/{{ APREFIX }}ocean.bkgerr_parametric_sstddev.nc']
+- ['{{ DATAstaticb }}/ice.bkgerr_parametric_stddev.nc', '{{ COMOUT_ICE_BMATRIX }}/{{ APREFIX }}ice.bkgerr_parametric_stddev.nc']
 {% if DOHYBVAR_OCN == "YES" or NMEM_ENS >= 2 %}
+- ['{{ DATAstaticb }}/ocn.bkgerr_ens_stddev.nc', '{{ COMOUT_OCEAN_BMATRIX }}/{{ APREFIX }}ocean.bkgerr_ens_stddev.nc']
+- ['{{ DATAstaticb }}/ice.bkgerr_ens_stddev.nc', '{{ COMOUT_ICE_BMATRIX }}/{{ APREFIX }}ice.bkgerr_ens_stddev.nc']
 - ['{{ DATAstaticb }}/ocn.ssh_recentering_error.incr.{{ MARINE_WINDOW_BEGIN_ISO }}.nc', '{{ COMOUT_OCEAN_BMATRIX }}/{{ APREFIX }}ocean.recentering_error.nc']
 - ['{{ DATAstaticb }}/ice.ssh_recentering_error.incr.{{ MARINE_WINDOW_BEGIN_ISO }}.nc', '{{ COMOUT_ICE_BMATRIX }}/{{ APREFIX }}ice.recentering_error.nc']
 {% endif %}


### PR DESCRIPTION
# Description

Fixes scrambling of ens and parametric bkgerr stats

# Companion PRs

Requires https://github.com/NOAA-EMC/jcb-gdas/pull/186 and pending g-w PR (https://github.com/NOAA-EMC/global-workflow/pull/4120)

<!-- Enter links to any companion PRs here. -->

# Issues

Resolves, with jcb-gdas and global-workflow PRs, https://github.com/NOAA-EMC/GDASApp/issues/1921

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmsnowDA <!-- JEDI snow cycled DA !-->
- [ ] C96_gcafs_cycled <!-- JEDI aerosol cycled DA !-->
- [x] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [x] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
