### PR TITLE
update path to g-w jobs for test_gdasapp_atm_jjob

### DIFF
--- a/test/atm/global-workflow/jjob_ens_final.sh
+++ b/test/atm/global-workflow/jjob_ens_final.sh
@@ -57,7 +57,7 @@ nodes: 1
 ntasks_per_node: 1
 threads_per_task: 1
 memory: ${memory}
-command: ${HOMEgfs}/jobs/JGLOBAL_ATMENS_ANALYSIS_FINALIZE
+command: ${HOMEgfs}/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_FINALIZE
 filename: submit_${type}.sh
 EOF
 
@@ -71,5 +71,5 @@ if [[ $SCHEDULER = 'slurm' ]]; then
 elif [[ $SCHEDULER = 'pbspro' ]]; then
     qsub -V -W block=true submit_${type}.sh
 else
-    ${HOMEgfs}/jobs/JGLOBAL_ATMENS_ANALYSIS_FINALIZE
+    ${HOMEgfs}/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_FINALIZE
 fi

--- a/test/atm/global-workflow/jjob_ens_inc.sh
+++ b/test/atm/global-workflow/jjob_ens_inc.sh
@@ -57,7 +57,7 @@ nodes: 1
 ntasks_per_node: 6
 threads_per_task: 1
 memory: ${memory}
-command: ${HOMEgfs}/jobs/JGLOBAL_ATMENS_ANALYSIS_FV3_INCREMENT
+command: ${HOMEgfs}/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_FV3_INCREMENT
 filename: submit_${type}.sh
 EOF
 
@@ -71,5 +71,5 @@ if [[ $SCHEDULER = 'slurm' ]]; then
 elif [[ $SCHEDULER = 'pbspro' ]]; then
     qsub -V -W block=true submit_${type}.sh
 else
-    ${HOMEgfs}/jobs/JGLOBAL_ATMENS_ANALYSIS_FV3_INCREMENT
+    ${HOMEgfs}/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_FV3_INCREMENT
 fi

--- a/test/atm/global-workflow/jjob_ens_init.sh
+++ b/test/atm/global-workflow/jjob_ens_init.sh
@@ -121,7 +121,7 @@ nodes: 1
 ntasks_per_node: 1
 threads_per_task: 1
 memory: ${memory}
-command: ${HOMEgfs}/jobs/JGLOBAL_ATMENS_ANALYSIS_INITIALIZE
+command: ${HOMEgfs}/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_INITIALIZE
 filename: submit_${type}.sh
 EOF
 
@@ -135,5 +135,5 @@ if [[ $SCHEDULER = 'slurm' ]]; then
 elif [[ $SCHEDULER = 'pbspro' ]]; then
     qsub -V -W block=true submit_${type}.sh
 else
-    ${HOMEgfs}/jobs/JGLOBAL_ATM_ANALYSIS_INITIALIZE
+    ${HOMEgfs}/dev/jobs/JGLOBAL_ATM_ANALYSIS_INITIALIZE
 fi

--- a/test/atm/global-workflow/jjob_ens_init_split.sh
+++ b/test/atm/global-workflow/jjob_ens_init_split.sh
@@ -124,7 +124,7 @@ nodes: 1
 ntasks_per_node: 1
 threads_per_task: 1
 memory: ${memory}
-command: ${HOMEgfs}/jobs/JGLOBAL_ATMENS_ANALYSIS_INITIALIZE
+command: ${HOMEgfs}/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_INITIALIZE
 filename: submit_${type}.sh
 EOF
 
@@ -138,5 +138,5 @@ if [[ $SCHEDULER = 'slurm' ]]; then
 elif [[ $SCHEDULER = 'pbspro' ]]; then
     qsub -V -W block=true submit_${type}.sh
 else
-    ${HOMEgfs}/jobs/JGLOBAL_ATM_ANALYSIS_INITIALIZE
+    ${HOMEgfs}/dev/jobs/JGLOBAL_ATM_ANALYSIS_INITIALIZE
 fi

