### PR TITLE
Make varbc file names more generic

### DIFF
--- a/parm/atm/jcb-base.yaml.j2
+++ b/parm/atm/jcb-base.yaml.j2
@@ -98,30 +98,30 @@ atmosphere_obsdataout_suffix: "_{{ current_cycle | to_YMDH }}.nc"
 
 # Naming conventions for bias correction files
 
-atmosphere_obsbiasin_path: "{{DATA}}/obs/"
+atmosphere_obsbiasin_path: "{{DATA}}/bc_in/"
 atmosphere_obsbiasin_prefix: "{{GPREFIX}}"
-atmosphere_obsbiasin_suffix: ".satbias.nc"
+atmosphere_obsbiasin_suffix: ".bias.nc"
 atmosphere_obstlapsein_prefix: "{{GPREFIX}}"
 atmosphere_obstlapsein_suffix: ".tlapse.txt"
 atmosphere_obsbiascovin_prefix: "{{GPREFIX}}"
-atmosphere_obsbiascovin_suffix: ".satbias_cov.nc"
+atmosphere_obsbiascovin_suffix: ".bias_cov.nc"
 
-atmosphere_obsbiasout_path: "{{DATA}}/bc/"
+atmosphere_obsbiasout_path: "{{DATA}}/bc_out/"
 atmosphere_obsbiasout_prefix: "{{APREFIX}}"
-atmosphere_obsbiasout_suffix: ".satbias.nc"
+atmosphere_obsbiasout_suffix: ".bias.nc"
 atmosphere_obsbiascovout_prefix: "{{APREFIX}}"
-atmosphere_obsbiascovout_suffix: ".satbias_cov.nc"
+atmosphere_obsbiascovout_suffix: ".bias_cov.nc"
 
 bias_files_dict:
-    radiance_atms_n20: rad_varbc_params.tar
-    radiance_atms_npp: rad_varbc_params.tar
-    radiance_mtiasi_metop-a: rad_varbc_params.tar
-    radiance_mtiasi_metop-b: rad_varbc_params.tar
-    radiance_amsua_n19: rad_varbc_params.tar
-    radiance_ssmis_f17: rad_varbc_params.tar
-    radiance_ssmis_f18: rad_varbc_params.tar
-    radiance_cris-fsr_n20: rad_varbc_params.tar
-    radiance_cris-fsr_npp: rad_varbc_params.tar
+    radiance_atms_n20: varbc_params.tar
+    radiance_atms_npp: varbc_params.tar
+    radiance_mtiasi_metop-a: varbc_params.tar
+    radiance_mtiasi_metop-b: varbc_params.tar
+    radiance_amsua_n19: varbc_params.tar
+    radiance_ssmis_f17: varbc_params.tar
+    radiance_ssmis_f18: varbc_params.tar
+    radiance_cris-fsr_n20: varbc_params.tar
+    radiance_cris-fsr_npp: varbc_params.tar
 
 # Local Ensemble DA (LETKF)
 # -------------------------

--- a/test/aero/global-workflow/jjob_var_init.sh
+++ b/test/aero/global-workflow/jjob_var_init.sh
@@ -54,11 +54,8 @@ gprefix=$GDUMP.t${gcyc}z
 oprefix=$CDUMP.t${cyc}z
 
 # Generate COM variables from templates
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_OBS:COM_OBS_TMPL
-
-RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
-    COMIN_ATMOS_RESTART_PREV:COM_ATMOS_RESTART_TMPL
+declare -rx COMIN_OBS="${ROTDIR}/${RUN}.${PDY}/${cyc}/obs"
+declare -rx COMIN_ATMOS_RESTART_PREV="${ROTDIR}/${GDUMP}.${gPDY}/${gcyc}/model/atmos/restart"
 
 # Link observations
 dpath=gdas.$PDY/$cyc/obs

--- a/test/atm/global-workflow/jjob_ens_init.sh
+++ b/test/atm/global-workflow/jjob_ens_init.sh
@@ -70,7 +70,7 @@ done
 # Link radiance bias correction tarball
 dpath=gdas.$gPDY/$gcyc/analysis/atmos
 mkdir -p $COMIN_ATMOS_ANALYSIS_PREV
