### PR TITLE
Fix gdas_marinebmat crash from FMS max_files_r limit (#2006)

### DIFF
--- a/parm/marine/fms/input.nml
+++ b/parm/marine/fms/input.nml
@@ -18,6 +18,7 @@
             calendar = 'NOLEAP' /
 
  &fms_io_nml
+      max_files_r=100
       max_files_w=100
       checksum_required=.false.
 /

--- a/parm/marine/fms/input.nml.j2
+++ b/parm/marine/fms/input.nml.j2
@@ -12,6 +12,7 @@
  /
 
  &fms_io_nml
+      max_files_r=100
       max_files_w=100
       checksum_required=.false.
 /


### PR DESCRIPTION
# Description

The FMS I/O layer reached the maximum allowed number of simultaneously open files and aborted the run.

# Companion PRs

None

# Issues

During the **marinebmat** workflow on WCOSS2, the `gdas_marinebmat` task failed with an FMS I/O error on compute node:

- `nid004062.cactus.wcoss2.ncep.noaa.gov` (PE 63)

The error message was:

```text
FATAL from PE 63: fms_io(get_file_unit): max_files_r exceeded, increase it via fms_io_nml
```

Resolves #1996 

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmsnowDA <!-- JEDI snow cycled DA !-->
- [ ] C96_gcafs_cycled <!-- JEDI aerosol cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA !-->
- [x] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_ufsgsi_hybatmDA <!-- JEDI atm Var with GSI EnKF cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->

# Description

<!-- Enter PR description here. -->

# Companion PRs

<!-- Enter links to any companion PRs here. -->

# Issues

<!-- Enter any issues referenced or resolved by this PR here. Use keywords "Resolves" or "Refs".
Resolves #1234
Refs #4321
Refs NOAA-EMC/repo#5678
-->

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmsnowDA <!-- JEDI snow cycled DA !-->
- [ ] C96_gcafs_cycled <!-- JEDI aerosol cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [ ] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_ufsgsi_hybatmDA <!-- JEDI atm Var with GSI EnKF cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
