### PR TITLE
Add CICE restart file validation and fixing utility

### DIFF
--- a/utils/soca/fixcicerst/README.md
+++ b/utils/soca/fixcicerst/README.md
@@ -4,7 +4,7 @@ This utility checks CICE6 restart files for unrealistic ice and snow thickness v
 
 ## Purpose
 
-The tool addresses issues where CICE6 restart files contain unrealistically thick ice or snow that can cause model instability or unphysical behavior. When ice or snow thickness exceeds specified maximum values, all sea ice state variables at those grid points are set to zero, effectively creating open water conditions.
+The tool addresses issues where CICE6 restart files contain unrealistically thick ice or snow that may cause model instability or unphysical behavior. When ice or snow thickness exceeds specified maximum values, all sea ice state variables at those grid points are set to zero, effectively creating open water conditions.
 
 ## Usage
 
@@ -15,7 +15,6 @@ python fix_cice_restart.py config.yaml
 ### Options
 
 - `config.yaml`: YAML configuration file specifying input parameters
-- `--dry-run`: Check thickness values without creating output file (not yet implemented)
 
 ## Configuration File Format
 
@@ -49,8 +48,8 @@ When thickness limits are exceeded, the following CICE state variables are zeroe
 ### Ice Physics
 - `Tsfcn`: Surface temperature per category
 - `iage`: Ice age
-- `alvl`: Level ice area fraction
-- `vlvl`: Level ice volume per unit area
+- `alvl`: Ridged Ice Area per Category
+- `vlvl`: Ridged Ice Volume per Category
 
 ### Melt Ponds
 - `apnd`: Melt pond area fraction
@@ -58,13 +57,13 @@ When thickness limits are exceeded, the following CICE state variables are zeroe
 - `ipnd`: Melt pond ice thickness
 
 ### Thermodynamics
-- `sice001`-`sice007`: Ice enthalpy per layer
-- `qice001`-`qice007`: Ice internal energy per layer
-- `qsno001`: Snow internal energy
+- `sice001`-`sice007`:Ice salinity per layer
+- `qice001`-`qice007`: Ice enthalpy per layer
+- `qsno001`: Snow enthalpy
 
 ### Other Variables
-- `dhs`: Snow depth difference
-- `ffrac`: Floe size distribution
+- `dhs`: change in mean snow thickness
+- `ffrac`: mean fraction of fsurfn used to melt ipond
 
 ## Algorithm
 

