### PR TITLE
GDASApp companion to GW PR #4356

### DIFF
--- a/parm/marine/mom_input.nml.j2
+++ b/parm/marine/mom_input.nml.j2
@@ -1,0 +1,22 @@
+ &MOM_input_nml
+        output_directory = './',
+        input_filename = 'r',
+        restart_input_dir = 'INPUT/',
+        restart_output_dir = 'RESTART/',
+        parameter_filename = 'MOM_input'
+ /
+
+ &diag_manager_nml
+ /
+
+ &fms_io_nml
+      max_files_r=100
+      max_files_w=100
+      checksum_required=.false.
+/
+
+ &fms_nml
+       clock_grain='MODULE'
+       domains_stack_size = {{ mom_domain_stack_size }}
+       clock_flags='SYNC'
+/

--- a/parm/marine/mom_input_anlgeom.nml.j2
+++ b/parm/marine/mom_input_anlgeom.nml.j2
@@ -1,0 +1,20 @@
+ &MOM_input_nml
+        output_directory = './',
+        input_filename = 'r',
+        parameter_filename = './anl_geom/MOM_input'
+ /
+
+ &diag_manager_nml
+ /
+
+ &fms_io_nml
+      max_files_r=100
+      max_files_w=100
+      checksum_required=.false.
+/
+
+ &fms_nml
+       clock_grain='MODULE'
+       domains_stack_size = {{ mom_domain_stack_size }}
+       clock_flags='SYNC'
+/


### PR DESCRIPTION
# Description

This PR adds two J2-templated namelists to `parm/marine` that replace `parm/marine/fms/input.nml.j2`. This allows me to remove a call to the `prep_input_nml()` in GW in https://github.com/NOAA-EMC/global-workflow/pull/4356.

I'm leaving `parm/marine/fms/input.nml.j2` around for now so I can merge this PR without breaking GW before my GW PR merges. All this PR does is add two templates, so it can't break anything.

# Companion PRs

https://github.com/NOAA-EMC/global-workflow/pull/4356

# Issues

https://github.com/NOAA-EMC/global-workflow/issues/4355

# Automated CI tests to run in Global Workflow

N/A - These changes will be tested in full CI suite for GW companion PR.
