### PR TITLE
Update EE2 Environment Variables: Replace NET-Specific (VARgfs) with Global (VARglobal)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -51,7 +51,7 @@ BUILD_SOCA=${BUILD_SOCA:-"ON"}
 while getopts "w:t:c:hvdfai" opt; do
   case $opt in
     w)
-      HOMEgfs=$OPTARG
+      HOMEglobal=$OPTARG
       ;;
     t)
       BUILD_TARGET=$OPTARG
@@ -117,8 +117,8 @@ if [[ $BUILD_SOCA == 'ON' ]]; then
     # Link MOM6 and Icepack in SOCA to submodules in the UFS repo
     rm -rf $dir_root/sorc/soca/external/mom6/MOM6
     rm -rf $dir_root/sorc/soca/external/icepack/Icepack
-    ln -sf $HOMEgfs/sorc/ufs_model.fd/MOM6-interface/MOM6/ $dir_root/sorc/soca/external/mom6/MOM6
-    ln -sf $HOMEgfs/sorc/ufs_model.fd/CICE-interface/CICE/icepack/ $dir_root/sorc/soca/external/icepack/Icepack
+    ln -sf $HOMEglobal/sorc/ufs_model.fd/MOM6-interface/MOM6/ $dir_root/sorc/soca/external/mom6/MOM6
+    ln -sf $HOMEglobal/sorc/ufs_model.fd/CICE-interface/CICE/icepack/ $dir_root/sorc/soca/external/icepack/Icepack
   else
     # Delete forked SOCA NOAA-EMC dev/emc repo and clone the original JCSDA develop repo
     rm -rf "$dir_root/sorc/soca/"

--- a/parm/aero/aero_bmat_config.yaml.j2
+++ b/parm/aero/aero_bmat_config.yaml.j2
@@ -1,22 +1,22 @@
 jedi_config:
     aero_interpbkg:
         rundir: '{{ DATA }}'
-        exe_src: '{{ EXECgfs }}/gdas.x'
+        exe_src: '{{ EXECglobal }}/gdas.x'
         jedi_args: ['fv3jedi', 'convertstate']
         mpi_cmd: '{{ APRUN_AEROANLGENB }}'
-        jcb_base_yaml: '{{ PARMgfs }}/gdas/aero/jcb-base.yaml.j2'
+        jcb_base_yaml: '{{ PARMglobal }}/gdas/aero/jcb-base.yaml.j2'
         jcb_algo: aero_convert_background
     aero_diagb:
         rundir: '{{ DATA }}'
-        exe_src: '{{ EXECgfs }}/gdas_fv3jedi_chem_diagb.x'
+        exe_src: '{{ EXECglobal }}/gdas_fv3jedi_chem_diagb.x'
         mpi_cmd: '{{ APRUN_AEROANLGENB }}'
-        jcb_base_yaml: '{{ PARMgfs }}/gdas/aero/jcb-base.yaml.j2'
+        jcb_base_yaml: '{{ PARMglobal }}/gdas/aero/jcb-base.yaml.j2'
         jcb_algo: aero_gen_bmatrix_diagb
     aero_diffusion:
         rundir: '{{ DATA }}'
-        exe_src: '{{ EXECgfs }}/gdas_fv3jedi_error_covariance_toolbox.x'
+        exe_src: '{{ EXECglobal }}/gdas_fv3jedi_error_covariance_toolbox.x'
         mpi_cmd: '{{ APRUN_AEROANLGENB }}'
-        jcb_base_yaml: '{{ PARMgfs }}/gdas/aero/jcb-base.yaml.j2'
+        jcb_base_yaml: '{{ PARMglobal }}/gdas/aero/jcb-base.yaml.j2'
         jcb_algo: aero_gen_bmatrix_diffusion
 
 data_in:

--- a/parm/aero/aero_det_config.yaml.j2
+++ b/parm/aero/aero_det_config.yaml.j2
@@ -1,11 +1,11 @@
 jedi_config:
     aeroanlvar:
         rundir: '{{ DATA }}'
-        exe_src: '{{ EXECgfs }}/gdas.x'
+        exe_src: '{{ EXECglobal }}/gdas.x'
         mpi_cmd: '{{ APRUN_AEROANL }}'
         jedi_args: ['fv3jedi', 'variational']
         jcb_algo: '3dfgat'
-        jcb_base_yaml: '{{ PARMgfs }}/gdas/aero/jcb-base.yaml.j2'
+        jcb_base_yaml: '{{ PARMglobal }}/gdas/aero/jcb-base.yaml.j2'
         obs_list_yaml: '{{ OBS_LIST_YAML }}'
 
 data_in:

--- a/parm/aero/aero_stage_jedi_fix.yaml.j2
+++ b/parm/aero/aero_stage_jedi_fix.yaml.j2
@@ -1,3 +1,3 @@
-- ['{{ FIXgfs }}/gdas/fv3jedi/fv3files/akbk{{ npz }}.nc4', '{{ DATA }}/fv3jedi/akbk.nc4']
-- ['{{ FIXgfs }}/gdas/fv3jedi/fv3files/fmsmpp.nml', '{{ DATA }}/fv3jedi/fmsmpp.nml']
-- ['{{ FIXgfs }}/gdas/fv3jedi/fv3files/field_table_gfdl', '{{ DATA }}/fv3jedi/field_table']
+- ['{{ FIXglobal }}/gdas/fv3jedi/fv3files/akbk{{ npz }}.nc4', '{{ DATA }}/fv3jedi/akbk.nc4']
+- ['{{ FIXglobal }}/gdas/fv3jedi/fv3files/fmsmpp.nml', '{{ DATA }}/fv3jedi/fmsmpp.nml']
+- ['{{ FIXglobal }}/gdas/fv3jedi/fv3files/field_table_gfdl', '{{ DATA }}/fv3jedi/field_table']

--- a/parm/aero/jcb-base.yaml.j2
+++ b/parm/aero/jcb-base.yaml.j2
@@ -1,10 +1,10 @@
 # Search path for model and obs for JCB
 # -------------------------------------
-algorithm_path: "{{PARMgfs}}/gdas/jcb-algorithms"
-app_path_algorithm: "{{PARMgfs}}/gdas/jcb-gdas/algorithm/aero"
-app_path_model: "{{PARMgfs}}/gdas/jcb-gdas/model/aero"
-app_path_observations: "{{PARMgfs}}/gdas/jcb-gdas/observations/aero"
-app_path_observation_chronicle: "{{PARMgfs}}/gdas/jcb-gdas/observation_chronicle/aero"
+algorithm_path: "{{PARMglobal}}/gdas/jcb-algorithms"
+app_path_algorithm: "{{PARMglobal}}/gdas/jcb-gdas/algorithm/aero"
+app_path_model: "{{PARMglobal}}/gdas/jcb-gdas/model/aero"
+app_path_observations: "{{PARMglobal}}/gdas/jcb-gdas/observations/aero"
+app_path_observation_chronicle: "{{PARMglobal}}/gdas/jcb-gdas/observation_chronicle/aero"
 
 
 # Places where we deviate from the generic file name of a yaml

--- a/parm/analcalc/analcalc_config.yaml.j2
+++ b/parm/analcalc/analcalc_config.yaml.j2
@@ -1,27 +1,27 @@
 jedi_config:
     atm_addincrement:
         rundir: '{{ DATA }}'
-        exe_src: '{{ EXECgfs }}/gdas.x'
+        exe_src: '{{ EXECglobal }}/gdas.x'
         jedi_args: ['fv3jedi', 'addincrement']
         mpi_cmd: '{{ APRUN_ANALCALC_FV3JEDI }}'
-        jcb_base_yaml: '{{ PARMgfs }}/gdas/atm/jcb-base.yaml.j2'
+        jcb_base_yaml: '{{ PARMglobal }}/gdas/atm/jcb-base.yaml.j2'
         jcb_algo: atm_addincrement
 {% if DO_AERO_ANL %}
     aero_addincrement:
         rundir: '{{ DATA }}'
-        exe_src: '{{ EXECgfs }}/gdas.x'
+        exe_src: '{{ EXECglobal }}/gdas.x'
         jedi_args: ['fv3jedi', 'addincrement']
         mpi_cmd: '{{ APRUN_ANALCALC_FV3JEDI }}'
-        jcb_base_yaml: '{{ PARMgfs }}/gdas/aero/jcb-base.yaml.j2'
+        jcb_base_yaml: '{{ PARMglobal }}/gdas/aero/jcb-base.yaml.j2'
         jcb_algo: aero_addincrement
 {% endif %}
 {% if DO_JEDISNOWDA %}
     snow_addincrement:
         rundir: '{{ DATA }}'
-        exe_src: '{{ EXECgfs }}/gdas.x'
+        exe_src: '{{ EXECglobal }}/gdas.x'
         jedi_args: ['fv3jedi', 'addincrement']
         mpi_cmd: '{{ APRUN_ANALCALC_FV3JEDI }}'
-        jcb_base_yaml: '{{ PARMgfs }}/gdas/snow/jcb-base.yaml.j2'
+        jcb_base_yaml: '{{ PARMglobal }}/gdas/snow/jcb-base.yaml.j2'
         jcb_algo: snow_addincrement
 {% endif %}
 
@@ -66,7 +66,7 @@ data_in:
     {% endif %}
 
 {% filter indent(width=4) %}
-{% include PARMgfs ~ '/gdas/' ~ '/atm/' ~ 'atm_stage_jedi_fix.yaml.j2' %}
+{% include PARMglobal ~ '/gdas/' ~ '/atm/' ~ 'atm_stage_jedi_fix.yaml.j2' %}
 {% endfilter %}
 
 data_out:

--- a/parm/anlstat/aero/jcb-base.yaml.j2
+++ b/parm/anlstat/aero/jcb-base.yaml.j2
@@ -1,8 +1,8 @@
 # Search path for model and obs for JCB
 # -------------------------------------
-algorithm_path: "{{ PARMgfs }}/gdas/jcb-algorithms"
-app_path_algorithm: "{{ PARMgfs }}/gdas/jcb-gdas/algorithm/observation_statistics"
-app_path_observations: "{{ PARMgfs }}/gdas/jcb-gdas/observation_statistics/aero"
+algorithm_path: "{{ PARMglobal }}/gdas/jcb-algorithms"
+app_path_algorithm: "{{ PARMglobal }}/gdas/jcb-gdas/algorithm/observation_statistics"
+app_path_observations: "{{ PARMglobal }}/gdas/jcb-gdas/observation_statistics/aero"
 
 # Assimilation window
 # -------------------

--- a/parm/anlstat/anlstat_config.yaml.j2
+++ b/parm/anlstat/anlstat_config.yaml.j2
@@ -1,32 +1,32 @@
 jedi_config:
     aero:
         rundir: '{{ DATA }}/aero'
-        exe_src: '{{ EXECgfs }}/gdas_ioda-stats.x'
+        exe_src: '{{ EXECglobal }}/gdas_ioda-stats.x'
         mpi_cmd: '{{ APRUN_ANLSTAT }}'
-        jcb_base_yaml: '{{ PARMgfs }}/gdas/anlstat/aero/jcb-base.yaml.j2'
+        jcb_base_yaml: '{{ PARMglobal }}/gdas/anlstat/aero/jcb-base.yaml.j2'
         jcb_algo: 'anlstat'
-        obs_list_yaml: '{{ PARMgfs }}/gdas/anlstat/aero/aero_obs_list.yaml.j2'
+        obs_list_yaml: '{{ PARMglobal }}/gdas/anlstat/aero/aero_obs_list.yaml.j2'
     atmos:
         rundir: '{{ DATA }}/atmos'
-        exe_src: '{{ EXECgfs }}/gdas_ioda-stats.x'
+        exe_src: '{{ EXECglobal }}/gdas_ioda-stats.x'
         mpi_cmd: '{{ APRUN_ANLSTAT }}'
-        jcb_base_yaml: '{{ PARMgfs }}/gdas/anlstat/atmos/jcb-base.yaml.j2'
+        jcb_base_yaml: '{{ PARMglobal }}/gdas/anlstat/atmos/jcb-base.yaml.j2'
         jcb_algo: 'anlstat'
-        obs_list_yaml: '{{ PARMgfs }}/gdas/anlstat/atmos/atmos_obs_list.yaml.j2'
+        obs_list_yaml: '{{ PARMglobal }}/gdas/anlstat/atmos/atmos_obs_list.yaml.j2'
     atmos_gsi:
         rundir: '{{ DATA }}/atmos_gsi'
-        exe_src: '{{ EXECgfs }}/gdas_ioda-stats.x'
+        exe_src: '{{ EXECglobal }}/gdas_ioda-stats.x'
         mpi_cmd: '{{ APRUN_ANLSTAT }}'
-        jcb_base_yaml: '{{ PARMgfs }}/gdas/anlstat/atmos_gsi/jcb-base.yaml.j2'
+        jcb_base_yaml: '{{ PARMglobal }}/gdas/anlstat/atmos_gsi/jcb-base.yaml.j2'
         jcb_algo: 'anlstat'
-        obs_list_yaml: '{{ PARMgfs }}/gdas/anlstat/atmos_gsi/atmos_gsi_obs_list.yaml.j2'
+        obs_list_yaml: '{{ PARMglobal }}/gdas/anlstat/atmos_gsi/atmos_gsi_obs_list.yaml.j2'
     snow:
         rundir: '{{ DATA }}/snow'
-        exe_src: '{{ EXECgfs }}/gdas_ioda-stats.x'
+        exe_src: '{{ EXECglobal }}/gdas_ioda-stats.x'
         mpi_cmd: '{{ APRUN_ANLSTAT }}'
-        jcb_base_yaml: '{{ PARMgfs }}/gdas/anlstat/snow/jcb-base.yaml.j2'
+        jcb_base_yaml: '{{ PARMglobal }}/gdas/anlstat/snow/jcb-base.yaml.j2'
         jcb_algo: 'anlstat'
-        obs_list_yaml: '{{ PARMgfs }}/gdas/anlstat/snow/snow_obs_list.yaml.j2'
+        obs_list_yaml: '{{ PARMglobal }}/gdas/anlstat/snow/snow_obs_list.yaml.j2'
 
 data_in:
     mkdir:

--- a/parm/anlstat/atmos/jcb-base.yaml.j2
+++ b/parm/anlstat/atmos/jcb-base.yaml.j2
@@ -1,8 +1,8 @@
 # Search path for model and obs for JCB
 # -------------------------------------
-algorithm_path: "{{ PARMgfs }}/gdas/jcb-algorithms"
-app_path_algorithm: "{{ PARMgfs }}/gdas/jcb-gdas/algorithm/observation_statistics"
-app_path_observations: "{{ PARMgfs }}/gdas/jcb-gdas/observation_statistics/atmosphere"
+algorithm_path: "{{ PARMglobal }}/gdas/jcb-algorithms"
+app_path_algorithm: "{{ PARMglobal }}/gdas/jcb-gdas/algorithm/observation_statistics"
+app_path_observations: "{{ PARMglobal }}/gdas/jcb-gdas/observation_statistics/atmosphere"
 
 # Assimilation window
 # -------------------

--- a/parm/anlstat/atmos_gsi/jcb-base.yaml.j2
+++ b/parm/anlstat/atmos_gsi/jcb-base.yaml.j2
@@ -1,8 +1,8 @@
 # Search path for model and obs for JCB
 # -------------------------------------
-algorithm_path: "{{ PARMgfs }}/gdas/jcb-algorithms"
-app_path_algorithm: "{{ PARMgfs }}/gdas/jcb-gdas/algorithm/observation_statistics"
-app_path_observations: "{{ PARMgfs }}/gdas/jcb-gdas/observation_statistics/atmosphere_gsi"
+algorithm_path: "{{ PARMglobal }}/gdas/jcb-algorithms"
+app_path_algorithm: "{{ PARMglobal }}/gdas/jcb-gdas/algorithm/observation_statistics"
+app_path_observations: "{{ PARMglobal }}/gdas/jcb-gdas/observation_statistics/atmosphere_gsi"
 
 # Assimilation window
 # -------------------

--- a/parm/anlstat/snow/jcb-base.yaml.j2
+++ b/parm/anlstat/snow/jcb-base.yaml.j2
@@ -1,8 +1,8 @@
 # Search path for model and obs for JCB
 # -------------------------------------
-algorithm_path: "{{ PARMgfs }}/gdas/jcb-algorithms"
-app_path_algorithm: "{{ PARMgfs }}/gdas/jcb-gdas/algorithm/observation_statistics"
-app_path_observations: "{{ PARMgfs }}/gdas/jcb-gdas/observation_statistics/snow"
+algorithm_path: "{{ PARMglobal }}/gdas/jcb-algorithms"
+app_path_algorithm: "{{ PARMglobal }}/gdas/jcb-gdas/algorithm/observation_statistics"
+app_path_observations: "{{ PARMglobal }}/gdas/jcb-gdas/observation_statistics/snow"
 
 # Assimilation window
 # -------------------

--- a/parm/atm/atm_det_config.yaml.j2
+++ b/parm/atm/atm_det_config.yaml.j2
@@ -1,18 +1,18 @@
 jedi_config:
     atmanlvar:
         rundir: '{{ DATA }}'
-        exe_src: '{{ EXECgfs }}/gdas.x'
+        exe_src: '{{ EXECglobal }}/gdas.x'
         mpi_cmd: '{{ APRUN_ATMANLVAR }}'
         jedi_args: ['fv3jedi', 'variational']
         jcb_algo: '3dvar'
-        jcb_base_yaml: '{{ PARMgfs }}/gdas/atm/jcb-base.yaml.j2'
+        jcb_base_yaml: '{{ PARMglobal }}/gdas/atm/jcb-base.yaml.j2'
         obs_list_yaml: '{{ OBS_LIST_YAML }}'
     atmanlfv3inc:
         rundir: '{{ DATA }}'
-        exe_src: '{{ EXECgfs }}/gdas_fv3jedi_fv3inc.x'
+        exe_src: '{{ EXECglobal }}/gdas_fv3jedi_fv3inc.x'
         mpi_cmd: '{{ APRUN_ATMANLFV3INC }}'
         jcb_algo: 'fv3jedi_fv3inc_variational'
-        jcb_base_yaml: '{{ PARMgfs }}/gdas/atm/jcb-base.yaml.j2'
+        jcb_base_yaml: '{{ PARMglobal }}/gdas/atm/jcb-base.yaml.j2'
 
 data_in:
     mkdir:

--- a/parm/atm/atm_det_stage_berror_gsibec.yaml.j2
+++ b/parm/atm/atm_det_stage_berror_gsibec.yaml.j2
@@ -1,2 +1,2 @@
-- ['{{ HOMEgfs }}/fix/gdas/gsibec/{{ CASE_ANL }}/gfs_gsi_global.nml', '{{ DATA }}/berror']
-- ['{{ HOMEgfs }}/fix/gdas/gsibec/{{ CASE_ANL }}/gsi-coeffs-gfs-global.nc', '{{ DATA }}/berror']
+- ['{{ HOMEglobal }}/fix/gdas/gsibec/{{ CASE_ANL }}/gfs_gsi_global.nml', '{{ DATA }}/berror']
+- ['{{ HOMEglobal }}/fix/gdas/gsibec/{{ CASE_ANL }}/gsi-coeffs-gfs-global.nc', '{{ DATA }}/berror']

--- a/parm/atm/atm_ecen_config.yaml.j2
+++ b/parm/atm/atm_ecen_config.yaml.j2
@@ -1,15 +1,15 @@
 jedi_config:
     correction_increment:
         rundir: '{{ DATA }}'
-        exe_src: '{{ EXECgfs }}/gdas_fv3jedi_correction_increment.x'
+        exe_src: '{{ EXECglobal }}/gdas_fv3jedi_correction_increment.x'
         mpi_cmd: '{{ APRUN_CORRECTION_INCREMENT }}'
-        jcb_base_yaml: '{{ PARMgfs }}/gdas/atm/jcb-base.yaml.j2'
+        jcb_base_yaml: '{{ PARMglobal }}/gdas/atm/jcb-base.yaml.j2'
         jcb_algo: fv3jedi_correction_increment
     ensemble_recenter:
         rundir: '{{ DATA }}'
