### PR TITLE
Use new naming convention for some obs in G-W CI test

### DIFF
--- a/parm/atm/jcb-base.yaml.j2
+++ b/parm/atm/jcb-base.yaml.j2
@@ -113,15 +113,15 @@ atmosphere_obsbiascovout_prefix: "{{APREFIX}}"
 atmosphere_obsbiascovout_suffix: ".satbias_cov.nc"
 
 bias_files_dict:
-    atms_n20: rad_varbc_params.tar
-    atms_npp: rad_varbc_params.tar
-    mtiasi_metop-a: rad_varbc_params.tar
-    mtiasi_metop-b: rad_varbc_params.tar
-    amsua_n19: rad_varbc_params.tar
-    ssmis_f17: rad_varbc_params.tar
-    ssmis_f18: rad_varbc_params.tar
-    cris-fsr_n20: rad_varbc_params.tar
-    cris-fsr_npp: rad_varbc_params.tar
+    radiance_atms_n20: rad_varbc_params.tar
+    radiance_atms_npp: rad_varbc_params.tar
+    radiance_mtiasi_metop-a: rad_varbc_params.tar
+    radiance_mtiasi_metop-b: rad_varbc_params.tar
+    radiance_amsua_n19: rad_varbc_params.tar
+    radiance_ssmis_f17: rad_varbc_params.tar
+    radiance_ssmis_f18: rad_varbc_params.tar
+    radiance_cris-fsr_n20: rad_varbc_params.tar
+    radiance_cris-fsr_npp: rad_varbc_params.tar
 
 # Local Ensemble DA (LETKF)
 # -------------------------

--- a/test/atm/global-workflow/atm_obs_list.yaml.j2
+++ b/test/atm/global-workflow/atm_obs_list.yaml.j2
@@ -1,3 +1,3 @@
 observations:
-- amsua_n19
+- radiance_amsua_n19
 - sondes

--- a/test/atm/global-workflow/jjob_ens_init.sh
+++ b/test/atm/global-workflow/jjob_ens_init.sh
@@ -64,7 +64,7 @@ RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
 # Link observations
 dpath=gdas.$PDY/$cyc/obs
 mkdir -p $COMIN_OBS/atmos
-flist="amsua_n19 sondes"
+flist="radiance_amsua_n19 sondes"
 for file in $flist; do
    ln -fs $GDASAPP_TESTDATA/lowres/$dpath/${oprefix}.${file}.${PDY}${cyc}.nc $COMIN_OBS/atmos/${oprefix}.${file}.nc
 done

--- a/test/atm/global-workflow/jjob_ens_init_split.sh
+++ b/test/atm/global-workflow/jjob_ens_init_split.sh
@@ -64,7 +64,7 @@ RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
 # Link observations
 dpath=gdas.$PDY/$cyc/obs
 mkdir -p $COMIN_OBS/atmos
-flist="amsua_n19 sondes"
+flist="radiance_amsua_n19 sondes"
 for file in $flist; do
    ln -fs $GDASAPP_TESTDATA/lowres/$dpath/${oprefix}.${file}.${PDY}${cyc}.nc $COMIN_OBS/atmos/${oprefix}.${file}.nc
 done
@@ -72,11 +72,11 @@ done
 # Link radiance bias correction files
 dpath=gdas.$gPDY/$gcyc/analysis/atmos
 mkdir -p $COMIN_ATMOS_ANALYSIS_PREV
-flist="amsua_n19.satbias amsua_n19.satbias_cov"
+flist="radiance_amsua_n19.satbias radiance_amsua_n19.satbias_cov"
 for file in $flist; do
    ln -fs $GDASAPP_TESTDATA/lowres/$dpath/$gprefix.${file}.nc $COMIN_ATMOS_ANALYSIS_PREV/$gprefix.${file}.nc
 done
-flist="amsua_n19.tlapse.txt"
+flist="radiance_amsua_n19.tlapse.txt"
 for file in $flist; do
    ln -fs $GDASAPP_TESTDATA/lowres/$dpath/$gprefix.$file $COMIN_ATMOS_ANALYSIS_PREV/$gprefix.$file
 done

--- a/test/atm/global-workflow/jjob_var_init.sh
+++ b/test/atm/global-workflow/jjob_var_init.sh
@@ -65,7 +65,7 @@ RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
 # Link observations
 dpath=gdas.$PDY/$cyc/obs
 mkdir -p $COMIN_OBS/atmos
-flist="amsua_n19 sondes"
+flist="radiance_amsua_n19 sondes"
 for file in $flist; do
    ln -fs $GDASAPP_TESTDATA/lowres/$dpath/${oprefix}.${file}.${PDY}${cyc}.nc $COMIN_OBS/atmos/${oprefix}.${file}.nc
 done

--- a/test/gw-ci/atm/atm_obs_list_ufs_hybatmDA.yaml.j2
+++ b/test/gw-ci/atm/atm_obs_list_ufs_hybatmDA.yaml.j2
@@ -1,8 +1,8 @@
 observations:
-- scatwnd.ascat_metop-b
-- atms_n20
+- retrieval_osw_ascat_metop-b
+- radiance_atms_n20
 - conventional_ps
 - gnssro_cosmic2
-- ozone.ompsnp_npp
-- ozone.ompstc_npp
-- satwnd.abi_goes-16
+- retrieval_ozone_ompsnp_npp
+- retrieval_ozone_ompstc_npp
+- retrieval_amv_abi_goes-16

--- a/ush/gsi_satbias2ioda_all.sh
+++ b/ush/gsi_satbias2ioda_all.sh
@@ -60,9 +60,9 @@ for instrument in $(echo $obsclass); do
     /bin/rm -f  testrun/varbc/*txt
     cd ./testrun/varbc/
     grep ${instrument}  ../../satbias_in  | awk '{print $2" "$3" "$4}' > \
-          ${locdir}/gdas.t${gcyc}z.${instrument}.tlapse.txt
-    /bin/cp -p satbias_${instrument}.nc4  ${locdir}/gdas.t${gcyc}z.${instrument}.satbias.nc
-    /bin/mv  satbias_${instrument}.nc4  ${locdir}/gdas.t${gcyc}z.${instrument}.satbias_cov.nc
+          ${locdir}/gdas.t${gcyc}z.radiance_${instrument}.tlapse.txt
+    /bin/cp -p satbias_${instrument}.nc4  ${locdir}/gdas.t${gcyc}z.radiance_${instrument}.satbias.nc
+    /bin/mv  satbias_${instrument}.nc4  ${locdir}/gdas.t${gcyc}z.radiance_${instrument}.satbias_cov.nc
     
     cd  ${locdir}
     /bin/rm -f satbias_converter.yaml


### PR DESCRIPTION
# Description

This PR switches to using the new observation naming conventions where appropriate for the G-W CI test for atmospheric JEDI DA.

# Companion PRs
https://github.com/NOAA-EMC/jcb-gdas/pull/207

# Issues

N/A right now, partially resolves https://github.com/NOAA-EMC/jcb-gdas/issues/224

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [x] atm_jjob <!-- JEDI atm single cycle DA !-->
- [x] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmsnowDA <!-- JEDI snow cycled DA !-->
- [ ] C96_gcafs_cycled <!-- JEDI aerosol cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [ ] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_ufsgsi_hybatmDA <!-- JEDI atm Var with GSI EnKF cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
