### PR TITLE
add gcdas_prep_emissions dependency to half cycle gcdas_fcst

### DIFF
--- a/test/gw-ci/CMakeLists.txt
+++ b/test/gw-ci/CMakeLists.txt
@@ -75,6 +75,7 @@ function(add_task task_name test_prefix is_full_cycle HALF_CYCLE FULL_CYCLE pslo
       list(APPEND TEST_DEPENDS "${test_prefix}_enkfgdas_fcst_${HALF_CYCLE}")
     elseif("${task_name}" STREQUAL "gcdas_fcst")
       list(APPEND TEST_DEPENDS "${test_prefix}_gcdas_stage_ic_${HALF_CYCLE}")
+      list(APPEND TEST_DEPENDS "${test_prefix}_gcdas_prep_emissions_${HALF_CYCLE}")
     elseif("${task_name}" STREQUAL "gcdas_atmos_prod")
       list(APPEND TEST_DEPENDS "${test_prefix}_gcdas_fcst_${HALF_CYCLE}")
     elseif("${task_name}" STREQUAL "gcdas_aeroanlgenb")
@@ -407,6 +408,7 @@ if (WORKFLOW_TESTS)
     set(YAML_PATH ${HOMEgfs}/dev/ci/cases/pr/${pslot}.yaml)
     set(HALF_CYCLE_TASKS
       "gcdas_stage_ic"
+      "gcdas_prep_emissions"
       "gcdas_fcst"
       "gcdas_atmos_prod"
       "gcdas_aeroanlgenb")


### PR DESCRIPTION
# Description

This PR adds `gcdas_prep_emissions` to the first half cycle dependency list for `gcdas_fcst`. 

# Companion PRs

None

# Issues

Resolves #2020


# Automated CI tests to run in Global Workflow
- [x] atm_jjob <!-- JEDI atm single cycle DA !-->
- [x] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [x] C96C48_hybatmsnowDA <!-- JEDI snow cycled DA !-->
- [x] C96_gcafs_cycled <!-- JEDI aerosol cycled DA !-->
- [x] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [x] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [x] C96C48_ufsgsi_hybatmDA <!-- JEDI atm Var with GSI EnKF cycled DA !-->
- [x] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