-        exe_src: '{{ EXECgfs }}/gdas_fv3jedi_ensemble_add_increment.x'
+        exe_src: '{{ EXECglobal }}/gdas_fv3jedi_ensemble_add_increment.x'
         mpi_cmd: '{{ APRUN_ENSEMBLE_RECENTER }}'
-        jcb_base_yaml: '{{ PARMgfs }}/gdas/atm/jcb-base.yaml.j2'
+        jcb_base_yaml: '{{ PARMglobal }}/gdas/atm/jcb-base.yaml.j2'
         jcb_algo: fv3jedi_ensemble_recenter
 
 data_in:

--- a/parm/atm/atm_ens_config.yaml.j2
+++ b/parm/atm/atm_ens_config.yaml.j2
@@ -1,33 +1,33 @@
 jedi_config:
     atmensanlobs:
         rundir: '{{ DATA }}'
-        exe_src: '{{ EXECgfs }}/gdas.x'
+        exe_src: '{{ EXECglobal }}/gdas.x'
         mpi_cmd: '{{ APRUN_ATMENSANLOBS }}'
         jedi_args: ['fv3jedi', 'localensembleda']
-        jcb_base_yaml: '{{ PARMgfs }}/gdas/atm/jcb-base.yaml.j2'
-        jcb_algo_yaml: '{{ PARMgfs }}/gdas/atm/jcb-prototype_lgetkf_observer.yaml.j2'
+        jcb_base_yaml: '{{ PARMglobal }}/gdas/atm/jcb-base.yaml.j2'
+        jcb_algo_yaml: '{{ PARMglobal }}/gdas/atm/jcb-prototype_lgetkf_observer.yaml.j2'
         obs_list_yaml: '{{ OBS_LIST_YAML }}'
     atmensanlsol:
         rundir: '{{ DATA }}'
-        exe_src: '{{ EXECgfs }}/gdas.x'
+        exe_src: '{{ EXECglobal }}/gdas.x'
         mpi_cmd: '{{ APRUN_ATMENSANLSOL }}'
         jedi_args: ['fv3jedi', 'localensembleda']
-        jcb_base_yaml: '{{ PARMgfs }}/gdas/atm/jcb-base.yaml.j2'
-        jcb_algo_yaml: '{{ PARMgfs }}/gdas/atm/jcb-prototype_lgetkf_solver.yaml.j2'
+        jcb_base_yaml: '{{ PARMglobal }}/gdas/atm/jcb-base.yaml.j2'
+        jcb_algo_yaml: '{{ PARMglobal }}/gdas/atm/jcb-prototype_lgetkf_solver.yaml.j2'
         obs_list_yaml: '{{ OBS_LIST_YAML }}'
     atmensanlfv3inc:
         rundir: '{{ DATA }}'
-        exe_src: '{{ EXECgfs }}/gdas_fv3jedi_fv3inc.x'
+        exe_src: '{{ EXECglobal }}/gdas_fv3jedi_fv3inc.x'
         mpi_cmd: '{{ APRUN_ATMENSANLFV3INC }}'
         jcb_algo: 'fv3jedi_fv3inc_lgetkf'
-        jcb_base_yaml: '{{ PARMgfs }}/gdas/atm/jcb-base.yaml.j2'
+        jcb_base_yaml: '{{ PARMglobal }}/gdas/atm/jcb-base.yaml.j2'
     atmensanlletkf:
         rundir: '{{ DATA }}'
-        exe_src: '{{ EXECgfs }}/gdas.x'
+        exe_src: '{{ EXECglobal }}/gdas.x'
         mpi_cmd: '{{ APRUN_ATMENSANLLETKF }}'
         jedi_args: ['fv3jedi', 'localensembleda']
-        jcb_base_yaml: '{{ PARMgfs }}/gdas/atm/jcb-base.yaml.j2'
-        jcb_algo_yaml: '{{ PARMgfs }}/gdas/atm/jcb-prototype_lgetkf.yaml.j2'
+        jcb_base_yaml: '{{ PARMglobal }}/gdas/atm/jcb-base.yaml.j2'
+        jcb_algo_yaml: '{{ PARMglobal }}/gdas/atm/jcb-prototype_lgetkf.yaml.j2'
         obs_list_yaml: '{{ OBS_LIST_YAML }}'
 
 data_in:

--- a/parm/atm/atm_stage_jedi_fix.yaml.j2
+++ b/parm/atm/atm_stage_jedi_fix.yaml.j2
@@ -1,3 +1,3 @@
-- ['{{ FIXgfs }}/gdas/fv3jedi/fv3files/akbk{{ npz }}.nc4', '{{ DATA }}/fv3jedi/akbk.nc4']
-- ['{{ FIXgfs }}/gdas/fv3jedi/fv3files/fmsmpp.nml', '{{ DATA }}/fv3jedi/fmsmpp.nml']
-- ['{{ FIXgfs }}/gdas/fv3jedi/fv3files/field_table_gfdl', '{{ DATA }}/fv3jedi/field_table']
+- ['{{ FIXglobal }}/gdas/fv3jedi/fv3files/akbk{{ npz }}.nc4', '{{ DATA }}/fv3jedi/akbk.nc4']
+- ['{{ FIXglobal }}/gdas/fv3jedi/fv3files/fmsmpp.nml', '{{ DATA }}/fv3jedi/fmsmpp.nml']
+- ['{{ FIXglobal }}/gdas/fv3jedi/fv3files/field_table_gfdl', '{{ DATA }}/fv3jedi/field_table']

--- a/parm/atm/jcb-base.yaml.j2
+++ b/parm/atm/jcb-base.yaml.j2
@@ -1,10 +1,10 @@
 # Search path for model and obs for JCB
 # -------------------------------------
-algorithm_path: "{{PARMgfs}}/gdas/jcb-algorithms"
-app_path_algorithm: "{{PARMgfs}}/gdas/jcb-gdas/algorithm/atmosphere"
-app_path_model: "{{PARMgfs}}/gdas/jcb-gdas/model/atmosphere"
-app_path_observations: "{{PARMgfs}}/gdas/jcb-gdas/observations/atmosphere"
-app_path_observation_chronicle: "{{PARMgfs}}/gdas/jcb-gdas/observation_chronicle/atmosphere"
+algorithm_path: "{{PARMglobal}}/gdas/jcb-algorithms"
+app_path_algorithm: "{{PARMglobal}}/gdas/jcb-gdas/algorithm/atmosphere"
+app_path_model: "{{PARMglobal}}/gdas/jcb-gdas/model/atmosphere"
+app_path_observations: "{{PARMglobal}}/gdas/jcb-gdas/observations/atmosphere"
+app_path_observation_chronicle: "{{PARMglobal}}/gdas/jcb-gdas/observation_chronicle/atmosphere"
 
 
 # Places where we deviate from the generic file name of a yaml
@@ -87,7 +87,7 @@ crtm_coefficient_path: "{{ DATA }}/crtm/"
 # Naming conventions for observational files
 
 atmosphere_obsdatain_path: "{{DATA}}/obs"
-atmosphere_obsdatain_script_path: "{{HOMEgfs}}/ush/spoc/atmosphere"
+atmosphere_obsdatain_script_path: "{{HOMEglobal}}/ush/spoc/atmosphere"
 atmosphere_obsdatain_prefix: "{{OPREFIX}}"
 atmosphere_obsdatain_suffix: ".nc"
 atmosphere_obsdatain_suffix_bufr: ".tm00.bufr_d"

--- a/parm/atm/jcb-prototype_lgetkf.yaml.j2
+++ b/parm/atm/jcb-prototype_lgetkf.yaml.j2
@@ -1,7 +1,7 @@
 # Use observations for lgetkf
 # ---------------------------
-app_path_observations: {{PARMgfs}}/gdas/jcb-gdas/observations/atmosphere
-app_path_observation_chronicle: {{PARMgfs}}/gdas/jcb-gdas/observation_chronicle/atmosphere
+app_path_observations: {{PARMglobal}}/gdas/jcb-gdas/observations/atmosphere
+app_path_observation_chronicle: {{PARMglobal}}/gdas/jcb-gdas/observation_chronicle/atmosphere
 
 # Algorithm
 # ---------

--- a/parm/atm/jcb-prototype_lgetkf_observer.yaml.j2
+++ b/parm/atm/jcb-prototype_lgetkf_observer.yaml.j2
@@ -1,7 +1,7 @@
 # Use observations for lgetkf
 # ---------------------------
-app_path_observations: {{PARMgfs}}/gdas/jcb-gdas/observations/atmosphere
-app_path_observation_chronicle: {{PARMgfs}}/gdas/jcb-gdas/observation_chronicle/atmosphere
+app_path_observations: {{PARMglobal}}/gdas/jcb-gdas/observations/atmosphere
+app_path_observation_chronicle: {{PARMglobal}}/gdas/jcb-gdas/observation_chronicle/atmosphere
 
 # Algorithm
 # ---------

--- a/parm/atm/jcb-prototype_lgetkf_solver.yaml.j2
+++ b/parm/atm/jcb-prototype_lgetkf_solver.yaml.j2
@@ -1,7 +1,7 @@
 # Use observations for lgetkf
 # ---------------------------
-app_path_observations: {{PARMgfs}}/gdas/jcb-gdas/observations/atmosphere
-app_path_observation_chronicle: {{PARMgfs}}/gdas/jcb-gdas/observation_chronicle/atmosphere
+app_path_observations: {{PARMglobal}}/gdas/jcb-gdas/observations/atmosphere
+app_path_observation_chronicle: {{PARMglobal}}/gdas/jcb-gdas/observation_chronicle/atmosphere
 
 # Algorithm
 # ---------

--- a/parm/marine/jcb-base.yaml.j2
+++ b/parm/marine/jcb-base.yaml.j2
@@ -1,10 +1,10 @@
 # Search path for model and obs for JCB
 # -------------------------------------
-algorithm_path: '{{PARMgfs}}/gdas/jcb-algorithms'
-app_path_algorithm: '{{PARMgfs}}/gdas/jcb-gdas/algorithm/marine'
-app_path_model: '{{PARMgfs}}/gdas/jcb-gdas/model/marine'
-app_path_observations: '{{PARMgfs}}/gdas/jcb-gdas/observations/marine'
-app_path_observation_chronicle: '{{PARMgfs}}/gdas/jcb-gdas/observation_chronicle/marine'
+algorithm_path: '{{PARMglobal}}/gdas/jcb-algorithms'
+app_path_algorithm: '{{PARMglobal}}/gdas/jcb-gdas/algorithm/marine'
+app_path_model: '{{PARMglobal}}/gdas/jcb-gdas/model/marine'
+app_path_observations: '{{PARMglobal}}/gdas/jcb-gdas/observations/marine'
+app_path_observation_chronicle: '{{PARMglobal}}/gdas/jcb-gdas/observation_chronicle/marine'
 
 
 # Places where we deviate from the generic file name of a yaml

--- a/parm/marine/marine_bmat_config.yaml.j2
+++ b/parm/marine/marine_bmat_config.yaml.j2
@@ -1,52 +1,52 @@
 jedi_config:
     gridgen:
         rundir: '{{ DATA }}'
-        exe_src: '{{ EXECgfs }}/gdas_soca_gridgen.x'
+        exe_src: '{{ EXECglobal }}/gdas_soca_gridgen.x'
         mpi_cmd: '{{ APRUN_MARINEBMAT }}'
-        jcb_base_yaml: '{{ PARMgfs }}/gdas/marine/jcb-base.yaml.j2'
+        jcb_base_yaml: '{{ PARMglobal }}/gdas/marine/jcb-base.yaml.j2'
         jcb_algo: soca_gridgen
     soca_diagb:
         rundir: '{{ DATA }}'
-        exe_src: '{{ EXECgfs }}/gdas_soca_diagb.x'
+        exe_src: '{{ EXECglobal }}/gdas_soca_diagb.x'
         mpi_cmd: '{{ APRUN_MARINEBMAT }}'
-        jcb_base_yaml: '{{ PARMgfs }}/gdas/marine/jcb-base.yaml.j2'
+        jcb_base_yaml: '{{ PARMglobal }}/gdas/marine/jcb-base.yaml.j2'
         jcb_algo: soca_diagb
     soca_chgres:
         rundir: '{{ DATA }}'
-        exe_src: '{{ EXECgfs }}/gdas.x'
+        exe_src: '{{ EXECglobal }}/gdas.x'
         mpi_cmd: '{{ APRUN_MARINEBMAT }}'
         jedi_args: ['soca', 'convertstate']
-        jcb_base_yaml: '{{ PARMgfs }}/gdas/marine/jcb-base.yaml.j2'
+        jcb_base_yaml: '{{ PARMglobal }}/gdas/marine/jcb-base.yaml.j2'
         jcb_algo: soca_chgres
     soca_parameters_diffusion_vt:
         rundir: '{{ DATA }}'
-        exe_src: '{{ EXECgfs }}/gdas_soca_error_covariance_toolbox.x'
+        exe_src: '{{ EXECglobal }}/gdas_soca_error_covariance_toolbox.x'
         mpi_cmd: '{{ APRUN_MARINEBMAT }}'
-        jcb_base_yaml: '{{ PARMgfs }}/gdas/marine/jcb-base.yaml.j2'
+        jcb_base_yaml: '{{ PARMglobal }}/gdas/marine/jcb-base.yaml.j2'
         jcb_algo: soca_parameters_diffusion_vt
     soca_setcorscales:
         rundir: '{{ DATA }}'
-        exe_src: '{{ EXECgfs }}/gdas_soca_setcorscales.x'
+        exe_src: '{{ EXECglobal }}/gdas_soca_setcorscales.x'
         mpi_cmd: '{{ APRUN_MARINEBMAT }}'
-        jcb_base_yaml: '{{ PARMgfs }}/gdas/marine/jcb-base.yaml.j2'
+        jcb_base_yaml: '{{ PARMglobal }}/gdas/marine/jcb-base.yaml.j2'
         jcb_algo: soca_setcorscales
     soca_parameters_diffusion_hz:
         rundir: '{{ DATA }}'
-        exe_src: '{{ EXECgfs }}/gdas_soca_error_covariance_toolbox.x'
+        exe_src: '{{ EXECglobal }}/gdas_soca_error_covariance_toolbox.x'
         mpi_cmd: '{{ APRUN_MARINEBMAT }}'
-        jcb_base_yaml: '{{ PARMgfs }}/gdas/marine/jcb-base.yaml.j2'
+        jcb_base_yaml: '{{ PARMglobal }}/gdas/marine/jcb-base.yaml.j2'
         jcb_algo: soca_parameters_diffusion_hz
     soca_ensb:
         rundir: '{{ DATA }}'
-        exe_src: '{{ EXECgfs }}/gdas_soca_ens_handler.x'
+        exe_src: '{{ EXECglobal }}/gdas_soca_ens_handler.x'
         mpi_cmd: '{{ APRUN_MARINEBMAT }}'
-        jcb_base_yaml: '{{ PARMgfs }}/gdas/marine/jcb-base.yaml.j2'
+        jcb_base_yaml: '{{ PARMglobal }}/gdas/marine/jcb-base.yaml.j2'
         jcb_algo: soca_ensb
     soca_ensweights:
         rundir: '{{ DATA }}'
-        exe_src: '{{ EXECgfs }}/gdas_soca_hybridweights.x'
+        exe_src: '{{ EXECglobal }}/gdas_soca_hybridweights.x'
         mpi_cmd: '{{ APRUN_MARINEBMAT }}'
-        jcb_base_yaml: '{{ PARMgfs }}/gdas/marine/jcb-base.yaml.j2'
+        jcb_base_yaml: '{{ PARMglobal }}/gdas/marine/jcb-base.yaml.j2'
         jcb_algo: soca_ensweights
 
 data_in:

--- a/parm/marine/marine_det_config.yaml.j2
+++ b/parm/marine/marine_det_config.yaml.j2
@@ -1,23 +1,23 @@
 jedi_config:
     var:
         rundir: '{{ DATA }}'
-        exe_src: '{{ EXECgfs }}/gdas.x'
+        exe_src: '{{ EXECglobal }}/gdas.x'
         mpi_cmd: '{{ APRUN_MARINEANLVAR }}'
         jedi_args: ['soca', 'variational']
         jcb_algo: '3dfgat'
-        jcb_base_yaml: '{{ PARMgfs }}/gdas/marine/jcb-base.yaml.j2'
+        jcb_base_yaml: '{{ PARMglobal }}/gdas/marine/jcb-base.yaml.j2'
         obs_list_yaml: '{{ OBS_LIST_YAML }}'
     soca_incpostproc:
         rundir: '{{ DATA }}'
-        exe_src: '{{ EXECgfs }}/gdas_soca_incr_handler.x'
+        exe_src: '{{ EXECglobal }}/gdas_soca_incr_handler.x'
         mpi_cmd: '{{ APRUN_MARINEANLCHKPT }}'
-        jcb_base_yaml: '{{ PARMgfs }}/gdas/marine/jcb-base.yaml.j2'
+        jcb_base_yaml: '{{ PARMglobal }}/gdas/marine/jcb-base.yaml.j2'
         jcb_algo: soca_incpostproc
     soca_diag_stats:
         rundir: '{{ DATA }}'
-        exe_src: '{{ EXECgfs }}/gdas_soca_obsstats.x'
+        exe_src: '{{ EXECglobal }}/gdas_soca_obsstats.x'
         mpi_cmd: '{{ APRUN_MARINEANLOBSSTATS }}'
-        jcb_base_yaml: '{{ PARMgfs }}/gdas/marine/jcb-base.yaml.j2'
+        jcb_base_yaml: '{{ PARMglobal }}/gdas/marine/jcb-base.yaml.j2'
         jcb_algo: soca_diag_stats
 
 data_in:

--- a/parm/marine/marine_ecen_config.yaml.j2
+++ b/parm/marine/marine_ecen_config.yaml.j2
@@ -1,15 +1,15 @@
 jedi_config:
     gridgen:
         rundir: '{{ DATA }}'
-        exe_src: '{{ EXECgfs }}/gdas_soca_gridgen.x'
+        exe_src: '{{ EXECglobal }}/gdas_soca_gridgen.x'
         mpi_cmd: '{{ APRUN_MARINEANLECEN }}'
-        jcb_base_yaml: '{{ PARMgfs }}/gdas/marine/jcb-base.yaml.j2'
+        jcb_base_yaml: '{{ PARMglobal }}/gdas/marine/jcb-base.yaml.j2'
         jcb_algo: soca_gridgen
     ens_handler:
         rundir: '{{ DATA }}'
-        exe_src: '{{ EXECgfs }}/gdas_soca_anpproc.x'
+        exe_src: '{{ EXECglobal }}/gdas_soca_anpproc.x'
         mpi_cmd: '{{ APRUN_MARINEANLECEN }}'
-        jcb_base_yaml: '{{ PARMgfs }}/gdas/marine/jcb-base.yaml.j2'
+        jcb_base_yaml: '{{ PARMglobal }}/gdas/marine/jcb-base.yaml.j2'
         jcb_algo: soca_ens_handler
 
 data_in:

--- a/parm/marine/marine_ens_config.yaml.j2
+++ b/parm/marine/marine_ens_config.yaml.j2
@@ -1,17 +1,17 @@
 jedi_config:
     gridgen:
         rundir: '{{ DATA }}'
-        exe_src: '{{ EXECgfs }}/gdas_soca_gridgen.x'
+        exe_src: '{{ EXECglobal }}/gdas_soca_gridgen.x'
         mpi_cmd: '{{ APRUN_MARINEANLLETKF }}'
-        jcb_base_yaml: '{{ PARMgfs }}/gdas/marine/jcb-base.yaml.j2'
+        jcb_base_yaml: '{{ PARMglobal }}/gdas/marine/jcb-base.yaml.j2'
         jcb_algo: soca_gridgen
     letkf:
         rundir: '{{ DATA }}'
-        exe_src: '{{ EXECgfs }}/gdas.x'
+        exe_src: '{{ EXECglobal }}/gdas.x'
         mpi_cmd: '{{ APRUN_MARINEANLLETKF }}'
         jedi_args: ['soca', 'localensembleda']
         jcb_algo: 'local_ensemble_da'