-flist="rad_varbc_params.tar"
+flist="varbc_params.tar"
 for file in $flist; do
    ln -fs $GDASAPP_TESTDATA/lowres/$dpath/$gprefix.${file} $COMIN_ATMOS_ANALYSIS_PREV/$gprefix.${file}
 done

--- a/test/atm/global-workflow/jjob_ens_init.sh
+++ b/test/atm/global-workflow/jjob_ens_init.sh
@@ -72,7 +72,7 @@ done
 # Link radiance bias correction tarball
 dpath=gdas.$gPDY/$gcyc/analysis/atmos
 mkdir -p $COMIN_ATMOS_ANALYSIS_PREV
-flist="rad_varbc_params.tar"
+flist="varbc_params.tar"
 for file in $flist; do
    ln -fs $GDASAPP_TESTDATA/lowres/$dpath/$gprefix.${file} $COMIN_ATMOS_ANALYSIS_PREV/$gprefix.${file}
 done

--- a/test/atm/global-workflow/jjob_ens_init.sh
+++ b/test/atm/global-workflow/jjob_ens_init.sh
@@ -56,10 +56,8 @@ gprefix=$GDUMP.t${gcyc}z
 oprefix=$GDUMP.t${cyc}z
 
 # Generate COM variables from templates
-RUN=${GDUMP} YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_OBS:COM_OBS_TMPL
-RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
-    COMIN_ATMOS_ANALYSIS_PREV:COM_ATMOS_ANALYSIS_TMPL \
+declare -rx COMIN_OBS="${ROTDIR}/${GDUMP}.${PDY}/${cyc}/obs"
+declare -rx COMIN_ATMOS_ANALYSIS_PREV="${ROTDIR}/${GDUMP}.${gPDY}/${gcyc}/analysis/atmos"
 
 # Link observations
 dpath=gdas.$PDY/$cyc/obs
@@ -72,7 +70,7 @@ done
 # Link radiance bias correction tarball
 dpath=gdas.$gPDY/$gcyc/analysis/atmos
 mkdir -p $COMIN_ATMOS_ANALYSIS_PREV
-flist="varbc_params.tar"
+flist="rad_varbc_params.tar"
 for file in $flist; do
    ln -fs $GDASAPP_TESTDATA/lowres/$dpath/$gprefix.${file} $COMIN_ATMOS_ANALYSIS_PREV/$gprefix.${file}
 done
@@ -82,9 +80,9 @@ dpath=enkfgdas.$gPDY/$gcyc
 for imem in $(seq 1 $NMEM_ENS); do
     memchar="mem"$(printf %03i $imem)
 
-    MEMDIR=${memchar} RUN=${RUN} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -x \
-	COMIN_ATMOS_HISTORY_PREV_ENS:COM_ATMOS_HISTORY_TMPL \
-	COMIN_ATMOS_RESTART_PREV_ENS:COM_ATMOS_RESTART_TMPL
+    declare -x COMIN_ATMOS_HISTORY_PREV_ENS="${ROTDIR}/${RUN}.${gPDY}/${gcyc}/${memchar}/model/atmos/history"
+    declare -x COMIN_ATMOS_RESTART_PREV_ENS="${ROTDIR}/${RUN}.${gPDY}/${gcyc}/${memchar}/model/atmos/restart"
+    
     COMIN_ATMOS_RESTART_PREV_DIRNAME_ENS=$(dirname $COMIN_ATMOS_RESTART_PREV_ENS)
 
     source=$GDASAPP_TESTDATA/lowres/$dpath/$memchar/model/atmos/history

--- a/test/atm/global-workflow/jjob_ens_init_split.sh
+++ b/test/atm/global-workflow/jjob_ens_init_split.sh
@@ -56,10 +56,8 @@ gprefix=$GDUMP.t${gcyc}z
 oprefix=$GDUMP.t${cyc}z
 
 # Generate COM variables from templates
-RUN=${GDUMP} YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-   COMIN_OBS:COM_OBS_TMPL
-RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
-   COMIN_ATMOS_ANALYSIS_PREV:COM_ATMOS_ANALYSIS_TMPL \
+declare -rx COMIN_OBS="${ROTDIR}/${GDUMP}.${PDY}/${cyc}/obs"
+declare -rx COMIN_ATMOS_ANALYSIS_PREV="${ROTDIR}/${GDUMP}.${gPDY}/${gcyc}/analysis/atmos"
 
 # Link observations
 dpath=gdas.$PDY/$cyc/obs
