### PR TITLE
add yaml for automated weekly-stable pull request

### DIFF
--- a/.github/workflows/weekly-stable-pr.yaml
+++ b/.github/workflows/weekly-stable-pr.yaml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      issues: write
       contents: read
     
     steps:

--- a/.github/workflows/weekly-stable-pr.yaml
+++ b/.github/workflows/weekly-stable-pr.yaml
@@ -43,7 +43,7 @@ jobs:
             --assignee "RussTreadon-NOAA" \
             --title "Weekly Merge: stable-nightly to develop ($DATE_STR)" \
             --body "Automated weekly PR to sync stable-nightly updates into develop. Triggered on $DATE_STR." \
-            --label "gaea-c6-GW-RT,hera-GW-RT,hercules-GW-RT,orion-GW-RT,ursa-GW-RT"
+            --label "gaeac6-GW-RT,hera-GW-RT,hercules-GW-RT,orion-GW-RT,ursa-GW-RT"
 
       - name: Update existing PR
         if: steps.check_pr.outputs.pr_number != ''

--- a/.github/workflows/weekly-stable-pr.yaml
+++ b/.github/workflows/weekly-stable-pr.yaml
@@ -1,0 +1,56 @@
+name: Weekly Stable-to-Develop PR
+
+on:
+  schedule:
+    # Runs at 09:00 UTC every Tuesday
+    - cron: '0 9 * * 2'
+  workflow_dispatch: # Allows manual triggering for testing
+
+jobs:
+  create-pull-request:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate Date String
+        id: date
+        run: echo "date_str=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
+
+      - name: Check for existing PR
+        id: check_pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          existing_pr=$(gh pr list --head feature/stable-nightly --base develop --json number --jq '.[0].number')
+          echo "pr_number=$existing_pr" >> $GITHUB_OUTPUT
+
+      - name: Create Pull Request
+        if: steps.check_pr.outputs.pr_number == ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DATE_STR: ${{ steps.date.outputs.date_str }}
+        run: |
+          gh pr create \
+            --base develop \
+            --head feature/stable-nightly \
+            --assignee "RussTreadon-NOAA" \
+            --title "Weekly Merge: stable-nightly to develop ($DATE_STR)" \
+            --body "Automated weekly PR to sync stable-nightly updates into develop. Triggered on $DATE_STR." \
+            --label "gaea-c6-GW-RT,hera-GW-RT,hercules-GW-RT,orion-GW-RT,ursa-GW-RT"
+
+      - name: Update existing PR
+        if: steps.check_pr.outputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Ensure labels and assignee are present even if the PR already existed
+          gh pr edit ${{ steps.check_pr.outputs.pr_number }} \
+            --add-assignee "RussTreadon-NOAA" \
+            --add-label "gaeac6-GW-RT,hera-GW-RT,hercules-GW-RT,orion-GW-RT,ursa-GW-RT"

--- a/.github/workflows/weekly-stable-pr.yaml
+++ b/.github/workflows/weekly-stable-pr.yaml
@@ -6,6 +6,9 @@ on:
     - cron: '0 9 * * 2'
   workflow_dispatch: # Allows manual triggering for testing
 
+concurrency:
+  group: ${{ github.workflow }}-develop-feature/stable-nightly
+  cancel-in-progress: false
 jobs:
   create-pull-request:
     runs-on: ubuntu-latest

--- a/.github/workflows/weekly-stable-pr.yaml
+++ b/.github/workflows/weekly-stable-pr.yaml
@@ -28,7 +28,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          existing_pr=$(gh pr list --head feature/stable-nightly --base develop --json number --jq '.[0].number')
+          existing_pr=$(gh pr list --head feature/stable-nightly --base develop --json number --jq '.[0].number // empty')
           echo "pr_number=$existing_pr" >> $GITHUB_OUTPUT
 
       - name: Create Pull Request


### PR DESCRIPTION
# Description

Add yaml for automated weekly stable github action to create PR to merge `feature/stable-nightly` into `develop`. The workflow checks for an existing PR and creates one if none exists, or updates the existing PR to enforce assignee and labels. Fixed a bug where the jq expression returned `null` instead of an empty string when no PR exists, which could cause the workflow to attempt `gh pr edit null` and fail. Now uses `.[0].number // empty` to correctly handle the case when no existing PR is found.

# Companion PRs

None

# Issues

Resolves #2106

# Automated CI tests to run in Global Workflow
- [x] atm_jjob 
- [x] C96C48_ufs_hybatmDA 
- [x] C96C48_hybatmsnowDA 
- [x] C96_gcafs_cycled 
- [x] C48mx500_3DVarAOWCDA 
- [x] C48mx500_hybAOWCDA 
- [x] C96C48_ufsgsi_hybatmDA 
- [x] C48_ufsenkf_atmDA 
- [x] C96C48_hybatmDA