-        jcb_base_yaml: '{{ PARMgfs }}/gdas/marine/jcb-base.yaml.j2'
+        jcb_base_yaml: '{{ PARMglobal }}/gdas/marine/jcb-base.yaml.j2'
         obs_list_yaml: '{{ OBS_LIST_YAML }}'
 
 data_in:
@@ -23,8 +23,8 @@ data_in:
 
     copy_req:
     # copy mom input template and det bkg
-    - ['{{ PARMgfs }}/gdas/marine/fms/input.nml', '{{ DATA }}/mom_input.nml.tmpl']
-    - ['{{ PARMgfs }}/gdas/marine/fields_metadata.yaml', '{{ DATA }}/fields_metadata.yaml']
+    - ['{{ PARMglobal }}/gdas/marine/fms/input.nml', '{{ DATA }}/mom_input.nml.tmpl']
+    - ['{{ PARMglobal }}/gdas/marine/fields_metadata.yaml', '{{ DATA }}/fields_metadata.yaml']
     - ['{{ COMIN_OCEAN_HISTORY_PREV }}/{{ GPREFIX }}inst.f009.nc', '{{ DATA }}/INPUT/MOM.res.nc']
     - ['{{ COMIN_ICE_HISTORY_PREV }}/{{ GPREFIX }}inst.f009.nc', '{{ DATA }}/INPUT/cice.res.nc']
 

--- a/parm/marine/marine_stage_utilities.yaml.j2
+++ b/parm/marine/marine_stage_utilities.yaml.j2
@@ -1,5 +1,5 @@
 ######################################
 # Utility yaml files to copy
 ######################################
-- ["{{ HOMEgfs }}/parm/gdas/marine/fields_metadata.yaml", "{{ DATA }}/fields_metadata.yaml"]
-- ["{{ HOMEgfs }}/parm/gdas/marine/obsop_name_map.yaml", "{{ DATA }}/obsop_name_map.yaml"]
+- ["{{ HOMEglobal }}/parm/gdas/marine/fields_metadata.yaml", "{{ DATA }}/fields_metadata.yaml"]
+- ["{{ HOMEglobal }}/parm/gdas/marine/obsop_name_map.yaml", "{{ DATA }}/obsop_name_map.yaml"]

--- a/parm/obsolete/snow/hofx/hofx_nomodel.yaml.j2
+++ b/parm/obsolete/snow/hofx/hofx_nomodel.yaml.j2
@@ -19,7 +19,7 @@ geometry:
       filetype: fms restart
       skip coupler file: true
       state variables: [orog_filt]
-      datapath: '{{ FIXgfs }}/fix_orog/{{ CASE }}/'
+      datapath: '{{ FIXglobal }}/fix_orog/{{ CASE }}/'
       filename_orog: '{{ CASE }}_oro_data.nc'
 state:
   datapath: './bkg'

--- a/parm/snow/apply_incr_nml.j2
+++ b/parm/snow/apply_incr_nml.j2
@@ -5,7 +5,7 @@
   frac_grid = .true.,
   rst_path = "./anl",
   inc_path = "./anl",
-  orog_path = "{{ HOMEgfs }}/fix/orog/{{ CASE }}",
+  orog_path = "{{ HOMEglobal }}/fix/orog/{{ CASE }}",
   otype = "{{ CASE }}.mx{{ OCNRES }}_oro_data",
   ntiles={{ ntiles }},
   ens_size={{ ens_size }},

--- a/parm/snow/ens_apply_incr_nml.j2
+++ b/parm/snow/ens_apply_incr_nml.j2
@@ -5,7 +5,7 @@
   frac_grid = .true.,
   rst_path = "{{ DATA }}/anl/mem{{ MYMEM }}",
   inc_path = "{{ DATA }}/anl",
-  orog_path = "{{ HOMEgfs }}/fix/orog/{{ CASE_ENS }}",
+  orog_path = "{{ HOMEglobal }}/fix/orog/{{ CASE_ENS }}",
   otype = "{{ CASE_ENS }}.mx{{ OCNRES }}_oro_data", 
   ntiles={{ ntiles }},
   ens_size={{ ens_size }},

--- a/parm/snow/jcb-base.yaml.j2
+++ b/parm/snow/jcb-base.yaml.j2
@@ -1,10 +1,10 @@
 # Search path for model and obs for JCB
 # -------------------------------------
-algorithm_path: "{{PARMgfs}}/gdas/jcb-algorithms"
-app_path_algorithm: "{{PARMgfs}}/gdas/jcb-gdas/algorithm/snow"
-app_path_model: "{{PARMgfs}}/gdas/jcb-gdas/model/snow"
-app_path_observations: "{{PARMgfs}}/gdas/jcb-gdas/observations/snow"
-app_path_observation_chronicle: "{{PARMgfs}}/gdas/jcb-gdas/observation_chronicle/snow/{{cycle}}"
+algorithm_path: "{{PARMglobal}}/gdas/jcb-algorithms"
+app_path_algorithm: "{{PARMglobal}}/gdas/jcb-gdas/algorithm/snow"
+app_path_model: "{{PARMglobal}}/gdas/jcb-gdas/model/snow"
+app_path_observations: "{{PARMglobal}}/gdas/jcb-gdas/observations/snow"
+app_path_observation_chronicle: "{{PARMglobal}}/gdas/jcb-gdas/observation_chronicle/snow/{{cycle}}"
 
 
 # Places where we deviate from the generic file name of a yaml

--- a/parm/snow/prep/prep_ghcn.yaml.j2
+++ b/parm/snow/prep/prep_ghcn.yaml.j2
@@ -3,7 +3,7 @@ stage:
     - '{{ snow_prepobs_path }}'
   copy_opt:
     - ['{{ COMIN_OBS }}/{{ OPREFIX }}ghcn_snow.csv', '{{ DATA }}']
-    - ['{{ FIXgfs }}/gdas/snow/ghcnd-stations.txt', '{{ DATA }}']
+    - ['{{ FIXglobal }}/gdas/snow/ghcnd-stations.txt', '{{ DATA }}']
 ghcn2ioda:
   copy_opt:
     - ['{{ DATA }}/{{ OPREFIX }}ghcn_snow.nc', '{{ snow_prepobs_path }}']

--- a/parm/snow/prep/prep_ims.yaml.j2
+++ b/parm/snow/prep/prep_ims.yaml.j2
@@ -4,8 +4,8 @@ calcfims:
   copy_req:
     - ['{{ COMIN_OBS }}/{{ OPREFIX }}imssnow96.asc', '{{ DATA }}/obs/ims{{ current_cycle | to_julian }}_4km_v1.3.asc']
 # remove the below line later once using the C++ IMS SCF code
-    - ['{{ FIXgfs }}/gdas/obs/ims/IMS_4km_to_{{ CASE }}.mx{{ OCNRES }}.nc', '{{ DATA }}/obs/IMS4km_to_FV3_mapping.{{ CASE }}_oro_data.nc']
-    - ['{{ FIXgfs }}/gdas/obs/ims/IMS_4km_to_{{ CASE }}.mx{{ OCNRES }}.nc', '{{ DATA }}/obs/IMS4km_to_FV3_mapping.{{ CASE }}.mx{{ OCNRES }}_oro_data.nc']
+    - ['{{ FIXglobal }}/gdas/obs/ims/IMS_4km_to_{{ CASE }}.mx{{ OCNRES }}.nc', '{{ DATA }}/obs/IMS4km_to_FV3_mapping.{{ CASE }}_oro_data.nc']
+    - ['{{ FIXglobal }}/gdas/obs/ims/IMS_4km_to_{{ CASE }}.mx{{ OCNRES }}.nc', '{{ DATA }}/obs/IMS4km_to_FV3_mapping.{{ CASE }}.mx{{ OCNRES }}_oro_data.nc']
 ims2ioda:
   copy_req:
     - ['{{ DATA }}/ims_snow_{{ current_cycle | to_YMDH }}.nc4', '{{ DATA }}/obs/{{ OPREFIX }}ims_snow.tm00.nc']

--- a/parm/snow/prep/prep_snocvr_snomad.yaml.j2
+++ b/parm/snow/prep/prep_snocvr_snomad.yaml.j2
@@ -4,8 +4,8 @@ stage:
   copy_opt:
     - ['{{ COMIN_OBS }}/{{ OPREFIX }}snocvr.tm00.bufr_d', '{{ DATA }}']
     - ['{{ COMIN_OBS }}/{{ OPREFIX }}snomad.tm00.bufr_d', '{{ DATA }}']
-    - ['{{ PARMgfs }}/gdas/snow/obs/config/bufr_snocvr_mapping.yaml', '{{ DATA }}']
-    - ['{{ PARMgfs }}/gdas/snow/obs/config/bufr_snomad_mapping.yaml', '{{ DATA }}']
+    - ['{{ PARMglobal }}/gdas/snow/obs/config/bufr_snocvr_mapping.yaml', '{{ DATA }}']
+    - ['{{ PARMglobal }}/gdas/snow/obs/config/bufr_snomad_mapping.yaml', '{{ DATA }}']
 netcdf:
   copy_opt:
     - ['{{ DATA }}/{{ OPREFIX }}snocvr_snomad.tm00.nc', '{{ snow_prepobs_path }}/{{ OPREFIX }}snocvr_snomad.tm00.nc']

--- a/parm/snow/snow_det_config.yaml.j2
+++ b/parm/snow/snow_det_config.yaml.j2
@@ -1,18 +1,18 @@
 jedi_config:
     snowanlvar:
         rundir: '{{ DATA }}'
-        exe_src: '{{ EXECgfs }}/gdas.x'
+        exe_src: '{{ EXECglobal }}/gdas.x'
         mpi_cmd: '{{ APRUN_SNOWANL }}'
         jedi_args: ['fv3jedi', 'variational']
         jcb_algo: '3dvar'
-        jcb_base_yaml: '{{ PARMgfs }}/gdas/snow/jcb-base.yaml.j2'
+        jcb_base_yaml: '{{ PARMglobal }}/gdas/snow/jcb-base.yaml.j2'
         obs_list_yaml: '{{ OBS_LIST_YAML }}'
     scf_to_ioda:
         rundir: '{{ DATA }}'
-        exe_src: '{{ EXECgfs }}/gdas_fv3jedi_scf_to_ioda.x'
+        exe_src: '{{ EXECglobal }}/gdas_fv3jedi_scf_to_ioda.x'
         mpi_cmd: '{{ APRUN_SNOWANL }}'
         jcb_algo: 'snow_ims_scf_preprocess'
-        jcb_base_yaml: '{{ PARMgfs }}/gdas/snow/jcb-base.yaml.j2'
+        jcb_base_yaml: '{{ PARMglobal }}/gdas/snow/jcb-base.yaml.j2'
 
 data_in:
     mkdir:

--- a/parm/snow/snow_ens_config.yaml.j2
+++ b/parm/snow/snow_ens_config.yaml.j2
@@ -1,25 +1,25 @@
 jedi_config:
     esnowanlensmean:
         rundir: '{{ DATA }}'
-        exe_src: '{{ EXECgfs }}/gdas.x'
+        exe_src: '{{ EXECglobal }}/gdas.x'
         mpi_cmd: '{{ APRUN_ESNOWANL }}'
         jedi_args: ['fv3jedi', 'ensmean']
         jcb_algo: 'fv3jedi_snow_ensmean'
-        jcb_base_yaml: '{{ PARMgfs }}/gdas/snow/jcb-base.yaml.j2'
+        jcb_base_yaml: '{{ PARMglobal }}/gdas/snow/jcb-base.yaml.j2'
     snowanlvar:
         rundir: '{{ DATA }}'
-        exe_src: '{{ EXECgfs }}/gdas.x'
+        exe_src: '{{ EXECglobal }}/gdas.x'
         mpi_cmd: '{{ APRUN_ESNOWANL }}'
         jedi_args: ['fv3jedi', 'variational']
         jcb_algo: '3dvar'
-        jcb_base_yaml: '{{ PARMgfs }}/gdas/snow/jcb-base.yaml.j2'
+        jcb_base_yaml: '{{ PARMglobal }}/gdas/snow/jcb-base.yaml.j2'
         obs_list_yaml: '{{ OBS_LIST_YAML }}'
     scf_to_ioda:
         rundir: '{{ DATA }}'
-        exe_src: '{{ EXECgfs }}/gdas_fv3jedi_scf_to_ioda.x'
+        exe_src: '{{ EXECglobal }}/gdas_fv3jedi_scf_to_ioda.x'
         mpi_cmd: '{{ APRUN_ESNOWANL }}'
         jcb_algo: 'snow_ims_scf_preprocess'
-        jcb_base_yaml: '{{ PARMgfs }}/gdas/snow/jcb-base.yaml.j2'
+        jcb_base_yaml: '{{ PARMglobal }}/gdas/snow/jcb-base.yaml.j2'
 
 data_in:
     mkdir:

--- a/parm/snow/snow_stage_berror.yaml.j2
+++ b/parm/snow/snow_stage_berror.yaml.j2
@@ -1,1 +1,1 @@
-- ['{{ HOMEgfs }}/fix/gdas/snow/snow_bump_nicas_250km_shadowlevels_nicas.nc', '{{ DATA }}/berror']
+- ['{{ HOMEglobal }}/fix/gdas/snow/snow_bump_nicas_250km_shadowlevels_nicas.nc', '{{ DATA }}/berror']

--- a/parm/snow/snow_stage_bufr2ioda_mapping.yaml.j2
+++ b/parm/snow/snow_stage_bufr2ioda_mapping.yaml.j2
@@ -1,3 +1,3 @@
-- ['{{PARMgfs}}/gdas/snow/obs/config/bufr_sfcsno_mapping.yaml', '{{ DATA }}/obs/']
-- ['{{PARMgfs}}/gdas/snow/obs/config/bufr_snocvr_mapping.yaml', '{{ DATA }}/obs/']
-- ['{{PARMgfs}}/gdas/snow/obs/config/bufr_snomad_mapping.yaml', '{{ DATA }}/obs/']
+- ['{{PARMglobal}}/gdas/snow/obs/config/bufr_sfcsno_mapping.yaml', '{{ DATA }}/obs/']
+- ['{{PARMglobal}}/gdas/snow/obs/config/bufr_snocvr_mapping.yaml', '{{ DATA }}/obs/']
+- ['{{PARMglobal}}/gdas/snow/obs/config/bufr_snomad_mapping.yaml', '{{ DATA }}/obs/']

--- a/parm/snow/snow_stage_ims_scf2ioda.yaml.j2
+++ b/parm/snow/snow_stage_ims_scf2ioda.yaml.j2
@@ -1,2 +1,2 @@
 - ['{{ ims_file }}', '{{ DATA }}/obs/ims{{ current_cycle | to_julian }}_4km_v1.3.{{ ims_scf_obs_suffix }}']
-- ['{{ FIXgfs }}/gdas/obs/ims/IMS_4km_to_{{ CASE }}.mx{{ OCNRES }}.nc', '{{ DATA }}/obs/IMS4km_to_FV3_mapping.{{ CASE }}.mx{{ OCNRES }}_oro_data.nc']
+- ['{{ FIXglobal }}/gdas/obs/ims/IMS_4km_to_{{ CASE }}.mx{{ OCNRES }}.nc', '{{ DATA }}/obs/IMS4km_to_FV3_mapping.{{ CASE }}.mx{{ OCNRES }}_oro_data.nc']

--- a/parm/snow/snow_stage_jedi_fix.yaml.j2
+++ b/parm/snow/snow_stage_jedi_fix.yaml.j2
@@ -1,3 +1,3 @@
-- ['{{ FIXgfs }}/gdas/fv3jedi/fv3files/akbk{{ npz }}.nc4', '{{ DATA }}/fv3jedi/akbk.nc4']
-- ['{{ FIXgfs }}/gdas/fv3jedi/fv3files/fmsmpp.nml', '{{ DATA }}/fv3jedi/fmsmpp.nml']
-- ['{{ FIXgfs }}/gdas/fv3jedi/fv3files/field_table_gfdl', '{{ DATA }}/fv3jedi/field_table']
+- ['{{ FIXglobal }}/gdas/fv3jedi/fv3files/akbk{{ npz }}.nc4', '{{ DATA }}/fv3jedi/akbk.nc4']
+- ['{{ FIXglobal }}/gdas/fv3jedi/fv3files/fmsmpp.nml', '{{ DATA }}/fv3jedi/fmsmpp.nml']
+- ['{{ FIXglobal }}/gdas/fv3jedi/fv3files/field_table_gfdl', '{{ DATA }}/fv3jedi/field_table']

--- a/scripts/exgdas_global_marine_analysis_vrfy.py
+++ b/scripts/exgdas_global_marine_analysis_vrfy.py
@@ -39,7 +39,7 @@ layer_file = os.path.join(comout, f'{RUN}.t'+cyc+'z.ocninc.nc')
 
 # for eva
 diagdir = os.path.join(comout, 'diags')
-HOMEgfs = os.getenv('HOMEgfs')
+HOMEglobal = os.getenv('HOMEglobal')
 
 
 # plot marine analysis vrfy
@@ -177,7 +177,7 @@ for process in processes:
 # eva plots
 #######################################
 
-evadir = os.path.join(HOMEgfs, 'sorc', f'{RUN}.cd', 'ush', 'eva')
+evadir = os.path.join(HOMEglobal, 'sorc', f'{RUN}.cd', 'ush', 'eva')
 marinetemplate = os.path.join(evadir, 'marine_gdas_plots.yaml')
 varyaml = os.path.join(comout, 'yaml', 'var_original.yaml')
 

--- a/test/aero/genyaml_3dvar.sh
+++ b/test/aero/genyaml_3dvar.sh
@@ -25,20 +25,20 @@ export YAMLout=$DATA/3dvar_gfs_aero.yaml
 rm -rf $DATA
 mkdir -p $DATA
 
-# Set g-w HOMEgfs
+# Set g-w HOMEglobal
 topdir=$(cd "$(dirname "$(readlink -f -n "${bindir}" )" )/../../.." && pwd -P)
-export HOMEgfs=$topdir
+export HOMEglobal=$topdir
 
 # Detect machine
-source "${HOMEgfs}/ush/detect_machine.sh"
+source "${HOMEglobal}/ush/detect_machine.sh"
 
-# Set up the PYTHONPATH to include wxflow from HOMEgfs
-if [[ -d "${HOMEgfs}/sorc/wxflow/src" ]]; then
-  PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${HOMEgfs}/sorc/wxflow/src"
+# Set up the PYTHONPATH to include wxflow from HOMEglobal
+if [[ -d "${HOMEglobal}/sorc/wxflow/src" ]]; then
+  PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${HOMEglobal}/sorc/wxflow/src"
 fi
 
 # Set python path for workflow utilities and tasks
-wxflowPATH="${HOMEgfs}/ush/python"
+wxflowPATH="${HOMEglobal}/ush/python"
 PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${wxflowPATH}"
 export PYTHONPATH
 

--- a/test/aero/global-workflow/config.aeroanl
+++ b/test/aero/global-workflow/config.aeroanl
@@ -6,18 +6,18 @@
 echo "BEGIN: config.aeroanl"
 
 export CASE_ANL=${CASE}
-export OBS_YAML_DIR=${HOMEgfs}/sorc/gdas.cd/parm/aero/obs/config/
+export OBS_YAML_DIR=${HOMEglobal}/sorc/gdas.cd/parm/aero/obs/config/
 export OBS_LIST=@OBS_LIST@
-export AEROVARYAML=${HOMEgfs}/sorc/gdas.cd/parm/aero/variational/3dvar_gfs_aero.yaml
+export AEROVARYAML=${HOMEglobal}/sorc/gdas.cd/parm/aero/variational/3dvar_gfs_aero.yaml
 export STATICB_TYPE='identity'
