### PR TITLE
Do not load prod-util when running ecflow

### DIFF
--- a/modulefiles/GDAS/wcoss2.intel.lua
+++ b/modulefiles/GDAS/wcoss2.intel.lua
@@ -63,7 +63,11 @@ load("ncview/2.1.9")
 load("netcdf-cxx4/4.3.1")
 load("json/3.11.3")
 --load("crtm/v2.4_jedi")
-load("prod_util/2.0.14")
+-- Do not load prod_util when running ecflow
+local is_ecf = os.getenv("ECF_JOB") ~= nil
+if not is_ecf then
+    load("prod_util/2.0.14")
+end
 load("grib-util/1.4.0")
 
 load("py-numpy/1.26.4")


### PR DESCRIPTION
# Description

This adds a conditional to check whether we are running the GDASApp in an ecflow environment. This is necessary to prevent loading prod_util, which is done in the ecf script.

# Issues

NOAA-emc/global-workflow#4599

# Automated CI tests to run in Global Workflow
- [x] atm_jjob <!-- JEDI atm single cycle DA !-->
- [x] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [x] C96C48_hybatmsnowDA <!-- JEDI snow cycled DA !-->
- [x] C96_gcafs_cycled <!-- JEDI aerosol cycled DA !-->
- [x] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [x] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [x] C96C48_ufsgsi_hybatmDA <!-- JEDI atm Var with GSI EnKF cycled DA !-->
- [x] C48_ufsenkf_atmDA <!-- JEDI atm EnKF cycled DA !-->
- [x] C96C48_hybatmDA <!-- GSI atm cycled DA !-->