@@ -86,8 +84,7 @@ dpath=enkfgdas.$gPDY/$gcyc
 for imem in $(seq 1 $NMEM_ENS); do
     memchar="mem"$(printf %03i $imem)
 
-    MEMDIR=${memchar} RUN=${RUN} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -x \
-	COMIN_ATMOS_HISTORY_PREV_ENS:COM_ATMOS_HISTORY_TMPL
+    declare -x COMIN_ATMOS_HISTORY_PREV_ENS="${ROTDIR}/${RUN}.${gPDY}/${gcyc}/${memchar}/model/atmos/history"    
 
     source=$GDASAPP_TESTDATA/lowres/$dpath/$memchar/model/atmos/history
     target=$COMIN_ATMOS_HISTORY_PREV_ENS

--- a/test/atm/global-workflow/jjob_var_init.sh
+++ b/test/atm/global-workflow/jjob_var_init.sh
@@ -56,11 +56,9 @@ gprefix=$GDUMP.t${gcyc}z
 oprefix=$CDUMP.t${cyc}z
 
 # Generate COM variables from templates
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-   COMIN_OBS:COM_OBS_TMPL
-RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
-    COMIN_ATMOS_ANALYSIS_PREV:COM_ATMOS_ANALYSIS_TMPL \
-    COMIN_ATMOS_HISTORY_PREV:COM_ATMOS_HISTORY_TMPL
+declare -rx COMIN_OBS="${ROTDIR}/${RUN}.${PDY}/${cyc}/obs"
+declare -rx COMIN_ATMOS_ANALYSIS_PREV="${ROTDIR}/${GDUMP}.${gPDY}/${gcyc}/analysis/atmos"
+declare -rx COMIN_ATMOS_HISTORY_PREV="${ROTDIR}/${GDUMP}.${gPDY}/${gcyc}/model/atmos/history"
 
 # Link observations
 dpath=gdas.$PDY/$cyc/obs
@@ -73,7 +71,7 @@ done
 # Link radiance bias correction tarball
 dpath=gdas.$gPDY/$gcyc/analysis/atmos
 mkdir -p $COMIN_ATMOS_ANALYSIS_PREV
-flist="varbc_params.tar"
+flist="rad_varbc_params.tar"
 for file in $flist; do
    ln -fs $GDASAPP_TESTDATA/lowres/$dpath/$gprefix.${file} $COMIN_ATMOS_ANALYSIS_PREV/$gprefix.${file}
 done
@@ -97,9 +95,8 @@ dpath=enkfgdas.$gPDY/$gcyc
 for imem in $(seq 1 $NMEM_ENS); do
     memchar="mem"$(printf %03i $imem)
 
-    MEMDIR=${memchar} RUN=enkf${RUN} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -x \
-	COMIN_ATMOS_HISTORY_PREV_ENS:COM_ATMOS_HISTORY_TMPL
-
+    declare -x COMIN_ATMOS_HISTORY_PREV_ENS="${ROTDIR}/enkf${GDUMP}.${gPDY}/${gcyc}/${memchar}/model/atmos/history"
+    
     source=$GDASAPP_TESTDATA/lowres/$dpath/$memchar/model/atmos/history
     target=$COMIN_ATMOS_HISTORY_PREV_ENS
     mkdir -p $target

--- a/test/atm/global-workflow/jjob_var_init.sh
+++ b/test/atm/global-workflow/jjob_var_init.sh
@@ -73,7 +73,7 @@ done
 # Link radiance bias correction tarball
 dpath=gdas.$gPDY/$gcyc/analysis/atmos
 mkdir -p $COMIN_ATMOS_ANALYSIS_PREV
-flist="rad_varbc_params.tar"
+flist="varbc_params.tar"
 for file in $flist; do
    ln -fs $GDASAPP_TESTDATA/lowres/$dpath/$gprefix.${file} $COMIN_ATMOS_ANALYSIS_PREV/$gprefix.${file}
 done

