### PR TITLE
Fix Jinja if-statement for snowanl

### DIFF
--- a/parm/snow/snow_det_config.yaml.j2
+++ b/parm/snow/snow_det_config.yaml.j2
@@ -56,7 +56,7 @@ data_out:
     copy:
     # Configuration files
     - ['{{ DATA }}/snowanlvar.yaml', '{{ COMOUT_CONF }}/{{ APREFIX }}snowanlvar.yaml']
-{% if cyc == 0 %}
+{% if DO_IMS_SCF %}
     - ['{{ DATA }}/scf_to_ioda.yaml', '{{ COMOUT_CONF }}/{{ APREFIX }}scf_to_ioda.yaml']
 {% endif %}
     


### PR DESCRIPTION
# Description

GFSv17 retrospectives found this bug where if the IMS SCF code does not run due to a missing input observation file, the end of the job will fail when it tries to copy a nonexistent YAML file. This fixes it to be conditional based on if the IMS SCF code is supposed to run, rather than if it is the 00z cycle.

# Companion PRs

None

# Issues

None

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmsnowDA <!-- JEDI snow cycled DA !-->
- [ ] C96_gcafs_cycled <!-- JEDI aerosol cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [ ] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
