### PR TITLE
restore GDASApp compute build

### DIFF
--- a/bundle/CMakeLists.txt
+++ b/bundle/CMakeLists.txt
@@ -128,7 +128,7 @@ if(BUILD_GDASBUNDLE)
 # Install jcb (JEDI Configuration Builder) Python package
   message(STATUS "Installing jcb (JEDI Configuration Builder)")
   execute_process(
-    COMMAND ${Python3_EXECUTABLE} -m pip install --no-deps --prefix ${CMAKE_INSTALL_PREFIX} .
+    COMMAND ${Python3_EXECUTABLE} -m pip install --no-deps --no-build-isolation --prefix ${CMAKE_INSTALL_PREFIX} .
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../sorc/jcb
     RESULT_VARIABLE jcb_install_result
   )


### PR DESCRIPTION
# Description

This PR adds `--no-build-isolation` to `bundle/CMakeLists.txt` so GDASApp can again be built on compute nodes.

# Companion PRs

None

# Issues

Resolves #2016 

# Automated CI tests to run in Global Workflow
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmsnowDA <!-- JEDI snow cycled DA !-->
- [ ] ~~C96_gcafs_cycled~~: _cannot be run until g-w [#4295](https://github.com/NOAA-EMC/global-workflow/issues/4295) is closed_
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [ ] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_ufsgsi_hybatmDA <!-- JEDI atm Var with GSI EnKF cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
