### PR TITLE
Add the ioda-stats for the new snow observations

### DIFF
--- a/parm/anlstat/anlstat_base_config.yaml.j2
+++ b/parm/anlstat/anlstat_base_config.yaml.j2
@@ -38,6 +38,12 @@ snow:
   - name: snocvr
     input file: "diag_snocvr_{{ current_cycle | to_YMDH }}.nc"
     output file: "snocvr_{{ current_cycle | to_YMDH }}_output_snow.nc"
+  - name: snomad
+    input file: "diag_snomad_{{ current_cycle | to_YMDH }}.nc"
+    output file: "snomad_{{ current_cycle | to_YMDH }}_output_snow.nc"
+  - name: snocvr_snomad
+    input file: "diag_snocvr_snomad_{{ current_cycle | to_YMDH }}.nc"
+    output file: "snocvr_snomad_{{ current_cycle | to_YMDH }}_output_snow.nc"
   - name: madis_snow
     input file: "diag_madis_snow_{{ current_cycle | to_YMDH }}.nc"
     output file: "madis_snow_{{ current_cycle | to_YMDH }}_output_snow.nc"


### PR DESCRIPTION
# Description

This PR adds the ioda-stats for the new snow observations: snomad and snocvr_snomad

# Companion PRs
https://github.com/NOAA-EMC/jcb-gdas/pull/202

# Issues

Resolves #1965 

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmsnowDA <!-- JEDI snow cycled DA !-->
- [ ] C96_gcafs_cycled <!-- JEDI aerosol cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [ ] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
