### PR TITLE
hack to improve operational hardening

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -145,6 +145,11 @@ mkdir -p $dir_root/bundle/test-data-release/
 ln -sf $GDASAPP_TESTDATA/crtm $dir_root/bundle/fix/test-data-release/crtm
 ln -sf $GDASAPP_TESTDATA/crtm $dir_root/bundle/test-data-release/crtm
 
+# Hack OOPS one line change to harden code for operations,
+# remove once the change is merged into the JCSDA develop branch and we can update the submodule
+sed -i 's|  ASSERT(spaces_.size() >0);|  // ASSERT(spaces_.size() >0);|' $dir_root/sorc/oops/src/oops/base/ObsSpaces.h
+
+
 # Configure
 echo "Configuring ... `date`"
 set -x


### PR DESCRIPTION
# Description

Add this hack to the dev/gcafs build script so that OOPS does not fail if the list of obs spaces is empty. A PR is being placed to OOPS develop to correct this, but that will require a lot of work to get this one line change into an updated release branch, so for now, this hack will suffice.

# Companion PRs

None

# Issues

None.

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmsnowDA <!-- JEDI snow cycled DA !-->
- [ ] C96_gcafs_cycled <!-- JEDI aerosol cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [ ] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_ufsgsi_hybatmDA <!-- JEDI atm Var with GSI EnKF cycled DA !-->
- [ ] C48_ufsenkf_atmDA <!-- JEDI atm EnKF cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
