### PR TITLE
Remove land-imsproc from repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -41,10 +41,6 @@
   path = sorc/soca
   url = https://github.com/NOAA-EMC/soca.git
   branch = dev/emc
-[submodule "sorc/land-imsproc"]
-  path = sorc/land-imsproc
-  url = https://github.com/NOAA-EMC/land-SCF_proc.git
-  branch = develop
 [submodule "sorc/land-jediincr"]
   path = sorc/land-jediincr
   url = https://github.com/NOAA-EMC/land-apply_jedi_incr.git

--- a/bundle/CMakeLists.txt
+++ b/bundle/CMakeLists.txt
@@ -119,7 +119,6 @@ if(BUILD_GDASBUNDLE)
   endif()
 
 # Land associated repositories
-  ecbuild_bundle( PROJECT land-imsproc SOURCE "../sorc/land-imsproc" )
   ecbuild_bundle( PROJECT land-jediincr SOURCE "../sorc/land-jediincr" )
 
 # GDASApp


### PR DESCRIPTION
# Description

This PR will remove the land-imsproc submodule from GDASApp as this functionality has been replaced by C++ OOPS based code

# Companion PRs

None

# Issues

None

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmsnowDA <!-- JEDI snow cycled DA !-->
- [ ] C96_gcafs_cycled <!-- JEDI aerosol cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [ ] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_ufsgsi_hybatmDA <!-- JEDI atm Var with GSI EnKF cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
