### PR TITLE
Marine recentering bugfixes: correct time and no ice thickness rescaling

### DIFF
--- a/parm/jcb-gdas/algorithm/marine/soca_ens_handler.yaml.j2
+++ b/parm/jcb-gdas/algorithm/marine/soca_ens_handler.yaml.j2
@@ -49,8 +49,8 @@ recentering state:
   - sea_ice_snow_thickness
   date: "{{ marine_window_end_iso }}"
   basename: ./bkg/
-  ocn_filename: ocean.bkg.f009.nc
-  ice_filename: ice.bkg.f009.nc
+  ocn_filename: ocean.bkg.f006.nc
+  ice_filename: ice.bkg.f006.nc
   read_from_file: 1
 
 output increments:
@@ -80,15 +80,15 @@ analysis postprocessing:
       shuffle: true
       rescale prior:
         rescale: true
-        min hice: 0.5
-        min hsno: 0.1
+        min hice: 10e+8 # effectively turn off rescaling for now as it's not working correctly
+        min hsno: 10e+8 # effectively turn off rescaling for now as it's not working correctly
     antarctic:
       seaice edge: 0.4
       shuffle: true
       rescale prior:
         rescale: true
-        min hice: 0.5
-        min hsno: 0.1
+        min hice: 10e+8 # effectively turn off rescaling for now as it's not working correctly
+        min hsno: 10e+8 # effectively turn off rescaling for now as it's not working correctly
     cice background state:
       restart: ens/cice_model.res.%mem%.nc
       ncat: 5


### PR DESCRIPTION
# Description

This fixes a few issues associated with marine recentering:
- time mismatch between the ensemble mean and control, resulting in diurnal cycle in the recentering increment. The fix uses control at +06hr, the same time that the ensemble is valid at.
Example of recentering increment before and after the fix:
<img width="633" height="410" alt="beforefix" src="https://github.com/user-attachments/assets/fbbc6f89-8ce7-42e8-a999-e433bbff7cb4" />
<img width="636" height="405" alt="afterfix" src="https://github.com/user-attachments/assets/a7331afb-d57c-4e40-a16b-caaf0e1b8879" />

- buggy sea ice thickness and snow depth rescaling. The fix turns it off (`min_hsno` and `min_hice` set to large values).

# Issues

Resolves #1688 
Resolves #2087 

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [x] atm_jjob <!-- JEDI atm single cycle DA !-->
- [x] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [x] C96C48_hybatmsnowDA <!-- JEDI snow cycled DA !-->
- [x] C96_gcafs_cycled <!-- JEDI aerosol cycled DA !-->
- [x] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [x] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [x] C96C48_ufsgsi_hybatmDA <!-- JEDI atm Var with GSI EnKF cycled DA !-->
- [x] C48_ufsenkf_atmDA <!-- JEDI atm EnKF cycled DA !-->
- [x] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
