### PR TITLE
Do not log __init__ method

### DIFF
--- a/ush/soca/prep_ocean_obs.py
+++ b/ush/soca/prep_ocean_obs.py
@@ -18,7 +18,6 @@ class PrepOceanObs(Task):
     Class for prepping obs for ocean analysis task
     """
 
-    @logit(logger, name="PrepOceanObs")
     def __init__(self, config: Dict) -> None:
         """Constructor for ocean obs prep task
         Parameters:


### PR DESCRIPTION
# Description
This removes the `logit` decorator from the `prep_ocean_obs.py` `__init__` method to reduce debug output (preventing the entire environment from being written to the log).

# Companion PRs
https://github.com/NOAA-EMC/global-workflow/pull/4856

# Issues
Refs https://github.com/NOAA-EMC/global-workflow/issues/4721

# Automated CI tests to run in Global Workflow
- [x] atm_jjob <!-- JEDI atm single cycle DA !-->
- [x] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [x] C96C48_hybatmsnowDA <!-- JEDI snow cycled DA !-->
- [x] C96_gcafs_cycled <!-- JEDI aerosol cycled DA !-->
- [x] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [x] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [x] C96C48_ufsgsi_hybatmDA <!-- JEDI atm Var with GSI EnKF cycled DA !-->
- [x] C48_ufsenkf_atmDA <!-- JEDI atm EnKF cycled DA !-->
- [x] C96C48_hybatmDA <!-- GSI atm cycled DA !-->