--- a/test/atm/global-workflow/jjob_var_init.sh
+++ b/test/atm/global-workflow/jjob_var_init.sh
@@ -71,7 +71,7 @@ done
 # Link radiance bias correction tarball
 dpath=gdas.$gPDY/$gcyc/analysis/atmos
 mkdir -p $COMIN_ATMOS_ANALYSIS_PREV
-flist="rad_varbc_params.tar"
+flist="varbc_params.tar"
 for file in $flist; do
    ln -fs $GDASAPP_TESTDATA/lowres/$dpath/$gprefix.${file} $COMIN_ATMOS_ANALYSIS_PREV/$gprefix.${file}
 done

--- a/ush/gsi_satbias2ioda_all.sh
+++ b/ush/gsi_satbias2ioda_all.sh
@@ -17,7 +17,7 @@ gcyc=${GDATE:8:2}
 
 ABIAS=${COMOUT_ATMOS_ANALYSIS_PREV}/${GDUMP}.t${gcyc}z.abias.txt
 ABIASPC=${COMOUT_ATMOS_ANALYSIS_PREV}/${GDUMP}.t${gcyc}z.abias_pc.txt
-ABIAS_JEDI=${COMOUT_ATMOS_ANALYSIS_PREV}/${GDUMP}.t${gcyc}z.rad_varbc_params.tar
+ABIAS_JEDI_TAR=${COMOUT_ATMOS_ANALYSIS_PREV}/${GDUMP}.t${gcyc}z.varbc_params.tar
 
 satbias2ioda_x=${HOMEgfs}/sorc/gdas.cd/build/bin/satbias2ioda.x
 satbias2ioda_y=${HOMEgfs}/sorc/gdas.cd/ush/satbias_converter.yaml.tmpl
@@ -61,8 +61,8 @@ for instrument in $(echo $obsclass); do
     cd ./testrun/varbc/
     grep ${instrument}  ../../satbias_in  | awk '{print $2" "$3" "$4}' > \
           ${locdir}/gdas.t${gcyc}z.radiance_${instrument}.tlapse.txt
-    /bin/cp -p satbias_${instrument}.nc4  ${locdir}/gdas.t${gcyc}z.radiance_${instrument}.satbias.nc
-    /bin/mv  satbias_${instrument}.nc4  ${locdir}/gdas.t${gcyc}z.radiance_${instrument}.satbias_cov.nc
+    /bin/cp -p satbias_${instrument}.nc4  ${locdir}/gdas.t${gcyc}z.radiance_${instrument}.bias.nc
+    /bin/mv  satbias_${instrument}.nc4  ${locdir}/gdas.t${gcyc}z.radiance_${instrument}.bias_cov.nc
     
     cd  ${locdir}
     /bin/rm -f satbias_converter.yaml
@@ -73,13 +73,13 @@ done
 
 # Create tarball with JEDI format radiance bias correction files
 cd ${locdir}
-if [[ -s ${ABIAS_JEDI} ]]; then
-    rm -f ${ABIAS_JEDI}
+if [[ -s ${ABIAS_JEDI_TAR} ]]; then
+    rm -f ${ABIAS_JEDI_TAR}
 fi
-tar -cvf ${ABIAS_JEDI} ./
+tar -cvf ${ABIAS_JEDI_TAR} ./
 export err=$?
 if [[ ${err} -ne 0 ]]; then
-    err_exit "Creation of $ABIAS_JEDI failed, ABORT!"
+    err_exit "Creation of ${ABIAS_JEDI_TAR} failed, ABORT!"
 fi
 
 

--- a/ush/soca/run_jjobs.py
+++ b/ush/soca/run_jjobs.py
@@ -158,8 +158,8 @@ class JobCard:
             if jjob in ENVS:
                 self.f.write(f"module load {ENVS[jjob].upper()}/{self.machine} \n")
 
-    def precom(self, com, tmpl):
-        cmd = f"RUN={self.RUN} YMD={self.gPDY} HH={self.gcyc} declare_from_tmpl -xr {com}:{tmpl}"
+    def precom(self, com):
+        cmd = f"declare -rx {com}={self.rotdir}/{self.RUN}.{self.gPDY}/{self.gcyc}/model/ocean/history"
         self.f.write(f"{cmd}\n")
 
     def copy_bkgs(self):