--- a/utils/soca/fixcicerst/README.md
+++ b/utils/soca/fixcicerst/README.md
@@ -1,0 +1,113 @@
+# CICE Restart File Fixing Utility
+
+This utility checks CICE6 restart files for unrealistic ice and snow thickness values and creates corrected restart files with the sea ice state "zeroed out" at problematic grid points.
+
+## Purpose
+
+The tool addresses issues where CICE6 restart files contain unrealistically thick ice or snow that can cause model instability or unphysical behavior. When ice or snow thickness exceeds specified maximum values, all sea ice state variables at those grid points are set to zero, effectively creating open water conditions.
+
+## Usage
+
+```bash
+python fix_cice_restart.py config.yaml
+```
+
+### Options
+
+- `config.yaml`: YAML configuration file specifying input parameters
+- `--dry-run`: Check thickness values without creating output file (not yet implemented)
+
+## Configuration File Format
+
+The YAML configuration file must contain:
+
+```yaml
+# Required: Path to input CICE restart file
+cice_restart_path: "/path/to/cice.r.yyyy-mm-dd-sssss.nc"
+
+# Required: Maximum ice thickness threshold (meters)
+max_ice_thickness: 10.0
+
+# Required: Maximum snow thickness threshold (meters)
+max_snow_thickness: 2.0
+
+# Optional: Output file path
+output_path: "/path/to/fixed_restart.nc"
+```
+
+If `output_path` is not specified, the output file will be named `fixed_<original_filename>` in the same directory as the input file.
+
+## Sea Ice Variables Modified
+
+When thickness limits are exceeded, the following CICE state variables are zeroed:
+
+### Ice and Snow
+- `aicen`: Ice concentration per category
+- `vicen`: Ice volume per unit area per category
+- `vsnon`: Snow volume per unit area per category
+
+### Ice Physics
+- `Tsfcn`: Surface temperature per category
+- `iage`: Ice age
+- `alvl`: Level ice area fraction
+- `vlvl`: Level ice volume per unit area
+
+### Melt Ponds
+- `apnd`: Melt pond area fraction
+- `hpnd`: Melt pond depth
+- `ipnd`: Melt pond ice thickness
+
+### Thermodynamics
+- `sice001`-`sice007`: Ice enthalpy per layer
+- `qice001`-`qice007`: Ice internal energy per layer
+- `qsno001`: Snow internal energy
+
+### Other Variables
+- `dhs`: Snow depth difference
+- `ffrac`: Floe size distribution
+
+## Algorithm
+
+1. **Read Configuration**: Parse YAML file for input parameters
+2. **Load Restart File**: Open NetCDF restart file and read dimensions
+3. **Calculate Thickness**: Sum ice/snow volumes across categories to get total thickness
+4. **Create Mask**: Identify grid points where thickness exceeds limits
+5. **Zero State Variables**: Set all sea ice variables to zero at masked points
+6. **Write Output**: Create new restart file with corrections applied
+
+## Dependencies
+
+- Python 3.6+
+- netCDF4
+- numpy
+- PyYAML
+
+## Example
+
+```bash
+# Create configuration file
+cat > config.yaml << EOF
+cice_restart_path: "cice.r.2023-01-15-00000.nc"
+max_ice_thickness: 8.0
+max_snow_thickness: 1.5
+output_path: "cice.r.2023-01-15-00000.fixed.nc"
+EOF
+
+# Run the fix
+python fix_cice_restart.py config.yaml
+```
+
+## Output
+
+The utility provides logging information about:
+- Input file dimensions and statistics
+- Number of grid points exceeding thickness limits
+- Variables modified and number of points affected
+- Output file location
+
+## Notes
+
+- The tool preserves all file attributes and metadata from the original restart file
+- Only sea ice state variables are modified; ocean and atmospheric forcing remain unchanged
+- Grid points with excessive thickness become open water (all sea ice variables = 0)
+- The original restart file is not modified; a new corrected file is created

--- a/utils/soca/fixcicerst/config_example.yaml
+++ b/utils/soca/fixcicerst/config_example.yaml
@@ -1,0 +1,21 @@
+# Example configuration for fix_cice_restart.py
+# This file specifies the CICE6 restart file to process and thickness limits
+
+# Path to the input CICE restart file
+cice_restart_path: "/home/gvernier/data/20250830.150000.cice_model.res.nc"
+
+# Maximum allowed ice thickness (meters)
+# Points with aggregated ice thickness exceeding this will be zeroed
+max_ice_thickness: 10.0
+
+# Maximum allowed snow thickness (meters)
+# Points with aggregated snow thickness exceeding this will be zeroed
+max_snow_thickness: 2.0
+
+# Optional: Path for the output fixed restart file
+# If not specified, will create "fixed_<original_name>" in same directory
+output_path: "./fixed_cice.nc"
+
+# Optional: Additional settings for future enhancements
+# verbose: true
+# backup_original: false

--- a/utils/soca/fixcicerst/config_example.yaml
+++ b/utils/soca/fixcicerst/config_example.yaml
@@ -2,7 +2,7 @@
 # This file specifies the CICE6 restart file to process and thickness limits
 
 # Path to the input CICE restart file
-cice_restart_path: "/home/gvernier/data/20250830.150000.cice_model.res.nc"
+cice_restart_path: "/path/to/cice/restart/20250830.150000.cice_model.res.nc"
 
 # Maximum allowed ice thickness (meters)
 # Points with aggregated ice thickness exceeding this will be zeroed
