### PR TITLE
Add jinja yaml template for moving (renaming) bkgerr stat files

### DIFF
--- a/parm/marine/marine_bmat_copy_bkgerr.yaml.j2
+++ b/parm/marine/marine_bmat_copy_bkgerr.yaml.j2
@@ -1,0 +1,8 @@
+copy_req:
+# diag B
+- ['{{ DATAstaticb }}/ocn.bkgerr_parametric_stddev.incr.{{ MARINE_WINDOW_END_ISO }}.nc', '{{ DATAstaticb }}/ocn.bkgerr_parametric_stddev.nc']
+- ['{{ DATAstaticb }}/ice.bkgerr_parametric_stddev.incr.{{ MARINE_WINDOW_END_ISO }}.nc', '{{ DATAstaticb }}/ice.bkgerr_parametric_stddev.nc']
+{% if DOHYBVAR_OCN == "YES" or NMEM_ENS >= 2 %}
+- ['{{ DATAstaticb }}/ocn.bkgerr_ens_stddev.incr.{{ MARINE_WINDOW_BEGIN_ISO }}.nc','{{ DATAstaticb }}/ocn.bkgerr_ens_stddev.nc']
+- ['{{ DATAstaticb }}/ice.bkgerr_ens_stddev.incr.{{ MARINE_WINDOW_BEGIN_ISO }}.nc','{{ DATAstaticb }}/ice.bkgerr_ens_stddev.nc']
+{% endif %}

--- a/parm/marine/marine_bmat_save.yaml.j2
+++ b/parm/marine/marine_bmat_save.yaml.j2
@@ -6,7 +6,7 @@ copy:
 - ['{{ DATAstaticb }}/{{ diff_type }}_ocean.nc', '{{ COMOUT_OCEAN_BMATRIX }}/{{ APREFIX }}{{ diff_type }}_ocean.nc']
 {% endfor %}
 # diag B
-- ['{{ DATAstaticb }}/ocn.bkgerr_parametric_stddev.nc', '{{ COMOUT_OCEAN_BMATRIX }}/{{ APREFIX }}ocean.bkgerr_parametric_sstddev.nc']
+- ['{{ DATAstaticb }}/ocn.bkgerr_parametric_stddev.nc', '{{ COMOUT_OCEAN_BMATRIX }}/{{ APREFIX }}ocean.bkgerr_parametric_stddev.nc']
 - ['{{ DATAstaticb }}/ice.bkgerr_parametric_stddev.nc', '{{ COMOUT_ICE_BMATRIX }}/{{ APREFIX }}ice.bkgerr_parametric_stddev.nc']
 {% if DOHYBVAR_OCN == "YES" or NMEM_ENS >= 2 %}
 - ['{{ DATAstaticb }}/ocn.bkgerr_ens_stddev.nc', '{{ COMOUT_OCEAN_BMATRIX }}/{{ APREFIX }}ocean.bkgerr_ens_stddev.nc']

--- a/parm/marine/marine_bmat_save.yaml.j2
+++ b/parm/marine/marine_bmat_save.yaml.j2
@@ -6,9 +6,11 @@ copy:
 - ['{{ DATAstaticb }}/{{ diff_type }}_ocean.nc', '{{ COMOUT_OCEAN_BMATRIX }}/{{ APREFIX }}{{ diff_type }}_ocean.nc']
 {% endfor %}
 # diag B
-- ['{{ DATAstaticb }}/ocn.bkgerr_stddev.nc', '{{ COMOUT_OCEAN_BMATRIX }}/{{ APREFIX }}ocean.bkgerr_ens_stddev.nc']
-- ['{{ DATAstaticb }}/ice.bkgerr_stddev.nc', '{{ COMOUT_ICE_BMATRIX }}/{{ APREFIX }}ice.bkgerr_ens_stddev.nc']
+- ['{{ DATAstaticb }}/ocn.bkgerr_parametric_stddev.nc', '{{ COMOUT_OCEAN_BMATRIX }}/{{ APREFIX }}ocean.bkgerr_parametric_sstddev.nc']
+- ['{{ DATAstaticb }}/ice.bkgerr_parametric_stddev.nc', '{{ COMOUT_ICE_BMATRIX }}/{{ APREFIX }}ice.bkgerr_parametric_stddev.nc']
 {% if DOHYBVAR_OCN == "YES" or NMEM_ENS >= 2 %}
+- ['{{ DATAstaticb }}/ocn.bkgerr_ens_stddev.nc', '{{ COMOUT_OCEAN_BMATRIX }}/{{ APREFIX }}ocean.bkgerr_ens_stddev.nc']
+- ['{{ DATAstaticb }}/ice.bkgerr_ens_stddev.nc', '{{ COMOUT_ICE_BMATRIX }}/{{ APREFIX }}ice.bkgerr_ens_stddev.nc']
 - ['{{ DATAstaticb }}/ocn.ssh_recentering_error.incr.{{ MARINE_WINDOW_BEGIN_ISO }}.nc', '{{ COMOUT_OCEAN_BMATRIX }}/{{ APREFIX }}ocean.recentering_error.nc']
 - ['{{ DATAstaticb }}/ice.ssh_recentering_error.incr.{{ MARINE_WINDOW_BEGIN_ISO }}.nc', '{{ COMOUT_ICE_BMATRIX }}/{{ APREFIX }}ice.recentering_error.nc']
 {% endif %}


### PR DESCRIPTION
# Description

Adds jinja yaml template for moving (renaming) bkgerr stat files in bmat task

# Companion PRs

Will need https://github.com/NOAA-EMC/global-workflow/pull/4120 to actually work

# Issues

Helps fix https://github.com/NOAA-EMC/GDASApp/issues/1921

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmsnowDA <!-- JEDI snow cycled DA !-->
- [ ] C96_gcafs_cycled <!-- JEDI aerosol cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [x] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [x] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
