### PR TITLE
Remove the monitored sss from the GFSv17 observation list

### DIFF
--- a/parm/marine/obs/obs_list_gfsv17.yaml.j2
+++ b/parm/marine/obs/obs_list_gfsv17.yaml.j2
@@ -1,8 +1,6 @@
 observations:
-# obsForge
 
 # ADT
-#- rads_adt_all
 - rads_adt_3a
 - rads_adt_3b
 - rads_adt_6a
@@ -12,10 +10,6 @@ observations:
 - rads_adt_sa
 - rads_adt_sw
 
-# SSS
-- sss_smap_l2
-- sss_smos_l2
-
 # SST
 - sst_viirs_n21_l3u
 - sst_viirs_n20_l3u
@@ -23,20 +17,10 @@ observations:
 - sst_avhrrf_ma_l3u
 - sst_avhrrf_mb_l3u
 - sst_avhrrf_mc_l3u
-#- sst_ahi_h08_l3c
-#- sst_abi_g17_l3c
-#- sst_abi_g16_l3c
 
 # Sea Ice
 - icec_amsr2_north
 - icec_amsr2_south
-#- icec_amsu_ma1_l2
-#- icec_atms_n20_l2
-#- icec_atms_n21_l2
-#- icec_atms_npp_l2
-#- icec_viirs_j01_l2
-#- icec_viirs_n21_l2
-#- icec_viirs_npp_l2
 
 # In situ
 - insitu_temp_profile_argo


### PR DESCRIPTION
... Inconvenient but does not affect the results. 
Bye bye `sss`!
- fixes #1949 