--- a/test/atm/global-workflow/jjob_ens_letkf.sh
+++ b/test/atm/global-workflow/jjob_ens_letkf.sh
@@ -62,7 +62,7 @@ nodes: 1
 ntasks_per_node: 6
 threads_per_task: 1
 memory: ${memory}
-command: ${HOMEgfs}/jobs/JGLOBAL_ATMENS_ANALYSIS_LETKF
+command: ${HOMEgfs}/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_LETKF
 filename: submit_${type}.sh
 EOF
 
@@ -76,5 +76,6 @@ if [[ $SCHEDULER = 'slurm' ]]; then
 elif [[ $SCHEDULER = 'pbspro' ]]; then
     qsub -V -W block=true submit_${type}.sh
 else
-    ${HOMEgfs}/jobs/JGLOBAL_ATMENS_ANALYSIS_LETKF
+
+    ${HOMEgfs}/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_LETKF
 fi

--- a/test/atm/global-workflow/jjob_ens_obs.sh
+++ b/test/atm/global-workflow/jjob_ens_obs.sh
@@ -62,7 +62,7 @@ nodes: 1
 ntasks_per_node: 6
 threads_per_task: 1
 memory: ${memory}
-command: ${HOMEgfs}/jobs/JGLOBAL_ATMENS_ANALYSIS_OBS
+command: ${HOMEgfs}/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_OBS
 filename: submit_${type}.sh
 EOF
 
@@ -76,5 +76,5 @@ if [[ $SCHEDULER = 'slurm' ]]; then
 elif [[ $SCHEDULER = 'pbspro' ]]; then
     qsub -V -W block=true submit_${type}.sh
 else
-    ${HOMEgfs}/jobs/JGLOBAL_ATMENS_ANALYSIS_OBS
+    ${HOMEgfs}/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_OBS
 fi

--- a/test/atm/global-workflow/jjob_ens_sol.sh
+++ b/test/atm/global-workflow/jjob_ens_sol.sh
@@ -62,7 +62,7 @@ nodes: 1
 ntasks_per_node: 6
 threads_per_task: 1
 memory: ${memory}
-command: ${HOMEgfs}/jobs/JGLOBAL_ATMENS_ANALYSIS_SOL
+command: ${HOMEgfs}/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_SOL
 filename: submit_${type}.sh
 EOF
 
@@ -76,5 +76,5 @@ if [[ $SCHEDULER = 'slurm' ]]; then
 elif [[ $SCHEDULER = 'pbspro' ]]; then
     qsub -V -W block=true submit_${type}.sh
 else
-    ${HOMEgfs}/jobs/JGLOBAL_ATMENS_ANALYSIS_SOL
+    ${HOMEgfs}/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_SOL
 fi

--- a/test/atm/global-workflow/jjob_var_final.sh
+++ b/test/atm/global-workflow/jjob_var_final.sh
@@ -57,7 +57,7 @@ nodes: 1
 ntasks_per_node: 1
 threads_per_task: 1
 memory: ${memory}
-command: ${HOMEgfs}/jobs/JGLOBAL_ATM_ANALYSIS_FINALIZE
+command: ${HOMEgfs}/dev/jobs/JGLOBAL_ATM_ANALYSIS_FINALIZE
 filename: submit_${type}.sh
 EOF
 
@@ -71,5 +71,5 @@ if [[ $SCHEDULER = 'slurm' ]]; then
 elif [[ $SCHEDULER = 'pbspro' ]]; then
     qsub -V -W block=true submit_${type}.sh
 else
-    ${HOMEgfs}/jobs/JGLOBAL_ATM_ANALYSIS_FINALIZE
+    ${HOMEgfs}/dev/jobs/JGLOBAL_ATM_ANALYSIS_FINALIZE
 fi

