### PR TITLE
remove csg_ from atmospheric  ensemble analysis increment filename

### DIFF
--- a/parm/atm/atm_ecen_config.yaml.j2
+++ b/parm/atm/atm_ecen_config.yaml.j2
@@ -37,7 +37,7 @@ data_in:
                          '${YMD}': current_cycle | to_YMD,
                          '${HH}': current_cycle | strftime('%H'),
                          '${MEMDIR}': 'mem%03d' | format(imem) }) %}
-    - ['{{ COM_ATMOS_ANALYSIS_TMPL | replace_tmpl(tmpl_dict) }}/{{ APREFIX_ENS }}csg_jedi_increment.atm.i{{ '%03d' % fh }}.nc', '{{ DATA }}/{{ 'mem%03d' | format(imem) }}/{{ APREFIX_ENS }}cubed_sphere_grid_atmi{{ '%03d' % fh }}.nc']
+    - ['{{ COM_ATMOS_ANALYSIS_TMPL | replace_tmpl(tmpl_dict) }}/{{ APREFIX_ENS }}jedi_increment.atm.i{{ '%03d' % fh }}.nc', '{{ DATA }}/{{ 'mem%03d' | format(imem) }}/{{ APREFIX_ENS }}cubed_sphere_grid_atmi{{ '%03d' % fh }}.nc']
 
 {% endfor %}
 {% endfor %}

--- a/parm/atm/atm_ens_config.yaml.j2
+++ b/parm/atm/atm_ens_config.yaml.j2
@@ -77,9 +77,9 @@ data_out:
                          '${MEMDIR}': 'mem%03d' | format(imem) }) %}
 {% if DOENKFONLY_ATM | default(false) %}
     {% for itile in range(1, ntiles + 1) %}
-    - ['{{ DATA }}/anl/{{ 'mem%03d' | format(imem) }}/{{ APREFIX_ENS }}cubed_sphere_grid_atminc.tile{{ itile }}.nc', '{{ COM_ATMOS_ANALYSIS_TMPL | replace_tmpl(tmpl_dict) }}/{{ APREFIX_ENS }}csg_jedi_increment.atm.i006.tile{{ itile }}.nc']
+    - ['{{ DATA }}/anl/{{ 'mem%03d' | format(imem) }}/{{ APREFIX_ENS }}cubed_sphere_grid_atminc.tile{{ itile }}.nc', '{{ COM_ATMOS_ANALYSIS_TMPL | replace_tmpl(tmpl_dict) }}/{{ APREFIX_ENS }}jedi_increment.atm.i006.tile{{ itile }}.nc']
    {% endfor %}
 {% else %}
-    - ['{{ DATA }}/anl/{{ 'mem%03d' | format(imem) }}/{{ APREFIX_ENS }}cubed_sphere_grid_atminc.nc', '{{ COM_ATMOS_ANALYSIS_TMPL | replace_tmpl(tmpl_dict) }}/{{ APREFIX_ENS }}csg_jedi_increment.atm.i006.nc']
+    - ['{{ DATA }}/anl/{{ 'mem%03d' | format(imem) }}/{{ APREFIX_ENS }}cubed_sphere_grid_atminc.nc', '{{ COM_ATMOS_ANALYSIS_TMPL | replace_tmpl(tmpl_dict) }}/{{ APREFIX_ENS }}jedi_increment.atm.i006.nc']
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
# Description

Remove `csg_` prefix from atmospheric ensemble analysis increment files to be consistent with deterministic atmospheric analysis increment naming convention.

# Companion PRs

The changes in this PR are required by g-w PR [#4345](https://github.com/NOAA-EMC/global-workflow/pull/4345).

# Issues

Resolves #2063


# Automated CI tests to run in Global Workflow
- [x] atm_jjob <!-- JEDI atm single cycle DA !-->
- [x] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [x] C96C48_hybatmsnowDA <!-- JEDI snow cycled DA !-->
- [x] C96_gcafs_cycled <!-- JEDI aerosol cycled DA !-->
- [x] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [x] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [x] C96C48_ufsgsi_hybatmDA <!-- JEDI atm Var with GSI EnKF cycled DA !-->
- [x] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