-export BERROR_YAML=${HOMEgfs}/sorc/gdas.cd/parm/aero/berror/staticb_${STATICB_TYPE}.yaml
-export FV3JEDI_FIX=${HOMEgfs}/fix/gdas
+export BERROR_YAML=${HOMEglobal}/sorc/gdas.cd/parm/aero/berror/staticb_${STATICB_TYPE}.yaml
+export FV3JEDI_FIX=${HOMEglobal}/fix/gdas
 export BERROR_DATA_DIR=${FV3JEDI_FIX}/bump/aero/${CASE_ANL}/
 export BERROR_DATE="20160630.000000"
 
 export io_layout_x=1
 export io_layout_y=1
 
-export JEDIEXE=${HOMEgfs}/exec/gdas.x
+export JEDIEXE=${HOMEglobal}/exec/gdas.x
 
 echo "END: config.aeroanl"

--- a/test/aero/global-workflow/jjob_var_final.sh
+++ b/test/aero/global-workflow/jjob_var_final.sh
@@ -4,9 +4,9 @@ set -x
 bindir=$1
 srcdir=$2
 
-# Set g-w HOMEgfs
+# Set g-w HOMEglobal
 topdir=$(cd "$(dirname "$(readlink -f -n "${bindir}" )" )/../../.." && pwd -P)
-export HOMEgfs=$topdir
+export HOMEglobal=$topdir
 
 # Set variables for ctest
 export PSLOT=gdas_test
@@ -23,20 +23,20 @@ export COMROOT=$DATAROOT
 export NMEM_ENS=0
 
 # Detect machine
-source "${HOMEgfs}/ush/detect_machine.sh"
+source "${HOMEglobal}/ush/detect_machine.sh"
 
-# Set up the PYTHONPATH to include wxflow from HOMEgfs
-if [[ -d "${HOMEgfs}/sorc/wxflow/src" ]]; then
-  PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${HOMEgfs}/sorc/wxflow/src"
+# Set up the PYTHONPATH to include wxflow from HOMEglobal
+if [[ -d "${HOMEglobal}/sorc/wxflow/src" ]]; then
+  PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${HOMEglobal}/sorc/wxflow/src"
 fi
 
 # Set python path for workflow utilities and tasks
-wxflowPATH="${HOMEgfs}/ush/python"
+wxflowPATH="${HOMEglobal}/ush/python"
 PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${wxflowPATH}"
 export PYTHONPATH
 
 # Export library path
-export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${HOMEgfs}/lib"
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${HOMEglobal}/lib"
 
 # Create yaml with job configuration
 memory="8Gb"
@@ -46,20 +46,20 @@ fi
 config_yaml="./config_${type}.yaml"
 cat <<EOF > ${config_yaml}
 machine: ${MACHINE_ID}
-homegfs: ${HOMEgfs}
+homegfs: ${HOMEglobal}
 job_name: ${type}
 walltime: "00:30:00"
 nodes: 1
 ntasks_per_node: 1
 threads_per_task: 1
 memory: ${memory}
-command: ${HOMEgfs}/dev/jobs/JGLOBAL_AERO_ANALYSIS_FINALIZE
+command: ${HOMEglobal}/dev/jobs/JGLOBAL_AERO_ANALYSIS_FINALIZE
 filename: submit_${type}.sh
 EOF
 
 # Create script to execute j-job
-$HOMEgfs/sorc/gdas.cd/test/workflow/generate_job_script.py ${config_yaml}
-SCHEDULER=$(echo `grep SCHEDULER ${HOMEgfs}/sorc/gdas.cd/test/workflow/hosts/${MACHINE_ID}.yaml | cut -d":" -f2` | tr -d ' ')
+$HOMEglobal/sorc/gdas.cd/test/workflow/generate_job_script.py ${config_yaml}
+SCHEDULER=$(echo `grep SCHEDULER ${HOMEglobal}/sorc/gdas.cd/test/workflow/hosts/${MACHINE_ID}.yaml | cut -d":" -f2` | tr -d ' ')
 
 # Submit script to execute j-job
 if [[ $SCHEDULER = 'slurm' ]]; then
@@ -67,5 +67,5 @@ if [[ $SCHEDULER = 'slurm' ]]; then
 elif [[ $SCHEDULER = 'pbspro' ]]; then
     qsub -V -W block=true submit_${type}.sh
 else
-    ${HOMEgfs}/dev/jobs/JGLOBAL_AERO_ANALYSIS_FINALIZE
+    ${HOMEglobal}/dev/jobs/JGLOBAL_AERO_ANALYSIS_FINALIZE
 fi

--- a/test/aero/global-workflow/jjob_var_init.sh
+++ b/test/aero/global-workflow/jjob_var_init.sh
@@ -4,9 +4,9 @@ set -x
 bindir=$1
 srcdir=$2
 
-# Set g-w HOMEgfs
+# Set g-w HOMEglobal
 topdir=$(cd "$(dirname "$(readlink -f -n "${bindir}" )" )/../../.." && pwd -P)
-export HOMEgfs=$topdir
+export HOMEglobal=$topdir
 
 # Set variables for ctest
 export PSLOT=gdas_test
@@ -25,24 +25,24 @@ export NMEM_ENS=0
 export COM_TOP=$ROTDIR
 
 # Set GFS COM paths
-source "${HOMEgfs}/ush/preamble.sh"
-source "${HOMEgfs}/dev/parm/config/gfs/config.com"
+source "${HOMEglobal}/ush/preamble.sh"
+source "${HOMEglobal}/dev/parm/config/gfs/config.com"
 
 # Detect machine
-source "${HOMEgfs}/ush/detect_machine.sh"
+source "${HOMEglobal}/ush/detect_machine.sh"
 
-# Set up the PYTHONPATH to include wxflow from HOMEgfs
-if [[ -d "${HOMEgfs}/sorc/wxflow/src" ]]; then
-  PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${HOMEgfs}/sorc/wxflow/src"
+# Set up the PYTHONPATH to include wxflow from HOMEglobal
+if [[ -d "${HOMEglobal}/sorc/wxflow/src" ]]; then
+  PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${HOMEglobal}/sorc/wxflow/src"
 fi
 
 # Set python path for workflow utilities and tasks
-wxflowPATH="${HOMEgfs}/ush/python"
+wxflowPATH="${HOMEglobal}/ush/python"
 PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${wxflowPATH}"
 export PYTHONPATH
 
 # Export library path
-export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${HOMEgfs}/lib"
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${HOMEglobal}/lib"
 
 # Set date variables for previous cycle
 gPDY=$(date +%Y%m%d -d "${PDY} ${cyc} - 6 hours")
@@ -89,20 +89,20 @@ fi
 config_yaml="./config_${type}.yaml"
 cat <<EOF > ${config_yaml}
 machine: ${MACHINE_ID}
-homegfs: ${HOMEgfs}
+homegfs: ${HOMEglobal}
 job_name: ${type}
 walltime: "00:30:00"
 nodes: 1
 ntasks_per_node: 1
 threads_per_task: 1
 memory: ${memory}
-command: ${HOMEgfs}/dev/jobs/JGLOBAL_AERO_ANALYSIS_INITIALIZE
+command: ${HOMEglobal}/dev/jobs/JGLOBAL_AERO_ANALYSIS_INITIALIZE
 filename: submit_${type}.sh
 EOF
 
 # Create script to execute j-job
-$HOMEgfs/sorc/gdas.cd/test/workflow/generate_job_script.py ${config_yaml}
-SCHEDULER=$(echo `grep SCHEDULER ${HOMEgfs}/sorc/gdas.cd/test/workflow/hosts/${MACHINE_ID}.yaml | cut -d":" -f2` | tr -d ' ')
+$HOMEglobal/sorc/gdas.cd/test/workflow/generate_job_script.py ${config_yaml}
+SCHEDULER=$(echo `grep SCHEDULER ${HOMEglobal}/sorc/gdas.cd/test/workflow/hosts/${MACHINE_ID}.yaml | cut -d":" -f2` | tr -d ' ')
 
 # Submit script to execute j-job
 if [[ $SCHEDULER = 'slurm' ]]; then
@@ -110,5 +110,5 @@ if [[ $SCHEDULER = 'slurm' ]]; then
 elif [[ $SCHEDULER = 'pbspro' ]]; then
     qsub -V -W block=true submit_${type}.sh
 else
-    ${HOMEgfs}/dev/jobs/JGLOBAL_AERO_ANALYSIS_INITIALIZE
+    ${HOMEglobal}/dev/jobs/JGLOBAL_AERO_ANALYSIS_INITIALIZE
 fi

--- a/test/aero/global-workflow/jjob_var_run.sh
+++ b/test/aero/global-workflow/jjob_var_run.sh
@@ -4,8 +4,8 @@ set -x
 bindir=$1
 srcdir=$2
 
-# Set g-w HOMEgfs
-export HOMEgfs=$srcdir/../../ # TODO: HOMEgfs had to be hard-coded in config
+# Set g-w HOMEglobal
+export HOMEglobal=$srcdir/../../ # TODO: HOMEglobal had to be hard-coded in config
 
 # Set variables for ctest
 export PSLOT=gdas_test
@@ -25,20 +25,20 @@ export COMROOT=$DATAROOT
 export NMEM_ENS=0
 
 # Detect machine
-source "${HOMEgfs}/ush/detect_machine.sh"
+source "${HOMEglobal}/ush/detect_machine.sh"
 
-# Set up the PYTHONPATH to include wxflow from HOMEgfs
-if [[ -d "${HOMEgfs}/sorc/wxflow/src" ]]; then
-  PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${HOMEgfs}/sorc/wxflow/src"
+# Set up the PYTHONPATH to include wxflow from HOMEglobal
+if [[ -d "${HOMEglobal}/sorc/wxflow/src" ]]; then
+  PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${HOMEglobal}/sorc/wxflow/src"
 fi
 
 # Set python path for workflow utilities and tasks
-wxflowPATH="${HOMEgfs}/ush/python"
+wxflowPATH="${HOMEglobal}/ush/python"
 PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${wxflowPATH}"
 export PYTHONPATH
 
 # Export library path
-export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${HOMEgfs}/lib"
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${HOMEglobal}/lib"
 
 # Create yaml with job configuration
 memory="96Gb"
@@ -48,20 +48,20 @@ fi
 config_yaml="./config_${type}.yaml"
 cat <<EOF > ${config_yaml}
 machine: ${MACHINE_ID}
-homegfs: ${HOMEgfs}
+homegfs: ${HOMEglobal}
 job_name: ${type}
 walltime: "00:30:00"
 nodes: 1
 ntasks_per_node: 6
 threads_per_task: 1
 memory: ${memory}
-command: ${HOMEgfs}/dev/jobs/JGLOBAL_AERO_ANALYSIS_RUN
+command: ${HOMEglobal}/dev/jobs/JGLOBAL_AERO_ANALYSIS_RUN
 filename: submit_${type}.sh
 EOF
 
 # Create script to execute j-job. Set job scheduler
-${HOMEgfs}/sorc/gdas.cd/test/workflow/generate_job_script.py ${config_yaml}
-SCHEDULER=$(echo `grep SCHEDULER ${HOMEgfs}/sorc/gdas.cd/test/workflow/hosts/${MACHINE_ID}.yaml | cut -d":" -f2` | tr -d ' ')
+${HOMEglobal}/sorc/gdas.cd/test/workflow/generate_job_script.py ${config_yaml}
+SCHEDULER=$(echo `grep SCHEDULER ${HOMEglobal}/sorc/gdas.cd/test/workflow/hosts/${MACHINE_ID}.yaml | cut -d":" -f2` | tr -d ' ')
 
 # Submit script to execute j-job
 if [[ $SCHEDULER = 'slurm' ]]; then
@@ -69,6 +69,6 @@ if [[ $SCHEDULER = 'slurm' ]]; then
 elif [[ $SCHEDULER = 'pbspro' ]]; then
     qsub -V -W block=true submit_${type}.sh
 else
-    ${HOMEgfs}/dev/jobs/JGLOBAL_AERO_ANALYSIS_RUN
+    ${HOMEglobal}/dev/jobs/JGLOBAL_AERO_ANALYSIS_RUN
 fi
 

--- a/test/atm/global-workflow/config.yaml
+++ b/test/atm/global-workflow/config.yaml
@@ -1,5 +1,5 @@
 base:
-  HOMEgfs: "@topdir@"
+  HOMEglobal: "@topdir@"
   DOHYBVAR: "NO"
   DO_JEDIATMVAR: "YES"
   DO_JEDIATMENS: "YES"
@@ -19,15 +19,15 @@ atmanl:
   ATMRES_ANL: "C48"
   LAYOUT_X_ATMANL: 1
   LAYOUT_Y_ATMANL: 1
-  OBS_LIST_YAML: "${HOMEgfs}/sorc/gdas.cd/test/atm/global-workflow/atm_obs_list.yaml.j2"
-  VAR_JEDI_TEST_YAML: "${HOMEgfs}/sorc/gdas.cd/test/atm/global-workflow/jedi-test_3dvar.yaml.j2"
-  FV3INC_JEDI_TEST_YAML: "${HOMEgfs}/sorc/gdas.cd/test/atm/global-workflow/jedi-test_3dvar-fv3inc.yaml.j2"
+  OBS_LIST_YAML: "${HOMEglobal}/sorc/gdas.cd/test/atm/global-workflow/atm_obs_list.yaml.j2"
+  VAR_JEDI_TEST_YAML: "${HOMEglobal}/sorc/gdas.cd/test/atm/global-workflow/jedi-test_3dvar.yaml.j2"
+  FV3INC_JEDI_TEST_YAML: "${HOMEglobal}/sorc/gdas.cd/test/atm/global-workflow/jedi-test_3dvar-fv3inc.yaml.j2"
 
 atmensanl: 
   LAYOUT_X_ATMENSANL: 1
   LAYOUT_Y_ATMENSANL: 1
-  OBS_LIST_YAML: "${HOMEgfs}/sorc/gdas.cd/test/atm/global-workflow/atm_obs_list.yaml.j2"
-  LETKF_JEDI_TEST_YAML: "${HOMEgfs}/sorc/gdas.cd/test/atm/global-workflow/jedi-test_lgetkf.yaml.j2"
-  OBS_JEDI_TEST_YAML: "${HOMEgfs}/sorc/gdas.cd/test/atm/global-workflow/jedi-test_lgetkf-observer.yaml.j2"
-  SOL_JEDI_TEST_YAML: "${HOMEgfs}/sorc/gdas.cd/test/atm/global-workflow/jedi-test_lgetkf-solver.yaml.j2"
-  FV3INC_JEDI_TEST_YAML: "${HOMEgfs}/sorc/gdas.cd/test/atm/global-workflow/jedi-test_lgetkf-fv3inc.yaml.j2"
+  OBS_LIST_YAML: "${HOMEglobal}/sorc/gdas.cd/test/atm/global-workflow/atm_obs_list.yaml.j2"
+  LETKF_JEDI_TEST_YAML: "${HOMEglobal}/sorc/gdas.cd/test/atm/global-workflow/jedi-test_lgetkf.yaml.j2"
+  OBS_JEDI_TEST_YAML: "${HOMEglobal}/sorc/gdas.cd/test/atm/global-workflow/jedi-test_lgetkf-observer.yaml.j2"
+  SOL_JEDI_TEST_YAML: "${HOMEglobal}/sorc/gdas.cd/test/atm/global-workflow/jedi-test_lgetkf-solver.yaml.j2"
+  FV3INC_JEDI_TEST_YAML: "${HOMEglobal}/sorc/gdas.cd/test/atm/global-workflow/jedi-test_lgetkf-fv3inc.yaml.j2"

--- a/test/atm/global-workflow/jedi-test_3dvar-fv3inc.yaml.j2
+++ b/test/atm/global-workflow/jedi-test_3dvar-fv3inc.yaml.j2
@@ -1,7 +1,7 @@
 {% if RUN == 'gdas' and current_cycle | to_YMDH == '2021032318' %}
 do_testing: true
-test_reference_filename: {{ HOMEgfs }}/sorc/gdas.cd/test/testreference/atm_jjob_3dvar-fv3inc.ref
-test_output_filename: {{ HOMEgfs }}/sorc/gdas.cd/build/gdas/test/testoutput/atm_jjob_3dvar-fv3inc.test.out
+test_reference_filename: {{ HOMEglobal }}/sorc/gdas.cd/test/testreference/atm_jjob_3dvar-fv3inc.ref
+test_output_filename: {{ HOMEglobal }}/sorc/gdas.cd/build/gdas/test/testoutput/atm_jjob_3dvar-fv3inc.test.out
 test_float_relative_tolerance: 1.0e-3
 test_float_absolute_tolerance: 1.0e-5
 {% endif %}

--- a/test/atm/global-workflow/jedi-test_3dvar.yaml.j2
+++ b/test/atm/global-workflow/jedi-test_3dvar.yaml.j2
@@ -1,7 +1,7 @@
 {% if RUN == 'gdas' and current_cycle | to_YMDH == '2021032318' %}
 do_testing: true
-test_reference_filename: {{ HOMEgfs }}/sorc/gdas.cd/test/testreference/atm_jjob_3dvar.ref
-test_output_filename: {{ HOMEgfs }}/sorc/gdas.cd/build/gdas/test/testoutput/atm_jjob_3dvar.test.out
+test_reference_filename: {{ HOMEglobal }}/sorc/gdas.cd/test/testreference/atm_jjob_3dvar.ref
+test_output_filename: {{ HOMEglobal }}/sorc/gdas.cd/build/gdas/test/testoutput/atm_jjob_3dvar.test.out
 test_float_relative_tolerance: 1.0e-3
 test_float_absolute_tolerance: 1.0e-5
 {% endif %}

--- a/test/atm/global-workflow/jedi-test_lgetkf-fv3inc.yaml.j2
+++ b/test/atm/global-workflow/jedi-test_lgetkf-fv3inc.yaml.j2
@@ -1,7 +1,7 @@
 {% if RUN == 'enkfgdas' and current_cycle | to_YMDH == '2021032318' %}
 do_testing: true
-test_reference_filename: {{ HOMEgfs }}/sorc/gdas.cd/test/testreference/atm_jjob_lgetkf-fv3inc.ref
-test_output_filename: {{ HOMEgfs }}/sorc/gdas.cd/build/gdas/test/testoutput/atm_jjob_lgetkf-fv3inc.test.out
+test_reference_filename: {{ HOMEglobal }}/sorc/gdas.cd/test/testreference/atm_jjob_lgetkf-fv3inc.ref
+test_output_filename: {{ HOMEglobal }}/sorc/gdas.cd/build/gdas/test/testoutput/atm_jjob_lgetkf-fv3inc.test.out
 test_float_relative_tolerance: 1.0e-3
 test_float_absolute_tolerance: 1.0e-5
 {% endif %}

--- a/test/atm/global-workflow/jedi-test_lgetkf-observer.yaml.j2
+++ b/test/atm/global-workflow/jedi-test_lgetkf-observer.yaml.j2
@@ -1,7 +1,7 @@
 {% if RUN == 'enkfgdas' and current_cycle | to_YMDH == '2021032318' %}
 do_testing: true
-test_reference_filename: {{ HOMEgfs }}/sorc/gdas.cd/test/testreference/atm_jjob_lgetkf_observer.ref
-test_output_filename: {{ HOMEgfs }}/sorc/gdas.cd/build/gdas/test/testoutput/atm_jjob_lgetkf_observer.test.out
+test_reference_filename: {{ HOMEglobal }}/sorc/gdas.cd/test/testreference/atm_jjob_lgetkf_observer.ref
+test_output_filename: {{ HOMEglobal }}/sorc/gdas.cd/build/gdas/test/testoutput/atm_jjob_lgetkf_observer.test.out
 test_float_relative_tolerance: 1.0e-3
 test_float_absolute_tolerance: 1.0e-5
 {% endif %}

--- a/test/atm/global-workflow/jedi-test_lgetkf-solver.yaml.j2
+++ b/test/atm/global-workflow/jedi-test_lgetkf-solver.yaml.j2
@@ -1,7 +1,7 @@
 {% if RUN == 'enkfgdas' and current_cycle | to_YMDH == '2021032318' %}
 do_testing: true
