### PR TITLE
Enable to read and process the IMS data in netcdf format

### DIFF
--- a/parm/snow/jcb-base.yaml.j2
+++ b/parm/snow/jcb-base.yaml.j2
@@ -87,6 +87,7 @@ snow_obsdataout_path: "{{DATA}}/diags"
 snow_prepobs_path: "{{DATA}}/prep"
 snow_obsdataout_prefix: diag_
 snow_obsdataout_suffix: "_{{ current_cycle | to_YMDH }}.nc"
+ims_scf_obs_suffix: "{{ ims_scf_obs_suffix }}"
 
 # Naming conventions for bias correction files
 snow_obsbiasin_path: "{{DATA}}/obs/"

--- a/parm/snow/snow_stage_ims_scf2ioda.yaml.j2
+++ b/parm/snow/snow_stage_ims_scf2ioda.yaml.j2
@@ -1,2 +1,2 @@
-- ['{{ ims_file }}', '{{ DATA }}/obs/ims{{ current_cycle | to_julian }}_4km_v1.3.dat']
+- ['{{ ims_file }}', '{{ DATA }}/obs/ims{{ current_cycle | to_julian }}_4km_v1.3.{{ ims_scf_obs_suffix }}']
 - ['{{ FIXgfs }}/gdas/obs/ims/IMS_4km_to_{{ CASE }}.mx{{ OCNRES }}.nc', '{{ DATA }}/obs/IMS4km_to_FV3_mapping.{{ CASE }}.mx{{ OCNRES }}_oro_data.nc']

--- a/parm/snow/snow_stage_ims_scf2ioda.yaml.j2
+++ b/parm/snow/snow_stage_ims_scf2ioda.yaml.j2
@@ -1,2 +1,2 @@
-- ['{{ ims_file }}', '{{ DATA }}/obs/ims{{ current_cycle | to_julian }}_4km_v1.3.asc']
+- ['{{ ims_file }}', '{{ DATA }}/obs/ims{{ current_cycle | to_julian }}_4km_v1.3.dat']
 - ['{{ FIXgfs }}/gdas/obs/ims/IMS_4km_to_{{ CASE }}.mx{{ OCNRES }}.nc', '{{ DATA }}/obs/IMS4km_to_FV3_mapping.{{ CASE }}.mx{{ OCNRES }}_oro_data.nc']

--- a/utils/land/gdas_fv3jedi_calc_scf_to_ioda.cc
+++ b/utils/land/gdas_fv3jedi_calc_scf_to_ioda.cc
@@ -393,9 +393,51 @@ void gdasapp::CalcSCFtoIODA::IMSscf::readIMS() {
     if (ncfile.isNull() == false) {
       isNetCDF = true;
       oops::Log::info() << "Opened IMS file as netCDF: " << imspath_ << std::endl;
-      // TODO(CoryMartin-NOAA) ... process netCDF file here ...
+
+      // define and get dimensions
+      netCDF::NcDim xDim = ncfile.getDim("x");
+      netCDF::NcDim yDim = ncfile.getDim("y");
+      netCDF::NcDim tDim = ncfile.getDim("time");
+
+      size_t nx = xDim.getSize();
+      size_t ny = yDim.getSize();
+      size_t nt = tDim.getSize();
+
+      oops::Log::info() << "IMS dimensions: "
+                        << nx << " x " << ny
+                        << " time=" << nt << std::endl;
+
+      // Get IMS variable
+      netCDF::NcVar imsVar = ncfile.getVar("IMS_Surface_Values");
+      if (imsVar.isNull()) {
+        throw eckit::UserError("IMS_Surface_Values variable not found", Here());
+      }
+
+      // Allocate storage
+      this->IMS_flag.resize(ny, std::vector<int>(nx));
+      this->IMS_index.resize(ny,
+          std::vector<std::vector<int>>(nx, std::vector<int>(3)));
+
+      // IMS_Surface_Values is: byte(time, y, x)
+      std::vector<unsigned char> buffer(nx * ny);
+
+      // Read only time index 0
+      std::vector<size_t> start = {0, 0, 0};
+      std::vector<size_t> count = {1, ny, nx};
+
+      imsVar.getVar(start, count, buffer.data());
+
+      // Copy into IMS_flag (row-major: y, x)
+      for (size_t j = 0; j < ny; ++j) {
+        for (size_t i = 0; i < nx; ++i) {
+          this->IMS_flag[j][i] = static_cast<int>(buffer[j * nx + i]);
+        }
+      }
+
+      oops::Log::info() << "IMS NetCDF data successfully read" << std::endl;
     }
-  } catch (...) {
+    ncfile.close();
+  } catch (netCDF::exceptions::NcException &e) {
     oops::Log::info() << "Failed to open as netCDF, will try ASCII: " << imspath_ << std::endl;
   }
 

--- a/utils/land/gdas_fv3jedi_calc_scf_to_ioda.cc
+++ b/utils/land/gdas_fv3jedi_calc_scf_to_ioda.cc
@@ -399,6 +399,16 @@ void gdasapp::CalcSCFtoIODA::IMSscf::readIMS() {
       netCDF::NcDim yDim = ncfile.getDim("y");
       netCDF::NcDim tDim = ncfile.getDim("time");
 
+      if (xDim.isNull()) {
+        throw eckit::UserError("Dimension 'x' not found in IMS netCDF file: " + imspath_, Here());
+      }
+      if (yDim.isNull()) {
+        throw eckit::UserError("Dimension 'y' not found in IMS netCDF file: " + imspath_, Here());
+      }
+      if (tDim.isNull()) {
+        throw eckit::UserError("Dimension 'time' not found in IMS netCDF file: " + imspath_, Here());
+      }
+
       size_t nx = xDim.getSize();
       size_t ny = yDim.getSize();
       size_t nt = tDim.getSize();


### PR DESCRIPTION
# Description

The current C++ IMS preprocessing code supports only ASCII-format input files. This PR adds support for netCDF input files to meet the requirements of reanalysis projects.

Contributes to https://github.com/NOAA-EMC/global-workflow/pull/4387

# Companion PRs
https://github.com/NOAA-EMC/jcb-gdas/pull/221

# Issues

Resolves #2022 

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmsnowDA <!-- JEDI snow cycled DA !-->
- [ ] C96_gcafs_cycled <!-- JEDI aerosol cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [ ] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_ufsgsi_hybatmDA <!-- JEDI atm Var with GSI EnKF cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
