### PR TITLE
Weekly update of JEDI hashes (20260105)

### DIFF
--- a/ci/driver.sh
+++ b/ci/driver.sh
@@ -50,14 +50,14 @@ case ${TARGET} in
     module list
     ;;
   gaeac6)
-      source $my_dir/${TARGET}.sh
-      if ( ! eval module help > /dev/null 2>&1 ) ; then
-          source /etc/profile
-      fi
-      module reset
-      module use $GDAS_MODULE_USE
-      module load GDAS/$TARGET
-      module list
+    source $my_dir/${TARGET}.sh
+    if ( ! eval module help > /dev/null 2>&1 ) ; then
+        source /etc/profile
+    fi
+    module reset
+    module use $GDAS_MODULE_USE
+    module load GDAS/$TARGET
+    module list
     ;;
   *)
     echo "Unsupported platform. Exiting with error."

--- a/ci/run_ci.sh
+++ b/ci/run_ci.sh
@@ -47,7 +47,8 @@ if [[ $TEST_WORKFLOW == 1 ]]; then
     gdasapp_dir=$workflow_dir/sorc/gdas.cd
 
     build_cmd_dir=$workflow_dir/sorc
-    build_cmd="./build_all.sh gfs gcafs gsi gdas"
+    sed -i 's/\(WORKFLOW_TESTS=.*:-"\)OFF\("\)/\1ON\2/' ${build_cmd_dir}/build_gdas.sh
+    build_cmd="./build_compute.sh -A ${SLURM_ACCOUNT} gfs gcafs gsi gdas"
     build_dir=$workflow_dir/build
 else
     export BUILD_JOBS=8
@@ -75,10 +76,10 @@ echo "---------------------------------------------------" >> $outfile
 cd $build_cmd_dir
 if [[ "${TARGET}" == "gaeac6" ]]; then
     if ( ! eval module help > /dev/null 2>&1 ) ; then
-	source /etc/profile
+        source /etc/profile
     fi
     module reset
-else    
+else
     module purge
 fi
 rm -rf log.build


### PR DESCRIPTION
# Description

This PR includes two sets of changes:
- weekly update of select JEDI hashes
- update `ci/run_ci.sh` to build on compute nodes when `TEST_WORKFLOW=1`

# Companion PRs

None

# Issues

None

# Automated CI tests to run in Global Workflow
- [x] atm_jjob <!-- JEDI atm single cycle DA !-->
- [x] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [x] C96C48_hybatmsnowDA <!-- JEDI snow cycled DA !-->
- [x] C96_gcafs_cycled <!-- JEDI aerosol cycled DA !-->
- [x] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [x] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [x] C96C48_ufsgsi_hybatmDA <!-- JEDI atm Var with GSI EnKF cycled DA !-->
- [x] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