-test_reference_filename: {{ HOMEgfs }}/sorc/gdas.cd/test/testreference/atm_jjob_lgetkf_solver.ref
-test_output_filename: {{ HOMEgfs }}/sorc/gdas.cd/build/gdas/test/testoutput/atm_jjob_lgetkf_solver.test.out
+test_reference_filename: {{ HOMEglobal }}/sorc/gdas.cd/test/testreference/atm_jjob_lgetkf_solver.ref
+test_output_filename: {{ HOMEglobal }}/sorc/gdas.cd/build/gdas/test/testoutput/atm_jjob_lgetkf_solver.test.out
 test_float_relative_tolerance: 1.0e-3
 test_float_absolute_tolerance: 1.0e-5
 {% endif %}

--- a/test/atm/global-workflow/jedi-test_lgetkf.yaml.j2
+++ b/test/atm/global-workflow/jedi-test_lgetkf.yaml.j2
@@ -1,7 +1,7 @@
 {% if RUN == 'enkfgdas' and current_cycle | to_YMDH == '2021032318' %}
 do_testing: true
-test_reference_filename: {{ HOMEgfs }}/sorc/gdas.cd/test/testreference/atm_jjob_lgetkf.ref
-test_output_filename: {{ HOMEgfs }}/sorc/gdas.cd/build/gdas/test/testoutput/atm_jjob_lgetkf.test.out
+test_reference_filename: {{ HOMEglobal }}/sorc/gdas.cd/test/testreference/atm_jjob_lgetkf.ref
+test_output_filename: {{ HOMEglobal }}/sorc/gdas.cd/build/gdas/test/testoutput/atm_jjob_lgetkf.test.out
 test_float_relative_tolerance: 1.0e-3
 test_float_absolute_tolerance: 1.0e-5
 {% endif %}

--- a/test/atm/global-workflow/jjob_ens_final.sh
+++ b/test/atm/global-workflow/jjob_ens_final.sh
@@ -6,9 +6,9 @@ srcdir=$2
 
 type="jjob_ens_final"
 
-# Set g-w HOMEgfs
+# Set g-w HOMEglobal
 topdir=$(cd "$(dirname "$(readlink -f -n "${bindir}" )" )/../../.." && pwd -P)
-export HOMEgfs=$topdir
+export HOMEglobal=$topdir
 
 # Set variables for ctest
 export PSLOT=gdas_test
@@ -27,20 +27,20 @@ export NMEM_ENS=3
 export ACCOUNT=da-cpu
 
 # Detect machine
-source "${HOMEgfs}/ush/detect_machine.sh"
+source "${HOMEglobal}/ush/detect_machine.sh"
 
-# Set up the PYTHONPATH to include wxflow from HOMEgfs
-if [[ -d "${HOMEgfs}/sorc/wxflow/src" ]]; then
-  PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${HOMEgfs}/sorc/wxflow/src"
+# Set up the PYTHONPATH to include wxflow from HOMEglobal
+if [[ -d "${HOMEglobal}/sorc/wxflow/src" ]]; then
+  PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${HOMEglobal}/sorc/wxflow/src"
 fi
 
 # Set python path for workflow utilities and tasks
-wxflowPATH="${HOMEgfs}/ush/python"
+wxflowPATH="${HOMEglobal}/ush/python"
 PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${wxflowPATH}"
 export PYTHONPATH
 
 # Export library path
-export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${HOMEgfs}/lib"
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${HOMEglobal}/lib"
 
 # Create yaml with job configuration
 memory="8Gb"
@@ -50,20 +50,20 @@ fi
 config_yaml="./config_${type}.yaml"
 cat <<EOF > ${config_yaml}
 machine: ${MACHINE_ID}
-homegfs: ${HOMEgfs}
+homegfs: ${HOMEglobal}
 job_name: ${type}
 walltime: "00:30:00"
 nodes: 1
 ntasks_per_node: 1
 threads_per_task: 1
 memory: ${memory}
-command: ${HOMEgfs}/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_FINALIZE
+command: ${HOMEglobal}/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_FINALIZE
 filename: submit_${type}.sh
 EOF
 
 # Create script to execute j-job
-$HOMEgfs/sorc/gdas.cd/test/workflow/generate_job_script.py ${config_yaml}
-SCHEDULER=$(echo `grep SCHEDULER ${HOMEgfs}/sorc/gdas.cd/test/workflow/hosts/${MACHINE_ID}.yaml | cut -d":" -f2` | tr -d ' ')
+$HOMEglobal/sorc/gdas.cd/test/workflow/generate_job_script.py ${config_yaml}
+SCHEDULER=$(echo `grep SCHEDULER ${HOMEglobal}/sorc/gdas.cd/test/workflow/hosts/${MACHINE_ID}.yaml | cut -d":" -f2` | tr -d ' ')
 
 # Submit script to execute j-job
 if [[ $SCHEDULER = 'slurm' ]]; then
@@ -71,5 +71,5 @@ if [[ $SCHEDULER = 'slurm' ]]; then
 elif [[ $SCHEDULER = 'pbspro' ]]; then
     qsub -V -W block=true submit_${type}.sh
 else
-    ${HOMEgfs}/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_FINALIZE
+    ${HOMEglobal}/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_FINALIZE
 fi

--- a/test/atm/global-workflow/jjob_ens_inc.sh
+++ b/test/atm/global-workflow/jjob_ens_inc.sh
@@ -6,9 +6,9 @@ srcdir=$2
 
 type="jjob_ens_inc"
 
-# Set g-w HOMEgfs
+# Set g-w HOMEglobal
 topdir=$(cd "$(dirname "$(readlink -f -n "${bindir}" )" )/../../.." && pwd -P)
-export HOMEgfs=$topdir
+export HOMEglobal=$topdir
 
 # Set variables for ctest
 export PSLOT=gdas_test
@@ -27,20 +27,20 @@ export NMEM_ENS=3
 export ACCOUNT=da-cpu
 
 # Detect machine
-source "${HOMEgfs}/ush/detect_machine.sh"
+source "${HOMEglobal}/ush/detect_machine.sh"
 
-# Set up the PYTHONPATH to include wxflow from HOMEgfs
-if [[ -d "${HOMEgfs}/sorc/wxflow/src" ]]; then
-  PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${HOMEgfs}/sorc/wxflow/src"
+# Set up the PYTHONPATH to include wxflow from HOMEglobal
+if [[ -d "${HOMEglobal}/sorc/wxflow/src" ]]; then
+  PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${HOMEglobal}/sorc/wxflow/src"
 fi
 
 # Set python path for workflow utilities and tasks
-wxflowPATH="${HOMEgfs}/ush/python"
+wxflowPATH="${HOMEglobal}/ush/python"
 PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${wxflowPATH}"
 export PYTHONPATH
 
 # Export library path
-export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${HOMEgfs}/lib"
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${HOMEglobal}/lib"
 
 # Create yaml with job configuration
 memory="8Gb"
@@ -50,20 +50,20 @@ fi
 config_yaml="./config_${type}.yaml"
 cat <<EOF > ${config_yaml}
 machine: ${MACHINE_ID}
-homegfs: ${HOMEgfs}
+homegfs: ${HOMEglobal}
 job_name: ${type}
 walltime: "00:30:00"
 nodes: 1
 ntasks_per_node: 6
 threads_per_task: 1
 memory: ${memory}
-command: ${HOMEgfs}/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_FV3_INCREMENT
+command: ${HOMEglobal}/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_FV3_INCREMENT
 filename: submit_${type}.sh
 EOF
 
 # Create script to execute j-job
-$HOMEgfs/sorc/gdas.cd/test/workflow/generate_job_script.py ${config_yaml}
-SCHEDULER=$(echo `grep SCHEDULER ${HOMEgfs}/sorc/gdas.cd/test/workflow/hosts/${MACHINE_ID}.yaml | cut -d":" -f2` | tr -d ' ')
+$HOMEglobal/sorc/gdas.cd/test/workflow/generate_job_script.py ${config_yaml}
+SCHEDULER=$(echo `grep SCHEDULER ${HOMEglobal}/sorc/gdas.cd/test/workflow/hosts/${MACHINE_ID}.yaml | cut -d":" -f2` | tr -d ' ')
 
 # Submit script to execute j-job
 if [[ $SCHEDULER = 'slurm' ]]; then
@@ -71,5 +71,5 @@ if [[ $SCHEDULER = 'slurm' ]]; then
 elif [[ $SCHEDULER = 'pbspro' ]]; then
     qsub -V -W block=true submit_${type}.sh
 else
-    ${HOMEgfs}/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_FV3_INCREMENT
+    ${HOMEglobal}/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_FV3_INCREMENT
 fi

--- a/test/atm/global-workflow/jjob_ens_init.sh
+++ b/test/atm/global-workflow/jjob_ens_init.sh
@@ -6,9 +6,9 @@ srcdir=$2
 
 type="jjob_ens_init"
 
-# Set g-w HOMEgfs
+# Set g-w HOMEglobal
 topdir=$(cd "$(dirname "$(readlink -f -n "${bindir}" )" )/../../.." && pwd -P)
-export HOMEgfs=$topdir
+export HOMEglobal=$topdir
 
 # Set variables for ctest
 export PSLOT=gdas_test
@@ -27,24 +27,24 @@ export ACCOUNT=da-cpu
 
 # Set GFS COM paths
 export STRICT="NO"
-source "${HOMEgfs}/ush/preamble.sh"
-source "${HOMEgfs}/dev/parm/config/gfs/config.com"
+source "${HOMEglobal}/ush/preamble.sh"
+source "${HOMEglobal}/dev/parm/config/gfs/config.com"
 
 # Detect machine
-source "${HOMEgfs}/ush/detect_machine.sh"
+source "${HOMEglobal}/ush/detect_machine.sh"
 
-# Set up the PYTHONPATH to include wxflow from HOMEgfs
-if [[ -d "${HOMEgfs}/sorc/wxflow/src" ]]; then
-  PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${HOMEgfs}/sorc/wxflow/src"
+# Set up the PYTHONPATH to include wxflow from HOMEglobal
+if [[ -d "${HOMEglobal}/sorc/wxflow/src" ]]; then
+  PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${HOMEglobal}/sorc/wxflow/src"
 fi
 
 # Set python path for workflow utilities and tasks
-wxflowPATH="${HOMEgfs}/ush/python"
+wxflowPATH="${HOMEglobal}/ush/python"
 PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${wxflowPATH}"
 export PYTHONPATH
 
 # Export library path
-export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${HOMEgfs}/lib"
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${HOMEglobal}/lib"
 
 # Set date variables for previous cycle
 gPDY=$(date +%Y%m%d -d "${PDY} ${cyc} - 6 hours")
@@ -114,20 +114,20 @@ fi
 config_yaml="./config_${type}.yaml"
 cat <<EOF > ${config_yaml}
 machine: ${MACHINE_ID}
-homegfs: ${HOMEgfs}
+homegfs: ${HOMEglobal}
 job_name: ${type}
 walltime: "00:30:00"
 nodes: 1
 ntasks_per_node: 1
 threads_per_task: 1
 memory: ${memory}
-command: ${HOMEgfs}/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_INITIALIZE
+command: ${HOMEglobal}/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_INITIALIZE
 filename: submit_${type}.sh
 EOF
 
 # Create script to execute j-job
-$HOMEgfs/sorc/gdas.cd/test/workflow/generate_job_script.py ${config_yaml}
-SCHEDULER=$(echo `grep SCHEDULER ${HOMEgfs}/sorc/gdas.cd/test/workflow/hosts/${MACHINE_ID}.yaml | cut -d":" -f2` | tr -d ' ')
+$HOMEglobal/sorc/gdas.cd/test/workflow/generate_job_script.py ${config_yaml}
+SCHEDULER=$(echo `grep SCHEDULER ${HOMEglobal}/sorc/gdas.cd/test/workflow/hosts/${MACHINE_ID}.yaml | cut -d":" -f2` | tr -d ' ')
 
 # Submit script to execute j-job
 if [[ $SCHEDULER = 'slurm' ]]; then
@@ -135,5 +135,5 @@ if [[ $SCHEDULER = 'slurm' ]]; then
 elif [[ $SCHEDULER = 'pbspro' ]]; then
     qsub -V -W block=true submit_${type}.sh
 else
-    ${HOMEgfs}/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_INITIALIZE
+    ${HOMEglobal}/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_INITIALIZE
 fi

--- a/test/atm/global-workflow/jjob_ens_init_split.sh
+++ b/test/atm/global-workflow/jjob_ens_init_split.sh
@@ -6,9 +6,9 @@ srcdir=$2
 
 type="jjob_ens_init_split"
 
-# Set g-w HOMEgfs
+# Set g-w HOMEglobal
 topdir=$(cd "$(dirname "$(readlink -f -n "${bindir}" )" )/../../.." && pwd -P)
-export HOMEgfs=$topdir
+export HOMEglobal=$topdir
 
 # Set variables for ctest
 export PSLOT=gdas_test
@@ -27,24 +27,24 @@ export ACCOUNT=da-cpu
 
 # Set GFS COM paths
 export STRICT="NO"
-source "${HOMEgfs}/ush/preamble.sh"
-source "${HOMEgfs}/dev/parm/config/gfs/config.com"
+source "${HOMEglobal}/ush/preamble.sh"
+source "${HOMEglobal}/dev/parm/config/gfs/config.com"
 
 # Detect machine
-source "${HOMEgfs}/ush/detect_machine.sh"
+source "${HOMEglobal}/ush/detect_machine.sh"
 
-# Set up the PYTHONPATH to include wxflow from HOMEgfs
-if [[ -d "${HOMEgfs}/sorc/wxflow/src" ]]; then
-  PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${HOMEgfs}/sorc/wxflow/src"
+# Set up the PYTHONPATH to include wxflow from HOMEglobal
+if [[ -d "${HOMEglobal}/sorc/wxflow/src" ]]; then
+  PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${HOMEglobal}/sorc/wxflow/src"
 fi
 
 # Set python path for workflow utilities and tasks
-wxflowPATH="${HOMEgfs}/ush/python"
+wxflowPATH="${HOMEglobal}/ush/python"
 PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${wxflowPATH}"
 export PYTHONPATH
 
 # Export library path
-export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${HOMEgfs}/lib"
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${HOMEglobal}/lib"
 
 # Set date variables for previous cycle
 gPDY=$(date +%Y%m%d -d "${PDY} ${cyc} - 6 hours")
@@ -117,20 +117,20 @@ fi
 config_yaml="./config_${type}.yaml"
 cat <<EOF > ${config_yaml}
 machine: ${MACHINE_ID}
-homegfs: ${HOMEgfs}
+homegfs: ${HOMEglobal}
 job_name: ${type}
 walltime: "00:30:00"
 nodes: 1
 ntasks_per_node: 1
 threads_per_task: 1
 memory: ${memory}
-command: ${HOMEgfs}/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_INITIALIZE
+command: ${HOMEglobal}/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_INITIALIZE
 filename: submit_${type}.sh
 EOF
 
 # Create script to execute j-job
-$HOMEgfs/sorc/gdas.cd/test/workflow/generate_job_script.py ${config_yaml}
-SCHEDULER=$(echo `grep SCHEDULER ${HOMEgfs}/sorc/gdas.cd/test/workflow/hosts/${MACHINE_ID}.yaml | cut -d":" -f2` | tr -d ' ')
+$HOMEglobal/sorc/gdas.cd/test/workflow/generate_job_script.py ${config_yaml}
+SCHEDULER=$(echo `grep SCHEDULER ${HOMEglobal}/sorc/gdas.cd/test/workflow/hosts/${MACHINE_ID}.yaml | cut -d":" -f2` | tr -d ' ')
 
 # Submit script to execute j-job
 if [[ $SCHEDULER = 'slurm' ]]; then
@@ -138,5 +138,5 @@ if [[ $SCHEDULER = 'slurm' ]]; then
 elif [[ $SCHEDULER = 'pbspro' ]]; then
     qsub -V -W block=true submit_${type}.sh
 else
-    ${HOMEgfs}/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_INITIALIZE
+    ${HOMEglobal}/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_INITIALIZE
 fi

--- a/test/atm/global-workflow/jjob_ens_letkf.sh
+++ b/test/atm/global-workflow/jjob_ens_letkf.sh
@@ -6,9 +6,9 @@ srcdir=$2
 
 type="jjob_ens_letkf"
 
-# Set g-w HOMEgfs
+# Set g-w HOMEglobal
 topdir=$(cd "$(dirname "$(readlink -f -n "${bindir}" )" )/../../.." && pwd -P)
-export HOMEgfs=$topdir
+export HOMEglobal=$topdir
 
 # Set variables for ctest
 export PSLOT=gdas_test
@@ -29,20 +29,20 @@ export NMEM_ENS=3
 export ACCOUNT=da-cpu
 
 # Detect machine
-source "${HOMEgfs}/ush/detect_machine.sh"
+source "${HOMEglobal}/ush/detect_machine.sh"
 
-# Set up the PYTHONPATH to include wxflow from HOMEgfs
-if [[ -d "${HOMEgfs}/sorc/wxflow/src" ]]; then
-  PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${HOMEgfs}/sorc/wxflow/src"
+# Set up the PYTHONPATH to include wxflow from HOMEglobal
+if [[ -d "${HOMEglobal}/sorc/wxflow/src" ]]; then
+  PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${HOMEglobal}/sorc/wxflow/src"
 fi
 
 # Set python path for workflow utilities and tasks
-wxflowPATH="${HOMEgfs}/ush/python"
+wxflowPATH="${HOMEglobal}/ush/python"
 PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${wxflowPATH}"
 export PYTHONPATH
 
 # Export library path
-export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${HOMEgfs}/lib"
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${HOMEglobal}/lib"
 
 # Set DO_JEDIATMENS_SPLIT_OBSSOL="NO" to run letkf as combined observer and solver job
 cp $EXPDIR/config.base_split_obssol_false $EXPDIR/config.base
@@ -55,20 +55,20 @@ fi
 config_yaml="./config_${type}.yaml"
 cat <<EOF > ${config_yaml}
 machine: ${MACHINE_ID}
-homegfs: ${HOMEgfs}
+homegfs: ${HOMEglobal}
 job_name: ${type}
 walltime: "00:30:00"
 nodes: 1
 ntasks_per_node: 6
 threads_per_task: 1
 memory: ${memory}
-command: ${HOMEgfs}/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_LETKF
+command: ${HOMEglobal}/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_LETKF
 filename: submit_${type}.sh
 EOF
 
 # Create script to execute j-job
-$HOMEgfs/sorc/gdas.cd/test/workflow/generate_job_script.py ${config_yaml}
-SCHEDULER=$(echo `grep SCHEDULER ${HOMEgfs}/sorc/gdas.cd/test/workflow/hosts/${MACHINE_ID}.yaml | cut -d":" -f2` | tr -d ' ')
+$HOMEglobal/sorc/gdas.cd/test/workflow/generate_job_script.py ${config_yaml}
+SCHEDULER=$(echo `grep SCHEDULER ${HOMEglobal}/sorc/gdas.cd/test/workflow/hosts/${MACHINE_ID}.yaml | cut -d":" -f2` | tr -d ' ')
 
 # Submit script to execute j-job
 if [[ $SCHEDULER = 'slurm' ]]; then
@@ -76,5 +76,5 @@ if [[ $SCHEDULER = 'slurm' ]]; then
 elif [[ $SCHEDULER = 'pbspro' ]]; then
     qsub -V -W block=true submit_${type}.sh
 else
-    ${HOMEgfs}/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_LETKF
+    ${HOMEglobal}/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_LETKF
 fi

--- a/test/atm/global-workflow/jjob_ens_obs.sh
+++ b/test/atm/global-workflow/jjob_ens_obs.sh
@@ -6,9 +6,9 @@ srcdir=$2
 
 type="jjob_ens_obs"
 
-# Set g-w HOMEgfs
+# Set g-w HOMEglobal
 topdir=$(cd "$(dirname "$(readlink -f -n "${bindir}" )" )/../../.." && pwd -P)
-export HOMEgfs=$topdir
+export HOMEglobal=$topdir
 
 # Set variables for ctest
 export PSLOT=gdas_test
@@ -29,20 +29,20 @@ export NMEM_ENS=3
 export ACCOUNT=da-cpu
 
 # Detect machine
-source "${HOMEgfs}/ush/detect_machine.sh"
+source "${HOMEglobal}/ush/detect_machine.sh"
 
