### PR TITLE
add to jcb-base.yaml.j2

### DIFF
--- a/parm/atm/jcb-base.yaml.j2
+++ b/parm/atm/jcb-base.yaml.j2
@@ -26,8 +26,7 @@ bound_to_include: begin
 minimizer: DRPCG
 final_diagnostics_departures: anlmob
 final_prints_frequency: PT3H
-#number_of_outer_loops: {{ NUMBER_OUTER_LOOPS | default(2, true) }}
-number_of_outer_loops: 1 
+number_of_outer_loops: {{ NUMBER_OUTER_LOOPS | default(2, true) }}
 atmosphere_ninner_1: {{ NINNER_LOOP1 | default(2, true) }}
 atmosphere_grad_red_1: 1e-10
 atmosphere_ninner_2: {{ NINNER_LOOP2 | default(4, true) }}

--- a/parm/atm/jcb-base.yaml.j2
+++ b/parm/atm/jcb-base.yaml.j2
@@ -26,7 +26,8 @@ bound_to_include: begin
 minimizer: DRPCG
 final_diagnostics_departures: anlmob
 final_prints_frequency: PT3H
-number_of_outer_loops: {{ NUMBER_OUTER_LOOPS | default(2, true) }}
+#number_of_outer_loops: {{ NUMBER_OUTER_LOOPS | default(2, true) }}
+number_of_outer_loops: 1 
 atmosphere_ninner_1: {{ NINNER_LOOP1 | default(2, true) }}
 atmosphere_grad_red_1: 1e-10
 atmosphere_ninner_2: {{ NINNER_LOOP2 | default(4, true) }}
@@ -101,6 +102,7 @@ atmosphere_obsdataout_suffix: "_{{ current_cycle | to_YMDH }}.nc"
 atmosphere_obsbiasin_path: "{{DATA}}/obs/"
 atmosphere_obsbiasin_prefix: "{{GPREFIX}}"
 atmosphere_obsbiasin_suffix: ".satbias.nc"
+atmosphere_obsbiasin_acft_suffix: ".acftbias.nc"
 atmosphere_obstlapsein_prefix: "{{GPREFIX}}"
 atmosphere_obstlapsein_suffix: ".tlapse.txt"
 atmosphere_obsbiascovin_prefix: "{{GPREFIX}}"


### PR DESCRIPTION
# Description

Updates jcb-base.yaml.j2

# Companion PRs

Should be added before running the workflow/gdasapp and before the jcb-gdas [PR#228](https://github.com/NOAA-EMC/jcb-gdas/issues/228) and likely at the same time as [UFO#3951](https://github.com/JCSDA-internal/ufo/pull/3951)

# Issues

Fixes issue #2035 

