### PR TITLE
Corrects sea salt bin mapping between forward operator and model

### DIFF
--- a/parm/aero/aero_det_inc_vars.yaml
+++ b/parm/aero/aero_det_inc_vars.yaml
@@ -1,1 +1,1 @@
-incvars: ['dust1', 'dust2', 'dust3', 'dust4', 'dust5', 'seas1', 'seas2', 'seas3', 'seas4', 'so4', 'oc1', 'oc2', 'bc1', 'bc2']
+incvars: ['dust1', 'dust2', 'dust3', 'dust4', 'dust5', 'seas2', 'seas3', 'seas4', 'seas5', 'so4', 'oc1', 'oc2', 'bc1', 'bc2']


### PR DESCRIPTION
# Description

This PR corrects sea salt bin mapping between CRTM forward operator and model. DA increments should be applied to sea-salt bins 2–5 instead of bins 1–4. This PR updates the increment variable names accordingly.

# Companion PRs

https://github.com/NOAA-EMC/jcb-gdas/pull/211


# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] C96_gcafs_cycled <!-- JEDI aerosol cycled DA !-->