-# Set up the PYTHONPATH to include wxflow from HOMEgfs
-if [[ -d "${HOMEgfs}/sorc/wxflow/src" ]]; then
-  PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${HOMEgfs}/sorc/wxflow/src"
+# Set up the PYTHONPATH to include wxflow from HOMEglobal
+if [[ -d "${HOMEglobal}/sorc/wxflow/src" ]]; then
+  PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${HOMEglobal}/sorc/wxflow/src"
 fi
 
 # Set python path for workflow utilities and tasks
-wxflowPATH="${HOMEgfs}/ush/python"
+wxflowPATH="${HOMEglobal}/ush/python"
 PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${wxflowPATH}"
 export PYTHONPATH
 
 # Export library path
-export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${HOMEgfs}/lib"
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${HOMEglobal}/lib"
 
 # Set DO_JEDIATMENS_SPLIT_OBSSOL="YES" to run letkf as stand-alone observer job
 cp $EXPDIR/config.base_split_obssol_true $EXPDIR/config.base
@@ -55,20 +55,20 @@ fi
 config_yaml="./config_${type}.yaml"
 cat <<EOF > ${config_yaml}
 machine: ${MACHINE_ID}
-homegfs: ${HOMEgfs}
+homegfs: ${HOMEglobal}
 job_name: ${type}
 walltime: "00:30:00"
 nodes: 1
 ntasks_per_node: 6
 threads_per_task: 1
 memory: ${memory}
-command: ${HOMEgfs}/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_OBS
+command: ${HOMEglobal}/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_OBS
 filename: submit_${type}.sh
 EOF
 
 # Create script to execute j-job
-$HOMEgfs/sorc/gdas.cd/test/workflow/generate_job_script.py ${config_yaml}
-SCHEDULER=$(echo `grep SCHEDULER ${HOMEgfs}/sorc/gdas.cd/test/workflow/hosts/${MACHINE_ID}.yaml | cut -d":" -f2` | tr -d ' ')
+$HOMEglobal/sorc/gdas.cd/test/workflow/generate_job_script.py ${config_yaml}
+SCHEDULER=$(echo `grep SCHEDULER ${HOMEglobal}/sorc/gdas.cd/test/workflow/hosts/${MACHINE_ID}.yaml | cut -d":" -f2` | tr -d ' ')
 
 # Submit script to execute j-job
 if [[ $SCHEDULER = 'slurm' ]]; then
@@ -76,5 +76,5 @@ if [[ $SCHEDULER = 'slurm' ]]; then
 elif [[ $SCHEDULER = 'pbspro' ]]; then
     qsub -V -W block=true submit_${type}.sh
 else
-    ${HOMEgfs}/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_OBS
+    ${HOMEglobal}/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_OBS
 fi

--- a/test/atm/global-workflow/jjob_ens_sol.sh
+++ b/test/atm/global-workflow/jjob_ens_sol.sh
@@ -6,9 +6,9 @@ srcdir=$2
 
 type="jjob_ens_sol"
 
-# Set g-w HOMEgfs
+# Set g-w HOMEglobal
 topdir=$(cd "$(dirname "$(readlink -f -n "${bindir}" )" )/../../.." && pwd -P)
-export HOMEgfs=$topdir
+export HOMEglobal=$topdir
 
 # Set variables for ctest
 export PSLOT=gdas_test
@@ -29,20 +29,20 @@ export NMEM_ENS=3
 export ACCOUNT=da-cpu
 
 # Detect machine
-source "${HOMEgfs}/ush/detect_machine.sh"
+source "${HOMEglobal}/ush/detect_machine.sh"
 
-# Set up the PYTHONPATH to include wxflow from HOMEgfs
-if [[ -d "${HOMEgfs}/sorc/wxflow/src" ]]; then
-  PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${HOMEgfs}/sorc/wxflow/src"
+# Set up the PYTHONPATH to include wxflow from HOMEglobal
+if [[ -d "${HOMEglobal}/sorc/wxflow/src" ]]; then
+  PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${HOMEglobal}/sorc/wxflow/src"
 fi
 
 # Set python path for workflow utilities and tasks
-wxflowPATH="${HOMEgfs}/ush/python"
+wxflowPATH="${HOMEglobal}/ush/python"
 PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${wxflowPATH}"
 export PYTHONPATH
 
 # Export library path
-export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${HOMEgfs}/lib"
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${HOMEglobal}/lib"
 
 # Set DO_JEDIATMENS_SPLIT_OBSSOL="YES" to run letkf as stand-alone solver job
 cp $EXPDIR/config.base_split_obssol_true $EXPDIR/config.base
@@ -55,20 +55,20 @@ fi
 config_yaml="./config_${type}.yaml"
 cat <<EOF > ${config_yaml}
 machine: ${MACHINE_ID}
-homegfs: ${HOMEgfs}
+homegfs: ${HOMEglobal}
 job_name: ${type}
 walltime: "00:30:00"
 nodes: 1
 ntasks_per_node: 6
 threads_per_task: 1
 memory: ${memory}
-command: ${HOMEgfs}/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_SOL
+command: ${HOMEglobal}/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_SOL
 filename: submit_${type}.sh
 EOF
 
 # Create script to execute j-job
-$HOMEgfs/sorc/gdas.cd/test/workflow/generate_job_script.py ${config_yaml}
-SCHEDULER=$(echo `grep SCHEDULER ${HOMEgfs}/sorc/gdas.cd/test/workflow/hosts/${MACHINE_ID}.yaml | cut -d":" -f2` | tr -d ' ')
+$HOMEglobal/sorc/gdas.cd/test/workflow/generate_job_script.py ${config_yaml}
+SCHEDULER=$(echo `grep SCHEDULER ${HOMEglobal}/sorc/gdas.cd/test/workflow/hosts/${MACHINE_ID}.yaml | cut -d":" -f2` | tr -d ' ')
 
 # Submit script to execute j-job
 if [[ $SCHEDULER = 'slurm' ]]; then
@@ -76,5 +76,5 @@ if [[ $SCHEDULER = 'slurm' ]]; then
 elif [[ $SCHEDULER = 'pbspro' ]]; then
     qsub -V -W block=true submit_${type}.sh
 else
-    ${HOMEgfs}/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_SOL
+    ${HOMEglobal}/dev/jobs/JGLOBAL_ATMENS_ANALYSIS_SOL
 fi

--- a/test/atm/global-workflow/jjob_var_final.sh
+++ b/test/atm/global-workflow/jjob_var_final.sh
@@ -6,9 +6,9 @@ srcdir=$2
 
 type="jjob_var_final"
 
-# Set g-w HOMEgfs
+# Set g-w HOMEglobal
 topdir=$(cd "$(dirname "$(readlink -f -n "${bindir}" )" )/../../.." && pwd -P)
-export HOMEgfs=$topdir
+export HOMEglobal=$topdir
 
 # Set variables for ctest
 export PSLOT=gdas_test
@@ -27,20 +27,20 @@ export NMEM_ENS=0
 export ACCOUNT=da-cpu
 
 # Detect machine
-source "${HOMEgfs}/ush/detect_machine.sh"
+source "${HOMEglobal}/ush/detect_machine.sh"
 
-# Set up the PYTHONPATH to include wxflow from HOMEgfs
-if [[ -d "${HOMEgfs}/sorc/wxflow/src" ]]; then
-  PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${HOMEgfs}/sorc/wxflow/src"
+# Set up the PYTHONPATH to include wxflow from HOMEglobal
+if [[ -d "${HOMEglobal}/sorc/wxflow/src" ]]; then
+  PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${HOMEglobal}/sorc/wxflow/src"
 fi
 
 # Set python path for workflow utilities and tasks
-wxflowPATH="${HOMEgfs}/ush/python"
+wxflowPATH="${HOMEglobal}/ush/python"
 PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${wxflowPATH}"
 export PYTHONPATH
 
 # Export library path
-export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${HOMEgfs}/lib"
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${HOMEglobal}/lib"
 
 # Create yaml with job configuration
 memory="8Gb"
@@ -50,20 +50,20 @@ fi
 config_yaml="./config_${type}.yaml"
 cat <<EOF > ${config_yaml}
 machine: ${MACHINE_ID}
-homegfs: ${HOMEgfs}
+homegfs: ${HOMEglobal}
 job_name: ${type}
 walltime: "00:30:00"
 nodes: 1
 ntasks_per_node: 1
 threads_per_task: 1
 memory: ${memory}
-command: ${HOMEgfs}/dev/jobs/JGLOBAL_ATM_ANALYSIS_FINALIZE
+command: ${HOMEglobal}/dev/jobs/JGLOBAL_ATM_ANALYSIS_FINALIZE
 filename: submit_${type}.sh
 EOF
 
 # Create script to execute j-job
-$HOMEgfs/sorc/gdas.cd/test/workflow/generate_job_script.py ${config_yaml}
-SCHEDULER=$(echo `grep SCHEDULER ${HOMEgfs}/sorc/gdas.cd/test/workflow/hosts/${MACHINE_ID}.yaml | cut -d":" -f2` | tr -d ' ')
+$HOMEglobal/sorc/gdas.cd/test/workflow/generate_job_script.py ${config_yaml}
+SCHEDULER=$(echo `grep SCHEDULER ${HOMEglobal}/sorc/gdas.cd/test/workflow/hosts/${MACHINE_ID}.yaml | cut -d":" -f2` | tr -d ' ')
 
 # Submit script to execute j-job
 if [[ $SCHEDULER = 'slurm' ]]; then
@@ -71,5 +71,5 @@ if [[ $SCHEDULER = 'slurm' ]]; then
 elif [[ $SCHEDULER = 'pbspro' ]]; then
     qsub -V -W block=true submit_${type}.sh
 else
-    ${HOMEgfs}/dev/jobs/JGLOBAL_ATM_ANALYSIS_FINALIZE
+    ${HOMEglobal}/dev/jobs/JGLOBAL_ATM_ANALYSIS_FINALIZE
 fi

--- a/test/atm/global-workflow/jjob_var_inc.sh
+++ b/test/atm/global-workflow/jjob_var_inc.sh
@@ -6,9 +6,9 @@ srcdir=$2
 
 type="jjob_var_inc"
 
-# Set g-w HOMEgfs
+# Set g-w HOMEglobal
 topdir=$(cd "$(dirname "$(readlink -f -n "${bindir}" )" )/../../.." && pwd -P)
-export HOMEgfs=$topdir
+export HOMEglobal=$topdir
 
 # Set variables for ctest
 export PSLOT=gdas_test
@@ -27,20 +27,20 @@ export NMEM_ENS=0
 export ACCOUNT=da-cpu
 
 # Detect machine
-source "${HOMEgfs}/ush/detect_machine.sh"
+source "${HOMEglobal}/ush/detect_machine.sh"
 
-# Set up the PYTHONPATH to include wxflow from HOMEgfs
-if [[ -d "${HOMEgfs}/sorc/wxflow/src" ]]; then
-  PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${HOMEgfs}/sorc/wxflow/src"
+# Set up the PYTHONPATH to include wxflow from HOMEglobal
+if [[ -d "${HOMEglobal}/sorc/wxflow/src" ]]; then
+  PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${HOMEglobal}/sorc/wxflow/src"
 fi
 
 # Set python path for workflow utilities and tasks
-wxflowPATH="${HOMEgfs}/ush/python"
+wxflowPATH="${HOMEglobal}/ush/python"
 PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${wxflowPATH}"
 export PYTHONPATH
 
 # Export library path
-export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${HOMEgfs}/lib"
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${HOMEglobal}/lib"
 
 # Create yaml with job confiugration
 memory="8Gb"
@@ -50,20 +50,20 @@ fi
 config_yaml="./config_${type}.yaml"
 cat <<EOF > ${config_yaml}
 machine: ${MACHINE_ID}
-homegfs: ${HOMEgfs}
+homegfs: ${HOMEglobal}
 job_name: ${type}
 walltime: "00:30:00"
 nodes: 1
 ntasks_per_node: 6
 threads_per_task: 1
 memory: ${memory}
-command: ${HOMEgfs}/dev/jobs/JGLOBAL_ATM_ANALYSIS_FV3_INCREMENT
+command: ${HOMEglobal}/dev/jobs/JGLOBAL_ATM_ANALYSIS_FV3_INCREMENT
 filename: submit_${type}.sh
 EOF
 
 # Create script to execute j-job
-$HOMEgfs/sorc/gdas.cd/test/workflow/generate_job_script.py ${config_yaml}
-SCHEDULER=$(echo `grep SCHEDULER ${HOMEgfs}/sorc/gdas.cd/test/workflow/hosts/${MACHINE_ID}.yaml | cut -d":" -f2` | tr -d ' ')
+$HOMEglobal/sorc/gdas.cd/test/workflow/generate_job_script.py ${config_yaml}
+SCHEDULER=$(echo `grep SCHEDULER ${HOMEglobal}/sorc/gdas.cd/test/workflow/hosts/${MACHINE_ID}.yaml | cut -d":" -f2` | tr -d ' ')
 
 # Submit script to execute j-job
 if [[ $SCHEDULER = 'slurm' ]]; then
@@ -71,5 +71,5 @@ if [[ $SCHEDULER = 'slurm' ]]; then
 elif [[ $SCHEDULER = 'pbspro' ]]; then
     qsub -V -W block=true submit_${type}.sh
 else
-    ${HOMEgfs}/dev/jobs/JGLOBAL_ATM_ANALYSIS_FV3_INCREMENT
+    ${HOMEglobal}/dev/jobs/JGLOBAL_ATM_ANALYSIS_FV3_INCREMENT
 fi

--- a/test/atm/global-workflow/jjob_var_init.sh
+++ b/test/atm/global-workflow/jjob_var_init.sh
@@ -6,9 +6,9 @@ srcdir=$2
 
 type="jjob_var_init"
 
-# Set g-w HOMEgfs
+# Set g-w HOMEglobal
 topdir=$(cd "$(dirname "$(readlink -f -n "${bindir}" )" )/../../.." && pwd -P)
-export HOMEgfs=$topdir
+export HOMEglobal=$topdir
 
 # Set variables for ctest
 export PSLOT=gdas_test
@@ -27,24 +27,24 @@ export ACCOUNT=da-cpu
 
 # Set GFS COM paths
 export STRICT="NO"
-source "${HOMEgfs}/ush/preamble.sh"
-source "${HOMEgfs}/dev/parm/config/gfs/config.com"
+source "${HOMEglobal}/ush/preamble.sh"
+source "${HOMEglobal}/dev/parm/config/gfs/config.com"
 
 # Detect machine
-source "${HOMEgfs}/ush/detect_machine.sh"
+source "${HOMEglobal}/ush/detect_machine.sh"
 
-# Set up the PYTHONPATH to include wxflow from HOMEgfs
-if [[ -d "${HOMEgfs}/sorc/wxflow/src" ]]; then
-  PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${HOMEgfs}/sorc/wxflow/src"
+# Set up the PYTHONPATH to include wxflow from HOMEglobal
+if [[ -d "${HOMEglobal}/sorc/wxflow/src" ]]; then
+  PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${HOMEglobal}/sorc/wxflow/src"
 fi
 
 # Set python path for workflow utilities and tasks
-wxflowPATH="${HOMEgfs}/ush/python"
+wxflowPATH="${HOMEglobal}/ush/python"
 PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${wxflowPATH}"
 export PYTHONPATH
 
 # Export library path
-export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${HOMEgfs}/lib"
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${HOMEglobal}/lib"
 
 # Set date variables for previous cycle
 gPDY=$(date +%Y%m%d -d "${PDY} ${cyc} - 6 hours")
@@ -123,20 +123,20 @@ fi
 config_yaml="./config_${type}.yaml"
 cat <<EOF > ${config_yaml}
 machine: ${MACHINE_ID}
-homegfs: ${HOMEgfs}
+homegfs: ${HOMEglobal}
 job_name: ${type}
 walltime: "00:30:00"
 nodes: 1
 ntasks_per_node: 1
 threads_per_task: 1
 memory: ${memory}
-command: ${HOMEgfs}/dev/jobs/JGLOBAL_ATM_ANALYSIS_INITIALIZE
+command: ${HOMEglobal}/dev/jobs/JGLOBAL_ATM_ANALYSIS_INITIALIZE
 filename: submit_${type}.sh
 EOF
 
 # Create script to execute j-job
-$HOMEgfs/sorc/gdas.cd/test/workflow/generate_job_script.py ${config_yaml}
-SCHEDULER=$(echo `grep SCHEDULER ${HOMEgfs}/sorc/gdas.cd/test/workflow/hosts/${MACHINE_ID}.yaml | cut -d":" -f2` | tr -d ' ')
+$HOMEglobal/sorc/gdas.cd/test/workflow/generate_job_script.py ${config_yaml}
+SCHEDULER=$(echo `grep SCHEDULER ${HOMEglobal}/sorc/gdas.cd/test/workflow/hosts/${MACHINE_ID}.yaml | cut -d":" -f2` | tr -d ' ')
 
 # Submit script to execute j-job
 if [[ $SCHEDULER = 'slurm' ]]; then
@@ -144,5 +144,5 @@ if [[ $SCHEDULER = 'slurm' ]]; then
 elif [[ $SCHEDULER = 'pbspro' ]]; then
     qsub -V -W block=true submit_${type}.sh
 else
-    ${HOMEgfs}/dev/jobs/JGLOBAL_ATM_ANALYSIS_INITIALIZE
+    ${HOMEglobal}/dev/jobs/JGLOBAL_ATM_ANALYSIS_INITIALIZE
 fi

--- a/test/atm/global-workflow/jjob_var_run.sh
+++ b/test/atm/global-workflow/jjob_var_run.sh
@@ -7,9 +7,9 @@ srcdir=$2
 
 type="jjob_var_run"
 
-# Set g-w HOMEgfs
+# Set g-w HOMEglobal
 topdir=$(cd "$(dirname "$(readlink -f -n "${bindir}" )" )/../../.." && pwd -P)
-export HOMEgfs=$topdir
+export HOMEglobal=$topdir
 
 # Set variables for ctest
 export PSLOT=gdas_test
@@ -30,20 +30,20 @@ export NMEM_ENS=0
 export ACCOUNT=da-cpu
 
 # Detect machine
-source "${HOMEgfs}/ush/detect_machine.sh"
+source "${HOMEglobal}/ush/detect_machine.sh"
 
-# Set up the PYTHONPATH to include wxflow from HOMEgfs
-if [[ -d "${HOMEgfs}/sorc/wxflow/src" ]]; then
-  PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${HOMEgfs}/sorc/wxflow/src"
+# Set up the PYTHONPATH to include wxflow from HOMEglobal
+if [[ -d "${HOMEglobal}/sorc/wxflow/src" ]]; then
+  PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${HOMEglobal}/sorc/wxflow/src"
 fi
 
 # Set python path for workflow utilities and tasks
-wxflowPATH="${HOMEgfs}/ush/python"
+wxflowPATH="${HOMEglobal}/ush/python"
 PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${wxflowPATH}"
 export PYTHONPATH
 
 # Export library path
-export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${HOMEgfs}/lib"
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${HOMEglobal}/lib"
 
 # Create yaml with job configuration
 memory="96Gb"
@@ -53,20 +53,20 @@ fi
 config_yaml="./config_${type}.yaml"
 cat <<EOF > ${config_yaml}
 machine: ${MACHINE_ID}
-homegfs: ${HOMEgfs}
+homegfs: ${HOMEglobal}
 job_name: ${type}
 walltime: "00:30:00"
 nodes: 1
 ntasks_per_node: 6
 threads_per_task: 1
 memory: ${memory}
-command: ${HOMEgfs}/dev/jobs/JGLOBAL_ATM_ANALYSIS_VARIATIONAL
+command: ${HOMEglobal}/dev/jobs/JGLOBAL_ATM_ANALYSIS_VARIATIONAL
 filename: submit_${type}.sh
 EOF
 
 # Create script to execute j-job. Set job scheduler
