### PR TITLE
Weekly update of JEDI hashes (20260309)

### DIFF
--- a/test/atm/global-workflow/jjob_ens_init.sh
+++ b/test/atm/global-workflow/jjob_ens_init.sh
@@ -56,10 +56,8 @@ gprefix=$GDUMP.t${gcyc}z
 oprefix=$GDUMP.t${cyc}z
 
 # Generate COM variables from templates
-RUN=${GDUMP} YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-    COMIN_OBS:COM_OBS_TMPL
-RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
-    COMIN_ATMOS_ANALYSIS_PREV:COM_ATMOS_ANALYSIS_TMPL \
+declare -rx COMIN_OBS="${ROTDIR}/${GDUMP}.${PDY}/${cyc}/obs"
+declare -rx COMIN_ATMOS_ANALYSIS_PREV="${ROTDIR}/${GDUMP}.${gPDY}/${gcyc}/analysis/atmos"
 
 # Link observations
 dpath=gdas.$PDY/$cyc/obs
@@ -82,9 +80,9 @@ dpath=enkfgdas.$gPDY/$gcyc
 for imem in $(seq 1 $NMEM_ENS); do
     memchar="mem"$(printf %03i $imem)
 
-    MEMDIR=${memchar} RUN=${RUN} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -x \
-	COMIN_ATMOS_HISTORY_PREV_ENS:COM_ATMOS_HISTORY_TMPL \
-	COMIN_ATMOS_RESTART_PREV_ENS:COM_ATMOS_RESTART_TMPL
+    declare -x COMIN_ATMOS_HISTORY_PREV_ENS="${ROTDIR}/${RUN}.${gPDY}/${gcyc}/${memchar}/model/atmos/history"
+    declare -x COMIN_ATMOS_RESTART_PREV_ENS="${ROTDIR}/${RUN}.${gPDY}/${gcyc}/${memchar}/model/atmos/restart"
+    
     COMIN_ATMOS_RESTART_PREV_DIRNAME_ENS=$(dirname $COMIN_ATMOS_RESTART_PREV_ENS)
 
     source=$GDASAPP_TESTDATA/lowres/$dpath/$memchar/model/atmos/history

--- a/test/atm/global-workflow/jjob_ens_init_split.sh
+++ b/test/atm/global-workflow/jjob_ens_init_split.sh
@@ -56,10 +56,8 @@ gprefix=$GDUMP.t${gcyc}z
 oprefix=$GDUMP.t${cyc}z
 
 # Generate COM variables from templates
-RUN=${GDUMP} YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-   COMIN_OBS:COM_OBS_TMPL
-RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
-   COMIN_ATMOS_ANALYSIS_PREV:COM_ATMOS_ANALYSIS_TMPL \
+declare -rx COMIN_OBS="${ROTDIR}/${GDUMP}.${PDY}/${cyc}/obs"
+declare -rx COMIN_ATMOS_ANALYSIS_PREV="${ROTDIR}/${GDUMP}.${gPDY}/${gcyc}/analysis/atmos"
 
 # Link observations
 dpath=gdas.$PDY/$cyc/obs
@@ -86,8 +84,7 @@ dpath=enkfgdas.$gPDY/$gcyc
 for imem in $(seq 1 $NMEM_ENS); do
     memchar="mem"$(printf %03i $imem)
 
-    MEMDIR=${memchar} RUN=${RUN} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -x \
-	COMIN_ATMOS_HISTORY_PREV_ENS:COM_ATMOS_HISTORY_TMPL
+    declare -x COMIN_ATMOS_HISTORY_PREV_ENS="${ROTDIR}/${RUN}.${gPDY}/${gcyc}/${memchar}/model/atmos/history"    
 
     source=$GDASAPP_TESTDATA/lowres/$dpath/$memchar/model/atmos/history
     target=$COMIN_ATMOS_HISTORY_PREV_ENS

--- a/test/atm/global-workflow/jjob_var_init.sh
+++ b/test/atm/global-workflow/jjob_var_init.sh
@@ -56,11 +56,9 @@ gprefix=$GDUMP.t${gcyc}z
 oprefix=$CDUMP.t${cyc}z
 
 # Generate COM variables from templates
-YMD=${PDY} HH=${cyc} declare_from_tmpl -rx \
-   COMIN_OBS:COM_OBS_TMPL
-RUN=${GDUMP} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -rx \
-    COMIN_ATMOS_ANALYSIS_PREV:COM_ATMOS_ANALYSIS_TMPL \
-    COMIN_ATMOS_HISTORY_PREV:COM_ATMOS_HISTORY_TMPL
+declare -rx COMIN_OBS="${ROTDIR}/${RUN}.${PDY}/${cyc}/obs"
+declare -rx COMIN_ATMOS_ANALYSIS_PREV="${ROTDIR}/${GDUMP}.${gPDY}/${gcyc}/analysis/atmos"
+declare -rx COMIN_ATMOS_HISTORY_PREV="${ROTDIR}/${GDUMP}.${gPDY}/${gcyc}/model/atmos/history"
 
 # Link observations
 dpath=gdas.$PDY/$cyc/obs
@@ -97,9 +95,8 @@ dpath=enkfgdas.$gPDY/$gcyc
 for imem in $(seq 1 $NMEM_ENS); do
     memchar="mem"$(printf %03i $imem)
 
-    MEMDIR=${memchar} RUN=enkf${RUN} YMD=${gPDY} HH=${gcyc} declare_from_tmpl -x \
-	COMIN_ATMOS_HISTORY_PREV_ENS:COM_ATMOS_HISTORY_TMPL
-
+    declare -x COMIN_ATMOS_HISTORY_PREV_ENS="${ROTDIR}/enkf${GDUMP}.${gPDY}/${gcyc}/${memchar}/model/atmos/history"
+    
     source=$GDASAPP_TESTDATA/lowres/$dpath/$memchar/model/atmos/history
     target=$COMIN_ATMOS_HISTORY_PREV_ENS
     mkdir -p $target


### PR DESCRIPTION
# Description

This PR contains the weekly update of select JEDI hashes

# Companion PRs

None

# Issues

# Automated CI tests to run in Global Workflow
- [x] atm_jjob <!-- JEDI atm single cycle DA !-->
- [x] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [x] C96C48_hybatmsnowDA <!-- JEDI snow cycled DA !-->
- [x] C96_gcafs_cycled <!-- JEDI aerosol cycled DA !-->
- [x] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [x] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [x] C96C48_ufsgsi_hybatmDA <!-- JEDI atm Var with GSI EnKF cycled DA !-->
- [x] C48_ufsenkf_atmDA <!-- JEDI atm EnKF cycled DA !-->
- [x] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
