### PR TITLE
Change the snow_orog_files_path to use the runtime directory.

### DIFF
--- a/parm/snow/jcb-base.yaml.j2
+++ b/parm/snow/jcb-base.yaml.j2
@@ -55,7 +55,7 @@ snow_npz_anl: {{ npz_ges | default(127, true) }}
 snow_variational_history_prefix: "{{ GPREFIX }}"
 
 snow_fv3jedi_files_path: ./fv3jedi  # Ideally this would be {{DATA}}/fv3jedi but FMS
-snow_orog_files_path: "{{ FIXgfs }}/orog/{{ CASE }}"
+snow_orog_files_path: "{{ DATA }}/bkg"
 snow_orog_prefix: "{{ CASE }}.mx{{ OCNRES }}"
 
 # Background


### PR DESCRIPTION
# Description

This PR updates the `jcb-base.yaml.j2` to use the orog data directly from the runtime directory.

# Issues

Resolves #1978 


# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmsnowDA <!-- JEDI snow cycled DA !-->
- [ ] C96_gcafs_cycled <!-- JEDI aerosol cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [ ] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