-${HOMEgfs}/sorc/gdas.cd/test/workflow/generate_job_script.py ${config_yaml}
-SCHEDULER=$(echo `grep SCHEDULER ${HOMEgfs}/sorc/gdas.cd/test/workflow/hosts/${MACHINE_ID}.yaml | cut -d":" -f2` | tr -d ' ')
+${HOMEglobal}/sorc/gdas.cd/test/workflow/generate_job_script.py ${config_yaml}
+SCHEDULER=$(echo `grep SCHEDULER ${HOMEglobal}/sorc/gdas.cd/test/workflow/hosts/${MACHINE_ID}.yaml | cut -d":" -f2` | tr -d ' ')
 
 # Submit script to execute j-job
 if [[ $SCHEDULER = 'slurm' ]]; then
@@ -74,5 +74,5 @@ if [[ $SCHEDULER = 'slurm' ]]; then
 elif [[ $SCHEDULER = 'pbspro' ]]; then
     qsub -V -W block=true submit_${type}.sh
 else
-    ${HOMEgfs}/dev/jobs/JGLOBAL_ATM_ANALYSIS_VARIATIONAL
+    ${HOMEglobal}/dev/jobs/JGLOBAL_ATM_ANALYSIS_VARIATIONAL
 fi

--- a/test/atm/global-workflow/setup_workflow_exp.sh
+++ b/test/atm/global-workflow/setup_workflow_exp.sh
@@ -4,9 +4,9 @@ set -x
 bindir=$1
 srcdir=$2
 
-# Set g-w HOMEgfs
+# Set g-w HOMEglobal
 topdir=$(cd "$(dirname "$(readlink -f -n "${bindir}" )" )/../../.." && pwd -P)
-export HOMEgfs=$topdir
+export HOMEglobal=$topdir
 
 # test experiment variables
 idate=2021032312
@@ -35,15 +35,15 @@ sed -i -e "s~@srcdir@~${srcdir}~g" config.yaml
 sed -i -e "s~@dumpdir@~${GDASAPP_TESTDATA}/lowres~g" config.yaml
 
 # Detect machine
-source "${HOMEgfs}/ush/detect_machine.sh"
+source "${HOMEglobal}/ush/detect_machine.sh"
 
-# Set up the PYTHONPATH to include wxflow from HOMEgfs
-if [[ -d "${HOMEgfs}/sorc/wxflow/src" ]]; then
-  PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${HOMEgfs}/sorc/wxflow/src"
+# Set up the PYTHONPATH to include wxflow from HOMEglobal
+if [[ -d "${HOMEglobal}/sorc/wxflow/src" ]]; then
+  PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${HOMEglobal}/sorc/wxflow/src"
 fi
 
 # Set python path for workflow utilities and tasks
-wxflowPATH="${HOMEgfs}/ush/python"
+wxflowPATH="${HOMEglobal}/ush/python"
 PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${wxflowPATH}"
 export PYTHONPATH
 

--- a/test/gw-ci/CMakeLists.txt
+++ b/test/gw-ci/CMakeLists.txt
@@ -417,7 +417,7 @@ if (WORKFLOW_TESTS)
   # -----------------------------------
   if(${TEST_GFS18})
     set(pslot "C48_ufsenkf_atmDA")
-    set(YAML_PATH ${HOMEgfs}/dev/ci/cases/pr/${pslot}.yaml)
+    set(YAML_PATH ${HOMEglobal}/dev/ci/cases/pr/${pslot}.yaml)
     set(HALF_CYCLE_TASKS
       "enkfgdas_stage_ic"
       "enkfgdas_fcst"
@@ -434,7 +434,7 @@ if (WORKFLOW_TESTS)
       "enkfgdas_esfc"
       "enkfgdas_fcst"
     )
-    add_cycling_tests(${pslot} ${YAML_PATH} ${HOMEgfs} ${WORKING_DIRECTORY} ${PROJECT_SOURCE_DIR} "${HALF_CYCLE_TASKS}" "${FULL_CYCLE_TASKS}")
+    add_cycling_tests(${pslot} ${YAML_PATH} ${HOMEglobal} ${WORKING_DIRECTORY} ${PROJECT_SOURCE_DIR} "${HALF_CYCLE_TASKS}" "${FULL_CYCLE_TASKS}")
   endif()  # TEST_V18
 
 # Aero DA C96

--- a/test/gw-ci/CMakeLists.txt
+++ b/test/gw-ci/CMakeLists.txt
@@ -256,13 +256,13 @@ function(add_task task_name test_prefix is_full_cycle HALF_CYCLE FULL_CYCLE pslo
 endfunction()
 
 # Function that generates the 1/2 cycle forecast and DA tasks
-function(add_cycling_tests pslot YAML_PATH HOMEgfs WORKING_DIRECTORY PROJECT_SOURCE_DIR HALF_CYCLE_TASKS FULL_CYCLE_TASKS)
+function(add_cycling_tests pslot YAML_PATH HOMEglobal WORKING_DIRECTORY PROJECT_SOURCE_DIR HALF_CYCLE_TASKS FULL_CYCLE_TASKS)
   set(test_prefix test_gdasapp_${pslot})
   # Prepare the COMROOT and EXPDIR for the cycling ctests
   ecbuild_add_test(TARGET ${test_prefix}
                    TYPE SCRIPT
                    COMMAND ${PROJECT_SOURCE_DIR}/test/gw-ci/create_exp.sh
-                   ARGS ${YAML_PATH} ${pslot} ${HOMEgfs} ${WORKING_DIRECTORY}
+                   ARGS ${YAML_PATH} ${pslot} ${HOMEglobal} ${WORKING_DIRECTORY}
                    WORKING_DIRECTORY ${WORKING_DIRECTORY})
 
   # Get the 1/2 cycle and full cycle's dates
@@ -302,14 +302,14 @@ if (WORKFLOW_TESTS)
   option(TEST_GFS17 "Enable the GFSv17 WCDA tests" OFF)
 
   # Setup the environement
-  set(HOMEgfs ${CMAKE_SOURCE_DIR}/../../..)
+  set(HOMEglobal ${CMAKE_SOURCE_DIR}/../../..)
   set(WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../../test/gw-ci)
 
   if(${TEST_GSI})
     # GSI Atm DA C96/C48
     # ------------------
     set(pslot "C96C48_hybatmDA")
-    set(YAML_PATH ${HOMEgfs}/dev/ci/cases/pr/${pslot}.yaml)
+    set(YAML_PATH ${HOMEglobal}/dev/ci/cases/pr/${pslot}.yaml)
     set(HALF_CYCLE_TASKS
       "gdas_stage_ic"
       "gdas_fcst"
@@ -332,14 +332,14 @@ if (WORKFLOW_TESTS)
       "enkfgdas_fcst"
     )
 
-    add_cycling_tests(${pslot} ${YAML_PATH} ${HOMEgfs} ${WORKING_DIRECTORY} ${PROJECT_SOURCE_DIR} "${HALF_CYCLE_TASKS}" "${FULL_CYCLE_TASKS}")
+    add_cycling_tests(${pslot} ${YAML_PATH} ${HOMEglobal} ${WORKING_DIRECTORY} ${PROJECT_SOURCE_DIR} "${HALF_CYCLE_TASKS}" "${FULL_CYCLE_TASKS}")
   endif()  # TEST_GSI
 
   # JEDI Atm DA C96/C48
   # -------------------
   if(${TEST_GFS18})
     set(pslot "C96C48_ufs_hybatmDA")
-    set(YAML_PATH ${HOMEgfs}/dev/ci/cases/pr/${pslot}.yaml)
+    set(YAML_PATH ${HOMEglobal}/dev/ci/cases/pr/${pslot}.yaml)
     set(HALF_CYCLE_TASKS
       "gdas_stage_ic"
       "gdas_fcst"
@@ -365,14 +365,14 @@ if (WORKFLOW_TESTS)
       "enkfgdas_esfc"
       "enkfgdas_fcst"
     )
-    add_cycling_tests(${pslot} ${YAML_PATH} ${HOMEgfs} ${WORKING_DIRECTORY} ${PROJECT_SOURCE_DIR} "${HALF_CYCLE_TASKS}" "${FULL_CYCLE_TASKS}")
+    add_cycling_tests(${pslot} ${YAML_PATH} ${HOMEglobal} ${WORKING_DIRECTORY} ${PROJECT_SOURCE_DIR} "${HALF_CYCLE_TASKS}" "${FULL_CYCLE_TASKS}")
   endif()  # TEST_V18
 
   # JEDI EnVar with GSI EnKF DA C96/C48
   # -----------------------------------
   if(${TEST_GFS18})
     set(pslot "C96C48_ufsgsi_hybatmDA")
-    set(YAML_PATH ${HOMEgfs}/dev/ci/cases/pr/${pslot}.yaml)
+    set(YAML_PATH ${HOMEglobal}/dev/ci/cases/pr/${pslot}.yaml)
     set(HALF_CYCLE_TASKS
       "gdas_stage_ic"
       "gdas_fcst"
@@ -397,7 +397,7 @@ if (WORKFLOW_TESTS)
       "enkfgdas_esfc"
       "enkfgdas_fcst"
     )
-    add_cycling_tests(${pslot} ${YAML_PATH} ${HOMEgfs} ${WORKING_DIRECTORY} ${PROJECT_SOURCE_DIR} "${HALF_CYCLE_TASKS}" "${FULL_CYCLE_TASKS}")
+    add_cycling_tests(${pslot} ${YAML_PATH} ${HOMEglobal} ${WORKING_DIRECTORY} ${PROJECT_SOURCE_DIR} "${HALF_CYCLE_TASKS}" "${FULL_CYCLE_TASKS}")
   endif()  # TEST_V18
 
 
@@ -405,7 +405,7 @@ if (WORKFLOW_TESTS)
   # ----------------
   if(${TEST_AERO})
     set(pslot "C96_gcafs_cycled")
-    set(YAML_PATH ${HOMEgfs}/dev/ci/cases/pr/${pslot}.yaml)
+    set(YAML_PATH ${HOMEglobal}/dev/ci/cases/pr/${pslot}.yaml)
     set(HALF_CYCLE_TASKS
       "gcdas_stage_ic"
       "gcdas_prep_emissions"
@@ -424,14 +424,14 @@ if (WORKFLOW_TESTS)
       "gcdas_prep_emissions"
       "gcdas_fcst"
     )
-    add_cycling_tests(${pslot} ${YAML_PATH} ${HOMEgfs} ${WORKING_DIRECTORY} ${PROJECT_SOURCE_DIR} "${HALF_CYCLE_TASKS}" "${FULL_CYCLE_TASKS}")
+    add_cycling_tests(${pslot} ${YAML_PATH} ${HOMEglobal} ${WORKING_DIRECTORY} ${PROJECT_SOURCE_DIR} "${HALF_CYCLE_TASKS}" "${FULL_CYCLE_TASKS}")
   endif()  # TEST_AERO
 
 # Land DA C96
   # ----------------
   if(${TEST_LAND})
     set(pslot "C96C48_hybatmsnowDA")
-    set(YAML_PATH ${HOMEgfs}/dev/ci/cases/pr/${pslot}.yaml)
+    set(YAML_PATH ${HOMEglobal}/dev/ci/cases/pr/${pslot}.yaml)
     set(HALF_CYCLE_TASKS
       "gdas_stage_ic"
       "gdas_fcst"
@@ -455,14 +455,14 @@ if (WORKFLOW_TESTS)
       "enkfgdas_esfc"
       "enkfgdas_fcst"
     )
-    add_cycling_tests(${pslot} ${YAML_PATH} ${HOMEgfs} ${WORKING_DIRECTORY} ${PROJECT_SOURCE_DIR} "${HALF_CYCLE_TASKS}" "${FULL_CYCLE_TASKS}")
+    add_cycling_tests(${pslot} ${YAML_PATH} ${HOMEglobal} ${WORKING_DIRECTORY} ${PROJECT_SOURCE_DIR} "${HALF_CYCLE_TASKS}" "${FULL_CYCLE_TASKS}")
   endif()  # TEST_LAND
 
   if(${TEST_MARINE_VAR})
     # GSI Atm DA C48, JEDI Marine DA 500
     # ----------------------------------
     set(pslot "C48mx500_3DVarAOWCDA")
-    set(YAML_PATH ${HOMEgfs}/dev/ci/cases/pr/${pslot}.yaml)
+    set(YAML_PATH ${HOMEglobal}/dev/ci/cases/pr/${pslot}.yaml)
     set(HALF_CYCLE_TASKS
       "gdas_stage_ic"
       "gdas_waveinit"
@@ -481,7 +481,7 @@ if (WORKFLOW_TESTS)
       #"gdas_sfcanl"
       #"gdas_fcst"
       )
-    add_cycling_tests(${pslot} ${YAML_PATH} ${HOMEgfs} ${WORKING_DIRECTORY} ${PROJECT_SOURCE_DIR} "${HALF_CYCLE_TASKS}" "${FULL_CYCLE_TASKS}")
+    add_cycling_tests(${pslot} ${YAML_PATH} ${HOMEglobal} ${WORKING_DIRECTORY} ${PROJECT_SOURCE_DIR} "${HALF_CYCLE_TASKS}" "${FULL_CYCLE_TASKS}")
   endif()  # TEST_MARINE_VAR
 
   if(${TEST_MARINE_HYB})
@@ -489,7 +489,7 @@ if (WORKFLOW_TESTS)
     # -------------
     set(pslot "C48mx500_hybAOWCDA")
     set(letkf TRUE)
-    set(YAML_PATH ${HOMEgfs}/dev/ci/cases/pr/${pslot}.yaml)
+    set(YAML_PATH ${HOMEglobal}/dev/ci/cases/pr/${pslot}.yaml)
     set(HALF_CYCLE_TASKS
       "gdas_stage_ic"
       "gdas_fcst"
@@ -506,7 +506,7 @@ if (WORKFLOW_TESTS)
       "gdas_marineanlchkpt"
       "gdas_marineanlfinal"
       )
-    add_cycling_tests(${pslot} ${YAML_PATH} ${HOMEgfs} ${WORKING_DIRECTORY} ${PROJECT_SOURCE_DIR} "${HALF_CYCLE_TASKS}" "${FULL_CYCLE_TASKS}")
+    add_cycling_tests(${pslot} ${YAML_PATH} ${HOMEglobal} ${WORKING_DIRECTORY} ${PROJECT_SOURCE_DIR} "${HALF_CYCLE_TASKS}" "${FULL_CYCLE_TASKS}")
     set(letkf FALSE)
   endif()  # TEST_MARINE_HYB
 
@@ -514,7 +514,7 @@ if (WORKFLOW_TESTS)
   # -----------------------
   if(TEST_GFS17)
     set(pslot "C384mx025_3DVarAOWCDA")
-    set(YAML_PATH ${HOMEgfs}/dev/ci/cases/gfsv17/${pslot}.yaml)
+    set(YAML_PATH ${HOMEglobal}/dev/ci/cases/gfsv17/${pslot}.yaml)
     set(HALF_CYCLE_TASKS
       "gdas_stage_ic"
       "gdas_fcst")
@@ -532,6 +532,6 @@ if (WORKFLOW_TESTS)
       "gdas_sfcanl"
       "gdas_fcst"
       )
-    add_cycling_tests(${pslot} ${YAML_PATH} ${HOMEgfs} ${WORKING_DIRECTORY} ${PROJECT_SOURCE_DIR} "${HALF_CYCLE_TASKS}" "${FULL_CYCLE_TASKS}")
+    add_cycling_tests(${pslot} ${YAML_PATH} ${HOMEglobal} ${WORKING_DIRECTORY} ${PROJECT_SOURCE_DIR} "${HALF_CYCLE_TASKS}" "${FULL_CYCLE_TASKS}")
   endif()
 endif()

--- a/test/gw-ci/atm/jedi-test_3dvar-fv3inc_ufs_hybatmDA.yaml.j2
+++ b/test/gw-ci/atm/jedi-test_3dvar-fv3inc_ufs_hybatmDA.yaml.j2
@@ -1,7 +1,7 @@
 {% if RUN == 'gdas' and current_cycle | to_YMDH == '2024022400' and machine != 'WCOSS2' %}
 do_testing: true
-test_reference_filename: {{ HOMEgfs }}/sorc/gdas.cd/test/testreference/{{ CASE }}{{ CASE_ENS }}_ufs_hybatmDA_3dvar-fv3inc.ref
-test_output_filename: {{ HOMEgfs }}/sorc/gdas.cd/build/gdas/test/testoutput/{{ CASE }}{{ CASE_ENS }}_ufs_hybatmDA_3dvar-fv3inc.test.out
+test_reference_filename: {{ HOMEglobal }}/sorc/gdas.cd/test/testreference/{{ CASE }}{{ CASE_ENS }}_ufs_hybatmDA_3dvar-fv3inc.ref
+test_output_filename: {{ HOMEglobal }}/sorc/gdas.cd/build/gdas/test/testoutput/{{ CASE }}{{ CASE_ENS }}_ufs_hybatmDA_3dvar-fv3inc.test.out
 test_float_relative_tolerance: 1.0e-3
 test_float_absolute_tolerance: 1.0e-5
 {% endif %}

--- a/test/gw-ci/atm/jedi-test_3dvar_ufs_hybatmDA.yaml.j2
+++ b/test/gw-ci/atm/jedi-test_3dvar_ufs_hybatmDA.yaml.j2
@@ -1,7 +1,7 @@
 {% if RUN == 'gdas' and current_cycle | to_YMDH == '2024022400' and machine != 'WCOSS2' %}
 do_testing: true
-test_reference_filename: {{ HOMEgfs }}/sorc/gdas.cd/test/testreference/{{ CASE }}{{ CASE_ENS }}_ufs_hybatmDA_3dvar.ref
-test_output_filename: {{ HOMEgfs }}/sorc/gdas.cd/build/gdas/test/testoutput/{{ CASE }}{{ CASE_ENS }}_ufs_hybatmDA_3dvar.test.out
+test_reference_filename: {{ HOMEglobal }}/sorc/gdas.cd/test/testreference/{{ CASE }}{{ CASE_ENS }}_ufs_hybatmDA_3dvar.ref
+test_output_filename: {{ HOMEglobal }}/sorc/gdas.cd/build/gdas/test/testoutput/{{ CASE }}{{ CASE_ENS }}_ufs_hybatmDA_3dvar.test.out
 test_float_relative_tolerance: 1.0e-3
 test_float_absolute_tolerance: 1.0e-5
 {% endif %}

--- a/test/gw-ci/atm/jedi-test_lgetkf-fv3inc_ufs_hybatmDA.yaml.j2
+++ b/test/gw-ci/atm/jedi-test_lgetkf-fv3inc_ufs_hybatmDA.yaml.j2
@@ -1,7 +1,7 @@
 {% if RUN == 'enkfgdas' and current_cycle | to_YMDH == '2024022400' and machine != 'WCOSS2' %}
 do_testing: true
-test_reference_filename: {{ HOMEgfs }}/sorc/gdas.cd/test/testreference/{{ CASE }}{{ CASE_ENS }}_ufs_hybatmDA_lgetkf-fv3inc.ref
-test_output_filename: {{ HOMEgfs }}/sorc/gdas.cd/build/gdas/test/testoutput/{{ CASE }}{{ CASE_ENS }}_ufs_hybatmDA_lgetkf-fv3inc.test.out
+test_reference_filename: {{ HOMEglobal }}/sorc/gdas.cd/test/testreference/{{ CASE }}{{ CASE_ENS }}_ufs_hybatmDA_lgetkf-fv3inc.ref
+test_output_filename: {{ HOMEglobal }}/sorc/gdas.cd/build/gdas/test/testoutput/{{ CASE }}{{ CASE_ENS }}_ufs_hybatmDA_lgetkf-fv3inc.test.out
 test_float_relative_tolerance: 1.0e-3
 test_float_absolute_tolerance: 1.0e-5
 {% endif %}

--- a/test/gw-ci/atm/jedi-test_lgetkf-observer_ufs_hybatmDA.yaml.j2
+++ b/test/gw-ci/atm/jedi-test_lgetkf-observer_ufs_hybatmDA.yaml.j2
@@ -1,7 +1,7 @@
 {% if RUN == 'enkfgdas' and current_cycle | to_YMDH == '2024022400' and machine != 'WCOSS2' %}
 do_testing: true