--- a/test/atm/global-workflow/jjob_var_inc.sh
+++ b/test/atm/global-workflow/jjob_var_inc.sh
@@ -57,7 +57,7 @@ nodes: 1
 ntasks_per_node: 6
 threads_per_task: 1
 memory: ${memory}
-command: ${HOMEgfs}/jobs/JGLOBAL_ATM_ANALYSIS_FV3_INCREMENT
+command: ${HOMEgfs}/dev/jobs/JGLOBAL_ATM_ANALYSIS_FV3_INCREMENT
 filename: submit_${type}.sh
 EOF
 
@@ -71,5 +71,5 @@ if [[ $SCHEDULER = 'slurm' ]]; then
 elif [[ $SCHEDULER = 'pbspro' ]]; then
     qsub -V -W block=true submit_${type}.sh
 else
-    ${HOMEgfs}/jobs/JGLOBAL_ATM_ANALYSIS_FV3_INCREMENT
+    ${HOMEgfs}/dev/jobs/JGLOBAL_ATM_ANALYSIS_FV3_INCREMENT
 fi

--- a/test/atm/global-workflow/jjob_var_init.sh
+++ b/test/atm/global-workflow/jjob_var_init.sh
@@ -130,7 +130,7 @@ nodes: 1
 ntasks_per_node: 1
 threads_per_task: 1
 memory: ${memory}
-command: ${HOMEgfs}/jobs/JGLOBAL_ATM_ANALYSIS_INITIALIZE
+command: ${HOMEgfs}/dev/jobs/JGLOBAL_ATM_ANALYSIS_INITIALIZE
 filename: submit_${type}.sh
 EOF
 
@@ -144,5 +144,5 @@ if [[ $SCHEDULER = 'slurm' ]]; then
 elif [[ $SCHEDULER = 'pbspro' ]]; then
     qsub -V -W block=true submit_${type}.sh
 else
-    ${HOMEgfs}/jobs/JGLOBAL_ATM_ANALYSIS_INITIALIZE
+    ${HOMEgfs}/dev/jobs/JGLOBAL_ATM_ANALYSIS_INITIALIZE
 fi

--- a/test/atm/global-workflow/jjob_var_run.sh
+++ b/test/atm/global-workflow/jjob_var_run.sh
@@ -60,7 +60,7 @@ nodes: 1
 ntasks_per_node: 6
 threads_per_task: 1
 memory: ${memory}
-command: ${HOMEgfs}/jobs/JGLOBAL_ATM_ANALYSIS_VARIATIONAL
+command: ${HOMEgfs}/dev/jobs/JGLOBAL_ATM_ANALYSIS_VARIATIONAL
 filename: submit_${type}.sh
 EOF
 
@@ -74,5 +74,5 @@ if [[ $SCHEDULER = 'slurm' ]]; then
 elif [[ $SCHEDULER = 'pbspro' ]]; then
     qsub -V -W block=true submit_${type}.sh
 else
-    ${HOMEgfs}/jobs/JGLOBAL_ATM_ANALYSIS_VARIATIONAL
+    ${HOMEgfs}/dev/jobs/JGLOBAL_ATM_ANALYSIS_VARIATIONAL
 fi


### PR DESCRIPTION
# Description

The merger of g-w PR [#4259](https://github.com/NOAA-EMC/global-workflow/pull/4259) into g-w `develop` breaks GDASApp `test_gdasapp_atm_jjob`.  These jobs execute g-w j-jobs.  PR [#4259](https://github.com/NOAA-EMC/global-workflow/pull/4259) moved the j-jobs from `$HOMEgfs/jobs` to `$HOMEgfs/dev/jobs`.  This PR updates the j-job path in the atm_jjob driver scripts.

# Companion PRs
 
None

# Issues

None

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [x] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmsnowDA <!-- JEDI snow cycled DA !-->
- [ ] C96_gcafs_cycled <!-- JEDI aerosol cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [ ] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_ufsgsi_hybatmDA <!-- JEDI atm Var with GSI EnKF cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
