### PR TITLE
Create DATA/obs from snow config

### DIFF
--- a/parm/snow/snow_det_config.yaml.j2
+++ b/parm/snow/snow_det_config.yaml.j2
@@ -18,6 +18,7 @@ data_in:
     mkdir:
     - '{{ DATA }}/bkg'
     - '{{ DATA }}/anl'
+    - '{{ DATA }}/obs'
     - '{{ DATA }}/fv3jedi'
     - '{{ DATA }}/berror'
 

--- a/parm/snow/snow_ens_config.yaml.j2
+++ b/parm/snow/snow_ens_config.yaml.j2
@@ -25,6 +25,7 @@ data_in:
     mkdir:
     - '{{ DATA }}/bkg'
     - '{{ DATA }}/anl'
+    - '{{ DATA }}/obs'
     - '{{ DATA }}/bkg/ensmean'
     - '{{ DATA }}/anl/ensmean'
 {% for mem in range(1, NMEM_ENS + 1) %}


### PR DESCRIPTION
# Description

While assimilating only GHCN and SOMAD obs, parm/snow/snow_stage_bufr2ioda_mapping.yaml.j2 failed because {{ DATA }}/obs was not created (The error doesn't appear if IMS Prep is called earlier). Add the mkdir to snow config to be safe. Or should we remove line 44 {% include 'snow_stage_bufr2ioda_mapping.yaml.j2' %} from snow det config?

# Issues
Resolves #2040 

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmsnowDA <!-- JEDI snow cycled DA !-->
- [ ] C96_gcafs_cycled <!-- JEDI aerosol cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [ ] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_ufsgsi_hybatmDA <!-- JEDI atm Var with GSI EnKF cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
