### PR TITLE
Update da-utils commit hash and address the co-pilot comments

### DIFF
--- a/ush/snow/ghcn_snod2ioda.py
+++ b/ush/snow/ghcn_snod2ioda.py
@@ -26,12 +26,6 @@ locationKeyList = [
     ("dateTime", "long"),
 ]
 
-AttrData = {
-}
-
-DimDict = {
-}
-
 VarDims = {
     'totalSnowDepth': ['Location'],
 }
@@ -49,7 +43,7 @@ def get_epoch_time(adatetime):
     return time_offset
 
 
-class ghcn(object):
+class GHCNConverter(object):
 
     def __init__(self, filename, fixfile, date, warn):
         self.filename = filename
@@ -60,6 +54,8 @@ class ghcn(object):
         self.metaDict = defaultdict(lambda: defaultdict(dict))
         self.outdata = defaultdict(lambda: DefaultOrderedDict(OrderedDict))
         self.varAttrs = defaultdict(lambda: DefaultOrderedDict(OrderedDict))
+        self.AttrData = {}
+        self.DimDict = {}
         self._read()
 
     def _read(self):
@@ -112,7 +108,7 @@ class ghcn(object):
         df300 = pd.merge(df30, df10[['ID', 'LATITUDE', 'LONGITUDE', 'ELEVATION']], on='ID', how='left')
 
         # if merge (left) cannot find ID in df10, will insert NaN
-        if (any(df300['LATITUDE'].isna())):
+        if any(df300['LATITUDE'].isna()):
             if (self.warn):
                 print(f"\n WARNING: ignoring ghcn stations missing from station_list")
             else:
@@ -154,7 +150,7 @@ class ghcn(object):
         self.outdata[self.varDict[iodavar]['errKey']] = errs
         self.outdata[self.varDict[iodavar]['qcKey']] = qflg
 
-        DimDict['Location'] = len(self.outdata[('dateTime', 'MetaData')])
+        self.DimDict['Location'] = len(self.outdata[('dateTime', 'MetaData')])
 
 
 def main():
@@ -185,16 +181,16 @@ def main():
     tic = record_time()
 
     # Read in the GHCN snow depth data
-    snod = ghcn(args.input, args.fixfile, args.date, args.warn_on_missing_stn)
+    snod = GHCNConverter(args.input, args.fixfile, args.date, args.warn_on_missing_stn)
 
-    # report time
-    toc = record_time(tic=tic)
+    writer = iconv.IodaWriter(args.output, locationKeyList, snod.DimDict)
 
-    # setup the IODA writer
-    writer = iconv.IodaWriter(args.output, locationKeyList, DimDict)
-
-    # write all data out
-    writer.BuildIoda(snod.outdata, VarDims, snod.varAttrs, AttrData)
+    writer.BuildIoda(
+        snod.outdata,
+        VarDims,
+        snod.varAttrs,
+        snod.AttrData
+    )
 
     # report time
     toc = record_time(tic=tic)


### PR DESCRIPTION
# Description

This PR updates the `da-utils` commit hash to include the required utilities.

This PR also addresses Copilot comments in `ghcn_snod2ioda.py`. In particular, it fixes the use of AttrData and DimDict as mutable module-level dictionaries, which is error-prone—especially since DimDict is modified within the class. These structures are now handled in a safer, more maintainable way.

This PR is a supplementary update to PR #2019 and contributes to https://github.com/NOAA-EMC/global-workflow/pull/4386

# Issues

Resolves #2018 

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmsnowDA <!-- JEDI snow cycled DA !-->
- [ ] C96_gcafs_cycled <!-- JEDI aerosol cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [ ] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_ufsgsi_hybatmDA <!-- JEDI atm Var with GSI EnKF cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
