### PR TITLE
Replaced 'TMANT' with 'TMBR' for ATMS brightness temperature data.

### DIFF
--- a/parm/ioda/bufr2ioda/bufr2ioda_atms.yaml
+++ b/parm/ioda/bufr2ioda/bufr2ioda_atms.yaml
@@ -64,7 +64,7 @@ observations:
             remappedBrightnessTemperature:
               fieldOfViewNumber: "*/FOVN"
               sensorChannelNumber: "*/ATMSCH/CHNM"
-              brightnessTemperature: "*/ATMSCH/TMANT"
+              brightnessTemperature: "*/ATMSCH/TMBR"
               obsTime:
                 year: "*/YEAR"
                 month: "*/MNTH"


### PR DESCRIPTION
# Description

What GSI reads in about ATMS data is 'TMBR' for brightness temperature because "ta2tb = true". See the reading code in GSI:
https://github.com/NOAA-EMC/GSI/blob/develop/src/gsi/read_atms.f90#L492

# Companion PRs

<!-- Enter links to any companion PRs here. -->

# Issues

<!-- Enter any issues referenced or resolved by this PR here. Use keywords "Resolves" or "Refs".
Resolves #1234
Refs #4321
Refs NOAA-EMC/repo#5678
-->

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmsnowDA <!-- JEDI snow cycled DA !-->
- [ ] C96_gcafs_cycled <!-- JEDI aerosol cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [ ] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
