### PR TITLE
Change name of executable for anlstat

### DIFF
--- a/parm/anlstat/anlstat_jedi_config.yaml.j2
+++ b/parm/anlstat/anlstat_jedi_config.yaml.j2
@@ -1,27 +1,27 @@
 aero:
   rundir: '{{ DATA }}'
-  exe_src: '{{ EXECgfs }}/gdas_ioda_diag-stats.x'
+  exe_src: '{{ EXECgfs }}/gdas_ioda-stats.x'
   mpi_cmd: '{{ APRUN_ANLSTAT }}'
   # jedi_args: None
   jcb_base_yaml: '{{ PARMgfs }}/gdas/anlstat/aero/jcb-base.yaml.j2'
   jcb_algo: 'anlstat'
 atmos:
   rundir: '{{ DATA }}'
-  exe_src: '{{ EXECgfs }}/gdas_ioda_diag-stats.x'
+  exe_src: '{{ EXECgfs }}/gdas_ioda-stats.x'
   mpi_cmd: '{{ APRUN_ANLSTAT }}'
   # jedi_args: None
   jcb_base_yaml: '{{ PARMgfs }}/gdas/anlstat/atmos/jcb-base.yaml.j2'
   jcb_algo: 'anlstat'
 atmos_gsi:
   rundir: '{{ DATA }}'
-  exe_src: '{{ EXECgfs }}/gdas_ioda_diag-stats.x'
+  exe_src: '{{ EXECgfs }}/gdas_ioda-stats.x'
   mpi_cmd: '{{ APRUN_ANLSTAT }}'
   # jedi_args: None
   jcb_base_yaml: '{{ PARMgfs }}/gdas/anlstat/atmos_gsi/jcb-base.yaml.j2'
   jcb_algo: 'anlstat'
 snow:
   rundir: '{{ DATA }}'
-  exe_src: '{{ EXECgfs }}/gdas_ioda_diag-stats.x'
+  exe_src: '{{ EXECgfs }}/gdas_ioda-stats.x'
   mpi_cmd: '{{ APRUN_ANLSTAT }}'
   # jedi_args: None
   jcb_base_yaml: '{{ PARMgfs }}/gdas/anlstat/snow/jcb-base.yaml.j2'


### PR DESCRIPTION
# Description

I changed the name of the executable in DA-Utils, but didn't change it when it is called. This fixes that.

# Companion PRs

None

# Issues

None

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmsnowDA <!-- JEDI snow cycled DA !-->
- [ ] C96_gcafs_cycled <!-- JEDI aerosol cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [ ] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
