### PR TITLE
Add crtm fix location to derecho module

### DIFF
--- a/modulefiles/GDAS/derecho.intel.lua
+++ b/modulefiles/GDAS/derecho.intel.lua
@@ -97,6 +97,8 @@ local mpinproc = '-n'
 setenv('MPIEXEC_EXEC', mpiexec)
 setenv('MPIEXEC_NPROC', mpinproc)
 
+setenv("CRTM_FIX","/lustre/desc1/p/nral0032/global/data/fix/crtm/v2.4.0.2")
+
 whatis("Name: ".. pkgName)
 whatis("Version: ".. tostring(pkgVersion))
 whatis("Category: GDASApp")


### PR DESCRIPTION
# Description

Adds the crtm fix location to the derecho modulefile.

# Companion PRs

None

# Issues


# Automated CI tests to run in Global Workflow
N/A, tested manually on Derecho