@@ -15,7 +15,3 @@ max_snow_thickness: 2.0
 # Optional: Path for the output fixed restart file
 # If not specified, will create "fixed_<original_name>" in same directory
 output_path: "./fixed_cice.nc"
-
-# Optional: Additional settings for future enhancements
-# verbose: true
-# backup_original: false

--- a/utils/soca/fixcicerst/fix_cice_restart.py
+++ b/utils/soca/fixcicerst/fix_cice_restart.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""
+Application to check and fix CICE6 restart files.
+
+This script reads a YAML configuration file containing paths to CICE6 restart
+files and upper bounds for ice and snow thickness. It creates new restart files
+with sea ice state "zeroed out" where thicknesses exceed the defined maximums.
+"""
+
+import sys
+import yaml
+import numpy as np
+from netCDF4 import Dataset
+from pathlib import Path
+import argparse
+import logging
+
+# Set up logging
+logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
+logger = logging.getLogger(__name__)
+
+
+def load_config(config_file):
+    """
+    Load YAML configuration file.
+
+    Expected format:
+    cice_restart_path: "/path/to/restart.nc"
+    max_ice_thickness: 10.0   # meters
+    max_snow_thickness: 2.0   # meters
+    output_path: "/path/to/fixed_restart.nc"  # optional
+    """
+    try:
+        with open(config_file, 'r') as f:
+            config = yaml.safe_load(f)
+        return config
+    except Exception as e:
+        logger.error(f"Error loading config file {config_file}: {e}")
+        sys.exit(1)
+
+
+def calculate_aggregated_thickness(vicen, vsnon):
+    """
+    Calculate aggregated ice and snow thickness across categories.
+
+    Parameters:
+    vicen: ice volume per unit area (ncat, nj, ni)
+    vsnon: snow volume per unit area (ncat, nj, ni)
+
+    Returns:
+    ice_thickness: aggregated ice thickness (nj, ni)
+    snow_thickness: aggregated snow thickness (nj, ni)
+    """
+    # Sum across categories (axis=0)
+    ice_thickness = np.sum(vicen, axis=0)
+    snow_thickness = np.sum(vsnon, axis=0)
+
+    return ice_thickness, snow_thickness
+
+
+def create_mask(ice_thickness, snow_thickness, max_ice, max_snow):
+    """
+    Create mask for points where ice or snow thickness exceeds limits.
+
+    Returns:
+    mask: True where thickness exceeds limits (should be zeroed)
+    """
+    ice_exceed = ice_thickness > max_ice
+    snow_exceed = snow_thickness > max_snow
+
+    # Mask is True where either ice or snow exceeds limits
+    mask = ice_exceed | snow_exceed
+
+    return mask
+
+
+def zero_seaice_state(dataset, mask):
+    """
+    Zero out sea ice state variables where mask is True.
+
+    Sea ice state variables to zero:
+    - aicen: ice concentration
+    - vicen: ice volume per unit area
+    - vsnon: snow volume per unit area
+    - Tsfcn: surface temperature
+    - iage: ice age
+    - alvl: level ice area fraction
+    - vlvl: level ice volume per unit area
+    - apnd: melt pond area fraction
+    - hpnd: melt pond depth
+    - ipnd: melt pond ice thickness
+    - dhs: snow depth difference
+    - ffrac: floe size distribution
+    - sice*: sea ice salinity
+    - qice*: ice enthalpy
+    - qsno*: snow enthalpy
+    """
+
+    seaice_vars = [
+        'aicen', 'vicen', 'vsnon', 'Tsfcn', 'iage', 'alvl', 'vlvl',
+        'apnd', 'hpnd', 'ipnd', 'dhs', 'ffrac'
+    ]
+
+    # Add salinity and enthalpy variables
+    for i in range(1, 8):  # sice001-007, qice001-007
+        seaice_vars.extend([f'sice{i:03d}', f'qice{i:03d}'])
+
+    # Add snow enthalpy (qsno001)
+    seaice_vars.append('qsno001')
+
+    points_modified = np.sum(mask)
+
+    for var_name in seaice_vars:
+        if var_name in dataset.variables:
+            var = dataset.variables[var_name]
+
+            if len(var.dimensions) == 3 and var.dimensions[0] == 'ncat':
+                # Category-based variable (ncat, nj, ni)
+                # Read all data, modify, then write back
+                data = var[:]
+                for cat in range(data.shape[0]):
+                    data[cat, mask] = 0.0
+                var[:] = data
+
+                if points_modified > 0:
+                    logger.info(f"Zeroed {points_modified} points for "
+                                f"variable {var_name}")
+
+            elif len(var.dimensions) == 2:
+                # 2D variable (nj, ni)
+                # Read data, modify, then write back
+                data = var[:]
+                data[mask] = 0.0
+                var[:] = data
+
+                if points_modified > 0:
+                    logger.info(f"Zeroed {points_modified} points for "
+                                f"variable {var_name}")
+
+    return points_modified
+
+
+def fix_cice_restart(config):
+    """
+    Main function to fix CICE restart file.
+    """
+    input_file = config['cice_restart_path']
+    max_ice = config.get('max_ice_thickness', 10.0)
+    max_snow = config.get('max_snow_thickness', 2.0)
+
+    # Determine output file
+    if 'output_path' in config:
+        output_file = config['output_path']
+    else:
+        input_path = Path(input_file)
+        output_file = input_path.parent / f"fixed_{input_path.name}"
+
+    logger.info(f"Processing CICE restart: {input_file}")
+    logger.info(f"Max ice thickness: {max_ice} m")
+    logger.info(f"Max snow thickness: {max_snow} m")
+    logger.info(f"Output file: {output_file}")
+
+    try:
+        # Open input file
+        with Dataset(input_file, 'r') as src:
+            ni_size = src.dimensions['ni'].size
+            nj_size = src.dimensions['nj'].size
+            ncat_size = src.dimensions['ncat'].size
+            logger.info(f"Input file dimensions: ni={ni_size}, "
+                        f"nj={nj_size}, ncat={ncat_size}")
+
+            # Read ice and snow volumes
+            vicen = src.variables['vicen'][:]
+            vsnon = src.variables['vsnon'][:]
+
+            # Calculate aggregated thicknesses
+            ice_thickness, snow_thickness = calculate_aggregated_thickness(
+                vicen, vsnon)
+
+            # Create mask
+            mask = create_mask(ice_thickness, snow_thickness,
+                               max_ice, max_snow)
+
+            ice_exceed = np.sum(ice_thickness > max_ice)
+            snow_exceed = np.sum(snow_thickness > max_snow)
+            logger.info(f"Points exceeding ice thickness limit: {ice_exceed}")
+            logger.info(f"Points exceeding snow thickness limit: "
+                        f"{snow_exceed}")
+            logger.info(f"Total points to be zeroed: {np.sum(mask)}")
+
+            if np.sum(mask) == 0:
+                logger.info("No points exceed the thickness limits. "
+                            "No changes needed.")
+                return
+
+            # Create output file (copy of input)
+            with Dataset(output_file, 'w') as dst:
+                # Copy dimensions
+                for name, dim in src.dimensions.items():
+                    size = len(dim) if not dim.isunlimited() else None
+                    dst.createDimension(name, size)
+
+                # Copy variables and attributes
+                for name, var in src.variables.items():
+                    dst_var = dst.createVariable(name, var.datatype,
+                                                 var.dimensions)
+
+                    # Copy attributes
+                    attrs = {k: var.getncattr(k) for k in var.ncattrs()}
+                    dst_var.setncatts(attrs)
+
+                    # Copy data
+                    dst_var[:] = var[:]
+
+                # Copy global attributes
+                dst.setncatts({k: src.getncattr(k) for k in src.ncattrs()})
+
+                # Zero out sea ice state where needed
+                points_modified = zero_seaice_state(dst, mask)
+
+        logger.info(f"Fixed restart file written to: {output_file}")
+        logger.info(f"Total grid points modified: {points_modified}")
+
+    except Exception as e:
+        logger.error(f"Error processing restart file: {e}")
+        sys.exit(1)
+
+
+def main():
+    description = ("Fix CICE6 restart files by zeroing sea ice state "
+                   "where thickness exceeds limits")
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument(
+        "config_file",
+        help="YAML configuration file"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Check thicknesses but don't create output file"
+    )
+
+    args = parser.parse_args()
+
+    # Load configuration
+    config = load_config(args.config_file)
+
+    # Validate required keys
+    required_keys = ['cice_restart_path']
+    for key in required_keys:
+        if key not in config:
+            logger.error(f"Required key '{key}' not found in config file")
+            sys.exit(1)
+
+    if args.dry_run:
+        logger.info("DRY RUN MODE - no output file will be created")
+        # TODO: Implement dry run logic
+        return
+
+    # Fix the restart file
+    fix_cice_restart(config)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds a python utility to identify and fix problematic `CICE6` restart files where unrealistic ice/snow thickness values may cause model instability, or at the very least, embarrassment.

- fixes #1937 

This utility was tested by generating a new `CICE6` restart and initializing a forecast with the fixed restart.
```console
[ufe01 /scratch3/NCEPDEV/.../soca/fixcicerst [feature/fixcice]] $ ./fix_cice_restart.py config_example.yaml 
INFO: Processing CICE restart: /scratch3/NCEPDEV/da/Guillaume.Vernieres/runs/gfsv17/mlb1/COMROOT/mlb1/gdas.20250831/18/analysis/ice/20250831.150000.cice_model_anl.res.nc
INFO: Max ice thickness: 10.0 m
INFO: Max snow thickness: 4.0 m
INFO: Output file: ./20250831.150000.cice_model_anl.res.nc
INFO: Input file dimensions: ni=1440, nj=1080, ncat=5
INFO: Points exceeding ice thickness limit: 7
INFO: Points exceeding snow thickness limit: 0
INFO: Total points to be zeroed: 7
INFO: Zeroed 7 points for variable aicen
INFO: Zeroed 7 points for variable vicen
INFO: Zeroed 7 points for variable vsnon
INFO: Zeroed 7 points for variable Tsfcn
INFO: Zeroed 7 points for variable iage
INFO: Zeroed 7 points for variable alvl
INFO: Zeroed 7 points for variable vlvl
INFO: Zeroed 7 points for variable apnd
INFO: Zeroed 7 points for variable hpnd
INFO: Zeroed 7 points for variable ipnd
INFO: Zeroed 7 points for variable dhs
INFO: Zeroed 7 points for variable ffrac
INFO: Zeroed 7 points for variable sice001
INFO: Zeroed 7 points for variable qice001
INFO: Zeroed 7 points for variable sice002
INFO: Zeroed 7 points for variable qice002
INFO: Zeroed 7 points for variable sice003
INFO: Zeroed 7 points for variable qice003
INFO: Zeroed 7 points for variable sice004
INFO: Zeroed 7 points for variable qice004
INFO: Zeroed 7 points for variable sice005
INFO: Zeroed 7 points for variable qice005
INFO: Zeroed 7 points for variable sice006
INFO: Zeroed 7 points for variable qice006
INFO: Zeroed 7 points for variable sice007
INFO: Zeroed 7 points for variable qice007
INFO: Zeroed 7 points for variable qsno001
INFO: Fixed restart file written to: ./20250831.150000.cice_model_anl.res.nc
INFO: Total grid points modified: 7
```
The original file had a few grid cells with ice thickness > ~45m, the new file's max ice thickness is ~8m (similar for the forecast). **Mission accomplished!**

