### PR TITLE
Uncomment line from jcb client testing workflow

### DIFF
--- a/.github/workflows/run_jcb_basic_testing.yaml
+++ b/.github/workflows/run_jcb_basic_testing.yaml
@@ -94,13 +94,12 @@ jobs:
     - name: Create custom jcb_clients.yaml for isolated testing
       run: |
         cd jcb_repo
-        
+
         # Create a custom jcb_clients.yaml that only includes the current repository
         cat > jcb_clients.yaml << EOF
         gdas:
           git_url: noaa-emc/gdasapp
-          #git_ref: develop
-          git_ref: feature/jcb-gdas
+          git_ref: develop
           app_subdir: parm/jcb-gdas
         EOF
 


### PR DESCRIPTION
# Description

I forgot to uncomment a line in the JCB-GDAS client testing GitHub Workflow when I was testing https://github.com/NOAA-EMC/GDASApp/pull/2038 . This uncomments that line.

# Companion PRs

<!-- Enter links to any companion PRs here. -->

# Issues

<!-- Enter any issues referenced or resolved by this PR here. Use keywords "Resolves" or "Refs".
Resolves #1234
Refs #4321
Refs NOAA-EMC/repo#5678
-->

# Automated CI tests to run in Global Workflow
JCB-GDAS client testing workflow
