### PR TITLE
(release/gfs.v17) Do not logit-decorate init method

### DIFF
--- a/ush/soca/prep_ocean_obs.py
+++ b/ush/soca/prep_ocean_obs.py
@@ -18,7 +18,6 @@ class PrepOceanObs(Task):
     Class for prepping obs for ocean analysis task
     """
 
-    @logit(logger, name="PrepOceanObs")
     def __init__(self, config: Dict) -> None:
         """Constructor for ocean obs prep task
         Parameters:


### PR DESCRIPTION
# Description
This removes the `logit` decoration from the `PrepOceanObs` `__init__` method to prevent logging the entire environment.

# Companion PRs
https://github.com/NOAA-EMC/global-workflow/pull/4933

# Issues
https://github.com/NOAA-EMC/global-workflow/issues/4721

# Automated CI tests to run in Global Workflow
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmsnowDA <!-- JEDI snow cycled DA !-->
- [ ] C96_gcafs_cycled <!-- JEDI aerosol cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [ ] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_ufsgsi_hybatmDA <!-- JEDI atm Var with GSI EnKF cycled DA !-->
- [ ] C48_ufsenkf_atmDA <!-- JEDI atm EnKF cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
