### PR TITLE
Output and save marine ensemble mean

### DIFF
--- a/parm/jcb-gdas/algorithm/marine/soca_ens_handler.yaml.j2
+++ b/parm/jcb-gdas/algorithm/marine/soca_ens_handler.yaml.j2
@@ -108,3 +108,9 @@ ensemble variance output:
   date: "{{ marine_window_end_iso }}"
   exp: ensvar
   type: incr
+
+ensemble mean output:
+  datadir: ./
+  date: "{{ marine_window_end_iso }}"
+  exp: ensmean
+  type: an

--- a/parm/marine/marine_ecen_config.yaml.j2
+++ b/parm/marine/marine_ecen_config.yaml.j2
@@ -85,3 +85,5 @@ data_out:
                       '${MEMDIR}': 'ensstat' }) %}
     - ['{{ DATA }}/ocn.ensvar.incr.{{ WINDOW_END | to_isotime }}.nc', '{{ COM_OCEAN_ANALYSIS_TMPL | replace_tmpl(tmpl_dict) }}/{{ APREFIX_ENS }}bg_ensvar.nc']
     - ['{{ DATA }}/ice.ensvar.incr.{{ WINDOW_END | to_isotime }}.nc', '{{ COM_ICE_ANALYSIS_TMPL | replace_tmpl(tmpl_dict) }}/{{ APREFIX_ENS }}bg_ensvar.nc']
+    - ['{{ DATA }}/ocn.ensmean.an.{{ WINDOW_END | to_isotime }}.nc', '{{ COM_OCEAN_ANALYSIS_TMPL | replace_tmpl(tmpl_dict) }}/{{ APREFIX_ENS }}bg_ensmean.nc']
+    - ['{{ DATA }}/ice.ensmean.an.{{ WINDOW_END | to_isotime }}.nc', '{{ COM_ICE_ANALYSIS_TMPL | replace_tmpl(tmpl_dict) }}/{{ APREFIX_ENS }}bg_ensmean.nc']


### PR DESCRIPTION
# Description

For v17.

# Companion PRs

https://github.com/NOAA-EMC/global-workflow/pull/4765

# Issues

Resolves #2090

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmsnowDA <!-- JEDI snow cycled DA !-->
- [ ] C96_gcafs_cycled <!-- JEDI aerosol cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [x] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_ufsgsi_hybatmDA <!-- JEDI atm Var with GSI EnKF cycled DA !-->
- [ ] C48_ufsenkf_atmDA <!-- JEDI atm EnKF cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