-test_reference_filename: {{ HOMEgfs }}/sorc/gdas.cd/test/testreference/{{ CASE }}{{ CASE_ENS }}_ufs_hybatmDA_lgetkf_observer.ref
-test_output_filename: {{ HOMEgfs }}/sorc/gdas.cd/build/gdas/test/testoutput/{{ CASE }}{{ CASE_ENS }}_ufs_hybatmDA_lgetkf_observer.test.out
+test_reference_filename: {{ HOMEglobal }}/sorc/gdas.cd/test/testreference/{{ CASE }}{{ CASE_ENS }}_ufs_hybatmDA_lgetkf_observer.ref
+test_output_filename: {{ HOMEglobal }}/sorc/gdas.cd/build/gdas/test/testoutput/{{ CASE }}{{ CASE_ENS }}_ufs_hybatmDA_lgetkf_observer.test.out
 test_float_relative_tolerance: 1.0e-3
 test_float_absolute_tolerance: 1.0e-5
 {% endif %}

--- a/test/gw-ci/atm/jedi-test_lgetkf-solver_ufs_hybatmDA.yaml.j2
+++ b/test/gw-ci/atm/jedi-test_lgetkf-solver_ufs_hybatmDA.yaml.j2
@@ -1,7 +1,7 @@
 {% if RUN == 'enkfgdas' and current_cycle | to_YMDH == '2024022400' and machine != 'WCOSS2' %}
 do_testing: true
-test_reference_filename: {{ HOMEgfs }}/sorc/gdas.cd/test/testreference/{{ CASE }}{{ CASE_ENS }}_ufs_hybatmDA_lgetkf_solver.ref
-test_output_filename: {{ HOMEgfs }}/sorc/gdas.cd/build/gdas/test/testoutput/{{ CASE }}{{ CASE_ENS }}_ufs_hybatmDA_lgetkf_solver.test.out
+test_reference_filename: {{ HOMEglobal }}/sorc/gdas.cd/test/testreference/{{ CASE }}{{ CASE_ENS }}_ufs_hybatmDA_lgetkf_solver.ref
+test_output_filename: {{ HOMEglobal }}/sorc/gdas.cd/build/gdas/test/testoutput/{{ CASE }}{{ CASE_ENS }}_ufs_hybatmDA_lgetkf_solver.test.out
 test_float_relative_tolerance: 1.0e-3
 test_float_absolute_tolerance: 1.0e-5
 {% endif %}

--- a/test/gw-ci/atm/jedi-test_lgetkf_ufs_hybatmDA.yaml.j2
+++ b/test/gw-ci/atm/jedi-test_lgetkf_ufs_hybatmDA.yaml.j2
@@ -1,7 +1,7 @@
 {% if RUN == 'enkfgdas' and current_cycle | to_YMDH == '2024022400' and machine != 'WCOSS2' %}
 do_testing: true
-test_reference_filename: {{ HOMEgfs }}/sorc/gdas.cd/test/testreference/{{ CASE }}{{ CASE_ENS }}_ufs_hybatmDA_lgetkf.ref
-test_output_filename: {{ HOMEgfs }}/sorc/gdas.cd/build/gdas/test/testoutput/{{ CASE }}{{ CASE_ENS }}_ufs_hybatmDA_lgetkf.test.out
+test_reference_filename: {{ HOMEglobal }}/sorc/gdas.cd/test/testreference/{{ CASE }}{{ CASE_ENS }}_ufs_hybatmDA_lgetkf.ref
+test_output_filename: {{ HOMEglobal }}/sorc/gdas.cd/build/gdas/test/testoutput/{{ CASE }}{{ CASE_ENS }}_ufs_hybatmDA_lgetkf.test.out
 test_float_relative_tolerance: 1.0e-3
 test_float_absolute_tolerance: 1.0e-5
 {% endif %}

--- a/test/gw-ci/create_exp.sh
+++ b/test/gw-ci/create_exp.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 expyaml_ctest="$1"
 pslot_ctest="$2"
-HOMEgfs="$3"
+HOMEglobal="$3"
 exp_path=$4
 
 # Get ICSDIR_ROOT
-source "${HOMEgfs}/ush/detect_machine.sh"
-source "${HOMEgfs}/dev/ci/platforms/config.${MACHINE_ID}"
+source "${HOMEglobal}/ush/detect_machine.sh"
+source "${HOMEglobal}/dev/ci/platforms/config.${MACHINE_ID}"
 
 # Arguments for the exp setup
 expyaml=${expyaml_ctest}
@@ -20,7 +20,7 @@ elif [[ $MACHINE_ID = gaeac6 ]]; then
 fi  
 
 # Source the gw environement
-source ${HOMEgfs}/dev/ush/gw_setup.sh
+source ${HOMEglobal}/dev/ush/gw_setup.sh
 
 # Create the experiment
-${HOMEgfs}/dev/workflow/create_experiment.py --yaml ${expyaml} --overwrite
+${HOMEglobal}/dev/workflow/create_experiment.py --yaml ${expyaml} --overwrite

--- a/test/gw-ci/soca/jcb-prototype_3dfgat_3DVarAOWCDA.yaml.j2
+++ b/test/gw-ci/soca/jcb-prototype_3dfgat_3DVarAOWCDA.yaml.j2
@@ -8,8 +8,8 @@ algorithm: 3dfgat
 # --------------
 {% if DO_TEST_MODE == true and RUN == 'gdas' and current_cycle | to_YMDH == '2021032418' and machine != 'WCOSS2' %}
 do_testing: true
-test_reference_filename: '{{HOMEgfs}}/sorc/gdas.cd/test/testreference/{{ CASE }}mx{{ OCNRES }}_3DVarAOWCDA_3dfgat.ref'
-test_output_filename: '{{HOMEgfs}}/sorc/gdas.cd/build/gdas/test/testoutput/{{ CASE }}mx{{ OCNRES }}_3DVarAOWCDA_3dfgat.test.out'
+test_reference_filename: '{{HOMEglobal}}/sorc/gdas.cd/test/testreference/{{ CASE }}mx{{ OCNRES }}_3DVarAOWCDA_3dfgat.ref'
+test_output_filename: '{{HOMEglobal}}/sorc/gdas.cd/build/gdas/test/testoutput/{{ CASE }}mx{{ OCNRES }}_3DVarAOWCDA_3dfgat.test.out'
 test_float_relative_tolerance: 1.0e-3
 test_float_absolute_tolerance: 1.0e-5
 {% endif %}

--- a/test/snow/apply_jedi_incr.sh
+++ b/test/snow/apply_jedi_incr.sh
@@ -18,23 +18,23 @@ EXECDIR=$project_source_dir/build/bin
 WORKDIR=$project_binary_dir/test/snow/apply_jedi_incr
 RSTDIR=$GDASAPP_TESTDATA/lowres/gdas.$GYMD/$GHR/model/atmos/restart
 INCDIR=$GDASAPP_TESTDATA/snow/C${RES}
-HOMEgfs=$project_source_dir/../../
+HOMEglobal=$project_source_dir/../../
 
 # Detect machine
-source "${HOMEgfs}/ush/detect_machine.sh"
+source "${HOMEglobal}/ush/detect_machine.sh"
 
-# Set up the PYTHONPATH to include wxflow from HOMEgfs
-if [[ -d "${HOMEgfs}/sorc/wxflow/src" ]]; then
-    PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${HOMEgfs}/sorc/wxflow/src"
+# Set up the PYTHONPATH to include wxflow from HOMEglobal
+if [[ -d "${HOMEglobal}/sorc/wxflow/src" ]]; then
+    PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${HOMEglobal}/sorc/wxflow/src"
 fi
 
 # Set python path for workflow utilities and tasks
-wxflowPATH="${HOMEgfs}/ush/python"
+wxflowPATH="${HOMEglobal}/ush/python"
 PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${wxflowPATH}"
 export PYTHONPATH
 
 # Export library path
-export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${HOMEgfs}/lib"
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${HOMEglobal}/lib"
 
 export TPATH="$GDASAPP_TESTDATA/snow/C${RES}"
 export TSTUB="C${RES}_oro_data"
@@ -119,7 +119,7 @@ submitsh="./submit.sh"
 config_yaml="./config.yaml"
 cat <<EOF > ${config_yaml}
 machine: ${MACHINE_ID}
-homegfs: ${HOMEgfs}
+homegfs: ${HOMEglobal}
 job_name: apply_jedi_incr
 walltime: "00:30:00"
 nodes: 1
@@ -132,8 +132,8 @@ EOF
 
 
 # Create submission script
-$HOMEgfs/sorc/gdas.cd/test/workflow/generate_job_script.py ${config_yaml}
-SCHEDULER=$(echo `grep SCHEDULER ${HOMEgfs}/sorc/gdas.cd/test/workflow/hosts/${MACHINE_ID}.yaml | cut -d":" -f2` | tr -d ' ')
+$HOMEglobal/sorc/gdas.cd/test/workflow/generate_job_script.py ${config_yaml}
+SCHEDULER=$(echo `grep SCHEDULER ${HOMEglobal}/sorc/gdas.cd/test/workflow/hosts/${MACHINE_ID}.yaml | cut -d":" -f2` | tr -d ' ')
 
 # Submit script
 if [[ $SCHEDULER = 'slurm' ]]; then

--- a/ush/gsi_satbias2ioda_all.sh
+++ b/ush/gsi_satbias2ioda_all.sh
@@ -3,7 +3,7 @@
 set -ex
 
 # Source UFSDA workflow modules
-source "${HOMEgfs}/dev/ush/load_modules.sh" ufsda
+source "${HOMEglobal}/dev/ush/load_modules.sh" ufsda
 status=$?
 if [[ ${status} -ne 0 ]]; then
     exit "${status}"
@@ -19,8 +19,8 @@ ABIAS=${COMOUT_ATMOS_ANALYSIS_PREV}/${GDUMP}.t${gcyc}z.abias.txt
 ABIASPC=${COMOUT_ATMOS_ANALYSIS_PREV}/${GDUMP}.t${gcyc}z.abias_pc.txt
 ABIAS_JEDI=${COMOUT_ATMOS_ANALYSIS_PREV}/${GDUMP}.t${gcyc}z.rad_varbc_params.tar
 
-satbias2ioda_x=${HOMEgfs}/sorc/gdas.cd/build/bin/satbias2ioda.x
-satbias2ioda_y=${HOMEgfs}/sorc/gdas.cd/ush/satbias_converter.yaml.tmpl
+satbias2ioda_x=${HOMEglobal}/sorc/gdas.cd/build/bin/satbias2ioda.x
+satbias2ioda_y=${HOMEglobal}/sorc/gdas.cd/ush/satbias_converter.yaml.tmpl
 
 
 # Create work directory

--- a/ush/soca/bkg_utils.py
+++ b/ush/soca/bkg_utils.py
@@ -17,7 +17,7 @@ logger = Logger()
 # get absolute path of ush/ directory either from env or relative to this file
 my_dir = os.path.dirname(__file__)
 my_home = os.path.dirname(os.path.dirname(my_dir))
-gdas_home = os.path.join(os.getenv('HOMEgfs'), 'sorc', 'gdas.cd')
+gdas_home = os.path.join(os.getenv('HOMEglobal'), 'sorc', 'gdas.cd')
 
 
 def agg_seaice(fname_in, fname_out):

--- a/ush/soca/prep_ocean_obs.py
+++ b/ush/soca/prep_ocean_obs.py
@@ -89,7 +89,7 @@ class PrepOceanObs(Task):
         run_date = self.task_config['PDY'].strftime('%Y%m%d')
         cycle = str(self.task_config['cyc']).zfill(2)  # ensures '00', '06', etc.
         run = self.task_config['RUN']
-        PARMgfs = self.task_config['PARMgfs']
+        PARMglobal = self.task_config['PARMglobal']
 
         # Ensure output directory exists
         os.makedirs(comout_obs, exist_ok=True)
@@ -122,7 +122,7 @@ class PrepOceanObs(Task):
             dummy_source = "sst_avhrr_ma_l3u"
             output_nc = f"{run}.t{cycle}z.{dummy_source}.nc"
             # TODO (AFE) replace this with something set in a config file
-            dummy_cdl = os.path.join(PARMgfs, 'gdas', 'marine', 'marine_prepobs_dummyobs.cdl')
+            dummy_cdl = os.path.join(PARMglobal, 'gdas', 'marine', 'marine_prepobs_dummyobs.cdl')
 
             converter = Executable('ncgen')
             converter.add_default_arg('-o')

--- a/ush/soca/run_jjobs.py
+++ b/ush/soca/run_jjobs.py
@@ -41,7 +41,7 @@ class JobCard:
             return
 
         self.pslot = config['gw environement']['experiment identifier']['PSLOT']
-        self.homegfs = config['gw environement']['experiment identifier']['HOMEgfs']
+        self.homegfs = config['gw environement']['experiment identifier']['HOMEglobal']
         self.stmp = config['gw environement']['working directories']['STMP']
         self.rotdirs = config['gw environement']['working directories']['ROTDIRS']
         self.rotdir = os.path.join(self.rotdirs, self.pslot)
@@ -93,7 +93,7 @@ class JobCard:
         self.f.write(f"export gcyc='{gcyc}'\n")
 
         # Add to python environment
-        self.f.write("PYTHONPATH=${HOMEgfs}/ush/python:${PYTHONPATH}\n")
+        self.f.write("PYTHONPATH=${HOMEglobal}/ush/python:${PYTHONPATH}\n")
 
     def setupexpt(self):
         """
@@ -101,7 +101,7 @@ class JobCard:
         """
 
         # Make a copy of the configs
-        origconfig = "${HOMEgfs}/dev/parm/config/gfs"
+        origconfig = "${HOMEglobal}/dev/parm/config/gfs"
         self.f.write("\n")
         self.f.write("# Make a copy of config\n")
         self.f.write(f"mkdir -p config\n")
@@ -115,7 +115,7 @@ class JobCard:
         self.f.write("\n")
         self.f.write("# Setup the experiment\n")
 
-        setupexpt = "${HOMEgfs}/workflow/setup_expt.py gfs cycled "
+        setupexpt = "${HOMEglobal}/workflow/setup_expt.py gfs cycled "
         # Most of the args keys are not used to run the jjobs but are needed to run setup_expt.py
         args = {
             "idate": "${PDY}${cyc}",
@@ -173,8 +173,8 @@ class JobCard:
         print(f"RUN: {self.RUN}")
 
         # setup COM variables
-        self.f.write("source ${HOMEgfs}/dev/parm/config/gfs/config.com\n")
-        self.f.write("source ${HOMEgfs}/ush/preamble.sh\n")
+        self.f.write("source ${HOMEglobal}/dev/parm/config/gfs/config.com\n")
+        self.f.write("source ${HOMEglobal}/ush/preamble.sh\n")
         self.precom('COM_OCEAN_HISTORY_PREV', 'COM_OCEAN_HISTORY_TMPL')
         self.precom('COM_ICE_HISTORY_PREV', 'COM_ICE_HISTORY_TMPL')
         self.precom('COM_ICE_RESTART_PREV', 'COM_ICE_RESTART_TMPL')
@@ -215,7 +215,7 @@ class JobCard:
 
         # swap a few variables in config.base
         self.homegfs_real = os.path.realpath(self.homegfs)
-        var2replace = {'HOMEgfs': self.homegfs_real,
+        var2replace = {'HOMEglobal': self.homegfs_real,
                        'STMP': self.stmp,
                        'ROTDIR': self.rotdir,
                        'EXPDIRS': self.expdirs}
@@ -237,7 +237,7 @@ class JobCard:
         """
         for job in self.config['jjobs']:
             self._conda_envs(job)  # Add module's jjob
-            thejob = "${HOMEgfs}/jobs/"+job
+            thejob = "${HOMEglobal}/jobs/"+job
             runjob = f"{thejob} &>{job}.out\n"
             self.f.write(runjob)
 

--- a/ush/ufoeval/README_phase3
+++ b/ush/ufoeval/README_phase3
@@ -15,7 +15,7 @@ config_gsi.yaml and config_jedi.yaml contain the following user settings
   - machine: hera, hercules, or orion
   - job options:  may need to adjust nodes, tasks-per-node, or mem appropriate for dataset being processed
 
-      HOMEgfs: global-workflow installation
+      HOMEglobal: global-workflow installation
       STAGEDIR: machine specific path containing job input, set to the machine appropriate path below
          Hera: /scratch3/NCEPDEV/da/Russ.Treadon/STAGEDIR
 	 Hercules, Orion: /work2/noaa/da/rtreadon/STAGEDIR

--- a/ush/ufoeval/config_gsi.yaml
+++ b/ush/ufoeval/config_gsi.yaml
@@ -11,7 +11,7 @@ job options:
   mem: 96Gb
 
 directories:
-  HOMEgfs: /scratch3/NCEPDEV/da/Russ.Treadon/git/global-workflow/test
+  HOMEglobal: /scratch3/NCEPDEV/da/Russ.Treadon/git/global-workflow/test
   STAGEDIR: /scratch3/NCEPDEV/da/Russ.Treadon/STAGEDIR
   RUNDIR: /scratch3/NCEPDEV/stmp2/Russ.Treadon/RUNDIRS
 

--- a/ush/ufoeval/config_jedi.yaml
+++ b/ush/ufoeval/config_jedi.yaml
@@ -11,7 +11,7 @@ job options:
   mem: 96Gb
 
 directories:
-  HOMEgfs: /scratch3/NCEPDEV/da/Russ.Treadon/git/global-workflow/test
+  HOMEglobal: /scratch3/NCEPDEV/da/Russ.Treadon/git/global-workflow/test
   STAGEDIR: /scratch3/NCEPDEV/da/Russ.Treadon/STAGEDIR
   RUNDIR: /scratch3/NCEPDEV/stmp2/Russ.Treadon/RUNDIRS
 

--- a/ush/ufoeval/setup_phase3.py
+++ b/ush/ufoeval/setup_phase3.py
@@ -29,7 +29,7 @@ class SlurmJobCard:
         self.appexe = config['app files']['APPEXE']
 
         self.machine = config['machine']
-        self.homegfs = config['directories']['HOMEgfs']
+        self.homegfs = config['directories']['HOMEglobal']
         self.rundir = os.path.join(config['directories']['RUNDIR'], self.appcore + '_' + self.apptype)
         if self.appcore == 'jedi':
             self.incexe = config['app files']['INCEXE']
@@ -61,7 +61,7 @@ class SlurmJobCard:
         """
         self.f.write("\n")
         self.f.write("# Load modules\n")
-        self.f.write(f"export HOMEgfs={self.homegfs}\n")
+        self.f.write(f"export HOMEglobal={self.homegfs}\n")
         self.f.write(f"source {self.homegfs}/ush/preamble.sh\n")
         if self.appcore == 'gsi':
             self.f.write(f". {self.homegfs}/ush/load_fv3gfs_modules.sh\n")


### PR DESCRIPTION
# Description

- This PR updates multiple scripts in GDASApp to adopt the EE2 global workflow naming convention. Modifications were made to test scripts and driver scripts, particularly within the ci and ush directories. These changes ensure that GDASApp is fully compatible with the global-workflow naming standards, aligning with the practices proposed in issue [#4410](https://github.com/NOAA-EMC/global-workflow/issues/4410). All NET-specific environment variables have been replaced with global equivalents, improving clarity, consistency, and maintainability across the workflow.

# Companion PRs

Ref: [#4540](https://github.com/NOAA-EMC/global-workflow/pull/4540)

# Issues

<!-- Enter any issues referenced or resolved by this PR here. Use keywords "Resolves" or "Refs".
Resolves #4410
Refs #4321
Refs NOAA-EMC/repo#5678
-->

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [x] atm_jjob <!-- JEDI atm single cycle DA !-->
- [x] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [x] C96C48_hybatmsnowDA <!-- JEDI snow cycled DA !-->
- [x] C96_gcafs_cycled <!-- JEDI aerosol cycled DA !-->
- [x] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [x] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [x] C96C48_ufsgsi_hybatmDA <!-- JEDI atm Var with GSI EnKF cycled DA !-->
- [x] C48_ufsenkf_atmDA <!-- JEDI atm EnKF cycled DA !-->
- [x] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