@@ -175,9 +175,9 @@ class JobCard:
         # setup COM variables
         self.f.write("source ${HOMEgfs}/dev/parm/config/gfs/config.com\n")
         self.f.write("source ${HOMEgfs}/ush/preamble.sh\n")
-        self.precom('COM_OCEAN_HISTORY_PREV', 'COM_OCEAN_HISTORY_TMPL')
-        self.precom('COM_ICE_HISTORY_PREV', 'COM_ICE_HISTORY_TMPL')
-        self.precom('COM_ICE_RESTART_PREV', 'COM_ICE_RESTART_TMPL')
+        self.precom('COM_OCEAN_HISTORY_PREV')
+        self.precom('COM_ICE_HISTORY_PREV')
+        self.precom('COM_ICE_RESTART_PREV')
 
         self.f.write("mkdir -p ${COM_OCEAN_HISTORY_PREV}/\n")
         self.f.write("mkdir -p ${COM_ICE_HISTORY_PREV}/\n")

--- a/ush/soca/run_jjobs.py
+++ b/ush/soca/run_jjobs.py
@@ -158,8 +158,8 @@ class JobCard:
             if jjob in ENVS:
                 self.f.write(f"module load {ENVS[jjob].upper()}/{self.machine} \n")
 
-    def precom(self, com):
-        cmd = f"declare -rx {com}={self.rotdir}/{self.RUN}.{self.gPDY}/{self.gcyc}/model/ocean/history"
+    def precom(self, com, path):
+        cmd = f"declare -rx {com}={self.rotdir}/{self.RUN}.{self.gPDY}/{self.gcyc}/{path}"
         self.f.write(f"{cmd}\n")
 
     def copy_bkgs(self):
@@ -175,9 +175,9 @@ class JobCard:
         # setup COM variables
         self.f.write("source ${HOMEgfs}/dev/parm/config/gfs/config.com\n")
         self.f.write("source ${HOMEgfs}/ush/preamble.sh\n")
-        self.precom('COM_OCEAN_HISTORY_PREV')
-        self.precom('COM_ICE_HISTORY_PREV')
-        self.precom('COM_ICE_RESTART_PREV')
+        self.precom('COM_OCEAN_HISTORY_PREV', 'model/ocean/history')
+        self.precom('COM_ICE_HISTORY_PREV', 'model/ice/history')
+        self.precom('COM_ICE_RESTART_PREV', 'model/ice/restart')
 
         self.f.write("mkdir -p ${COM_OCEAN_HISTORY_PREV}/\n")
         self.f.write("mkdir -p ${COM_ICE_HISTORY_PREV}/\n")

--- a/ush/soca/run_jjobs.py
+++ b/ush/soca/run_jjobs.py
@@ -173,8 +173,8 @@ class JobCard:
         print(f"RUN: {self.RUN}")
 
         # setup COM variables
-        self.f.write("source ${HOMEgfs}/dev/parm/config/gfs/config.com\n")
-        self.f.write("source ${HOMEgfs}/ush/preamble.sh\n")
+        self.f.write("source ${HOMEglobal}/dev/parm/config/gfs/config.com\n")
+        self.f.write("source ${HOMEglobal}/ush/preamble.sh\n")
         self.precom('COM_OCEAN_HISTORY_PREV', 'model/ocean/history')
         self.precom('COM_ICE_HISTORY_PREV', 'model/ice/history')
         self.precom('COM_ICE_RESTART_PREV', 'model/ice/restart')


### PR DESCRIPTION
# Description

This PR changes the suffixes of the VarBC files from `satbias.nc` to `bias.nc` and `satbias_cov` to `bias_cov`.
Additionally the tar ball is renamed from `rad_varbc_params` to `varbc_params` to include any aircraft VarBC files.

# Companion PRs

Will require a sync'd global-workflow PR to work properly. Coming soon.

# Issues

Resolves #2077

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmsnowDA <!-- JEDI snow cycled DA !-->
- [ ] C96_gcafs_cycled <!-- JEDI aerosol cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [ ] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_ufsgsi_hybatmDA <!-- JEDI atm Var with GSI EnKF cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
