### PR TITLE
Remove `config.com` dependency from GDASApp

### DIFF
--- a/parm/atm/atm_det_config.yaml.j2
+++ b/parm/atm/atm_det_config.yaml.j2
@@ -36,9 +36,9 @@ data_in:
 
 {% if DOHYBVAR %}
     {% for imem in range(1,NMEM_ENS+1) %}
-        {% set ens_hist_prev = ROTDIR ~ '/enkfgdas.' ~ (previous_cycle | to_YMD) ~ '/' ~ (previous_cycle | strftime('%H')) ~ '/' ~ ('mem%03d' | format(imem)) ~ '/model/atmos/history' %}
-    - ['{{ ens_hist_prev }}/{{ GPREFIX_ENS }}csg_atm.f006.nc', '{{ DATA }}/ens/{{ 'mem%03d' | format(imem) }}/{{ GPREFIX_ENS }}cubed_sphere_grid_atmf006.nc']
-    - ['{{ ens_hist_prev }}/{{ GPREFIX_ENS }}csg_sfc.f006.nc', '{{ DATA }}/ens/{{ 'mem%03d' | format(imem) }}/{{ GPREFIX_ENS }}cubed_sphere_grid_sfcf006.nc']
+        {% COMIN_ATMOS_HISTORY_PREV_MEM = ROTDIR ~ '/enkfgdas.' ~ (previous_cycle | to_YMD) ~ '/' ~ (previous_cycle | strftime('%H')) ~ '/' ~ ('mem%03d' | format(imem)) ~ '/model/atmos/history' %}
+    - ['{{ COMIN_ATMOS_HISTORY_PREV_MEM }}/{{ GPREFIX_ENS }}csg_atm.f006.nc', '{{ DATA }}/ens/{{ 'mem%03d' | format(imem) }}/{{ GPREFIX_ENS }}cubed_sphere_grid_atmf006.nc']
+    - ['{{ COMIN_ATMOS_HISTORY_PREV_MEM }}/{{ GPREFIX_ENS }}csg_sfc.f006.nc', '{{ DATA }}/ens/{{ 'mem%03d' | format(imem) }}/{{ GPREFIX_ENS }}cubed_sphere_grid_sfcf006.nc']
     {% endfor %}
 {% endif %}
 

--- a/parm/atm/atm_det_config.yaml.j2
+++ b/parm/atm/atm_det_config.yaml.j2
@@ -36,9 +36,9 @@ data_in:
 
 {% if DOHYBVAR %}
     {% for imem in range(1,NMEM_ENS+1) %}
-        {% COMIN_ATMOS_HISTORY_PREV_MEM = ROTDIR ~ '/enkfgdas.' ~ (previous_cycle | to_YMD) ~ '/' ~ (previous_cycle | strftime('%H')) ~ '/' ~ ('mem%03d' | format(imem)) ~ '/model/atmos/history' %}
-    - ['{{ COMIN_ATMOS_HISTORY_PREV_MEM }}/{{ GPREFIX_ENS }}csg_atm.f006.nc', '{{ DATA }}/ens/{{ 'mem%03d' | format(imem) }}/{{ GPREFIX_ENS }}cubed_sphere_grid_atmf006.nc']
-    - ['{{ COMIN_ATMOS_HISTORY_PREV_MEM }}/{{ GPREFIX_ENS }}csg_sfc.f006.nc', '{{ DATA }}/ens/{{ 'mem%03d' | format(imem) }}/{{ GPREFIX_ENS }}cubed_sphere_grid_sfcf006.nc']
+        {% COMIN_ATMOS_HISTORY_MEM_PREV = ROTDIR ~ '/enkfgdas.' ~ (previous_cycle | to_YMD) ~ '/' ~ (previous_cycle | strftime('%H')) ~ '/' ~ ('mem%03d' | format(imem)) ~ '/model/atmos/history' %}
+    - ['{{ COMIN_ATMOS_HISTORY_MEM_PREV }}/{{ GPREFIX_ENS }}csg_atm.f006.nc', '{{ DATA }}/ens/{{ 'mem%03d' | format(imem) }}/{{ GPREFIX_ENS }}cubed_sphere_grid_atmf006.nc']
+    - ['{{ COMIN_ATMOS_HISTORY_MEM_PREV }}/{{ GPREFIX_ENS }}csg_sfc.f006.nc', '{{ DATA }}/ens/{{ 'mem%03d' | format(imem) }}/{{ GPREFIX_ENS }}cubed_sphere_grid_sfcf006.nc']
     {% endfor %}
 {% endif %}
 

--- a/parm/atm/atm_det_config.yaml.j2
+++ b/parm/atm/atm_det_config.yaml.j2
@@ -36,13 +36,9 @@ data_in:
 
 {% if DOHYBVAR %}
     {% for imem in range(1,NMEM_ENS+1) %}
-        {% set tmpl_dict = ({ '${ROTDIR}': ROTDIR,
-                              '${RUN}': 'enkfgdas',
-                              '${YMD}': previous_cycle | to_YMD,
-                              '${HH}': previous_cycle | strftime('%H'),
-                              '${MEMDIR}': 'mem%03d' | format(imem) }) %}
-    - ['{{ COM_ATMOS_HISTORY_TMPL | replace_tmpl(tmpl_dict) }}/{{ GPREFIX_ENS }}csg_atm.f006.nc', '{{ DATA }}/ens/{{ 'mem%03d' | format(imem) }}/{{ GPREFIX_ENS }}cubed_sphere_grid_atmf006.nc']
-    - ['{{ COM_ATMOS_HISTORY_TMPL | replace_tmpl(tmpl_dict) }}/{{ GPREFIX_ENS }}csg_sfc.f006.nc', '{{ DATA }}/ens/{{ 'mem%03d' | format(imem) }}/{{ GPREFIX_ENS }}cubed_sphere_grid_sfcf006.nc']
+        {% set ens_hist_prev = ROTDIR ~ '/enkfgdas.' ~ (previous_cycle | to_YMD) ~ '/' ~ (previous_cycle | strftime('%H')) ~ '/' ~ ('mem%03d' | format(imem)) ~ '/model/atmos/history' %}
+    - ['{{ ens_hist_prev }}/{{ GPREFIX_ENS }}csg_atm.f006.nc', '{{ DATA }}/ens/{{ 'mem%03d' | format(imem) }}/{{ GPREFIX_ENS }}cubed_sphere_grid_atmf006.nc']
+    - ['{{ ens_hist_prev }}/{{ GPREFIX_ENS }}csg_sfc.f006.nc', '{{ DATA }}/ens/{{ 'mem%03d' | format(imem) }}/{{ GPREFIX_ENS }}cubed_sphere_grid_sfcf006.nc']
     {% endfor %}
 {% endif %}
 

--- a/parm/atm/atm_ecen_config.yaml.j2
+++ b/parm/atm/atm_ecen_config.yaml.j2
@@ -32,8 +32,8 @@ data_in:
     - ["{{ COMIN_ATMOS_ANALYSIS }}/{{ APREFIX }}jedi_increment.atm.i{{ '%03d' % fh }}.tile6.nc", "{{ DATA }}/{{ APREFIX }}cubed_sphere_grid_atmi{{ '%03d' % fh }}.tile6.nc"]
 
 {% for imem in range(1,NMEM_ENS+1) %}
-    {% set ens_anl = ROTDIR ~ '/' ~ RUN ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/' ~ ('mem%03d' | format(imem)) ~ '/analysis/atmos' %}
-    - ['{{ ens_anl }}/{{ APREFIX_ENS }}csg_jedi_increment.atm.i{{ '%03d' % fh }}.nc', '{{ DATA }}/{{ 'mem%03d' | format(imem) }}/{{ APREFIX_ENS }}cubed_sphere_grid_atmi{{ '%03d' % fh }}.nc']
+    {% set COM_ATMOS_ANALYSIS_MEM = ROTDIR ~ '/' ~ RUN ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/' ~ ('mem%03d' | format(imem)) ~ '/analysis/atmos' %}
+    - ['{{ COM_ATMOS_ANALYSIS_MEM }}/{{ APREFIX_ENS }}csg_jedi_increment.atm.i{{ '%03d' % fh }}.nc', '{{ DATA }}/{{ 'mem%03d' | format(imem) }}/{{ APREFIX_ENS }}cubed_sphere_grid_atmi{{ '%03d' % fh }}.nc']
 
 {% endfor %}
 {% endfor %}
@@ -48,12 +48,12 @@ data_out:
     - ['{{ DATA }}/ensemble_recenter.yaml', '{{ COMOUT_CONF }}/{{ APREFIX_ENS }}ensemble_recenter.yaml']
 {% for fh in IAUFHRS %}
     {% for imem in range(1,NMEM_ENS+1) %}
-        {% set ens_anl = ROTDIR ~ '/' ~ RUN ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/' ~ ('mem%03d' | format(imem)) ~ '/analysis/atmos' %}
-    - ['{{ DATA }}/{{ 'mem%03d' | format(imem) }}/{{ APREFIX_ENS }}cubed_sphere_grid_ratmi{{ '%03d' % fh }}.tile1.nc', '{{ ens_anl }}/{{ APREFIX_ENS }}recentered_jedi_increment.atm.i{{ '%03d' % fh }}.tile1.nc']
-    - ['{{ DATA }}/{{ 'mem%03d' | format(imem) }}/{{ APREFIX_ENS }}cubed_sphere_grid_ratmi{{ '%03d' % fh }}.tile2.nc', '{{ ens_anl }}/{{ APREFIX_ENS }}recentered_jedi_increment.atm.i{{ '%03d' % fh }}.tile2.nc']
-    - ['{{ DATA }}/{{ 'mem%03d' | format(imem) }}/{{ APREFIX_ENS }}cubed_sphere_grid_ratmi{{ '%03d' % fh }}.tile3.nc', '{{ ens_anl }}/{{ APREFIX_ENS }}recentered_jedi_increment.atm.i{{ '%03d' % fh }}.tile3.nc']
-    - ['{{ DATA }}/{{ 'mem%03d' | format(imem) }}/{{ APREFIX_ENS }}cubed_sphere_grid_ratmi{{ '%03d' % fh }}.tile4.nc', '{{ ens_anl }}/{{ APREFIX_ENS }}recentered_jedi_increment.atm.i{{ '%03d' % fh }}.tile4.nc']
-    - ['{{ DATA }}/{{ 'mem%03d' | format(imem) }}/{{ APREFIX_ENS }}cubed_sphere_grid_ratmi{{ '%03d' % fh }}.tile5.nc', '{{ ens_anl }}/{{ APREFIX_ENS }}recentered_jedi_increment.atm.i{{ '%03d' % fh }}.tile5.nc']
-    - ['{{ DATA }}/{{ 'mem%03d' | format(imem) }}/{{ APREFIX_ENS }}cubed_sphere_grid_ratmi{{ '%03d' % fh }}.tile6.nc', '{{ ens_anl }}/{{ APREFIX_ENS }}recentered_jedi_increment.atm.i{{ '%03d' % fh }}.tile6.nc']
+        {% set COMOUT_ATMOS_ANALYSIS_MEM = ROTDIR ~ '/' ~ RUN ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/' ~ ('mem%03d' | format(imem)) ~ '/analysis/atmos' %}
+    - ['{{ DATA }}/{{ 'mem%03d' | format(imem) }}/{{ APREFIX_ENS }}cubed_sphere_grid_ratmi{{ '%03d' % fh }}.tile1.nc', '{{ COMOUT_ATMOS_ANALYSIS_MEM }}/{{ APREFIX_ENS }}recentered_jedi_increment.atm.i{{ '%03d' % fh }}.tile1.nc']
+    - ['{{ DATA }}/{{ 'mem%03d' | format(imem) }}/{{ APREFIX_ENS }}cubed_sphere_grid_ratmi{{ '%03d' % fh }}.tile2.nc', '{{ COMOUT_ATMOS_ANALYSIS_MEM }}/{{ APREFIX_ENS }}recentered_jedi_increment.atm.i{{ '%03d' % fh }}.tile2.nc']
+    - ['{{ DATA }}/{{ 'mem%03d' | format(imem) }}/{{ APREFIX_ENS }}cubed_sphere_grid_ratmi{{ '%03d' % fh }}.tile3.nc', '{{ COMOUT_ATMOS_ANALYSIS_MEM }}/{{ APREFIX_ENS }}recentered_jedi_increment.atm.i{{ '%03d' % fh }}.tile3.nc']
+    - ['{{ DATA }}/{{ 'mem%03d' | format(imem) }}/{{ APREFIX_ENS }}cubed_sphere_grid_ratmi{{ '%03d' % fh }}.tile4.nc', '{{ COMOUT_ATMOS_ANALYSIS_MEM }}/{{ APREFIX_ENS }}recentered_jedi_increment.atm.i{{ '%03d' % fh }}.tile4.nc']
+    - ['{{ DATA }}/{{ 'mem%03d' | format(imem) }}/{{ APREFIX_ENS }}cubed_sphere_grid_ratmi{{ '%03d' % fh }}.tile5.nc', '{{ COMOUT_ATMOS_ANALYSIS_MEM }}/{{ APREFIX_ENS }}recentered_jedi_increment.atm.i{{ '%03d' % fh }}.tile5.nc']
+    - ['{{ DATA }}/{{ 'mem%03d' | format(imem) }}/{{ APREFIX_ENS }}cubed_sphere_grid_ratmi{{ '%03d' % fh }}.tile6.nc', '{{ COMOUT_ATMOS_ANALYSIS_MEM }}/{{ APREFIX_ENS }}recentered_jedi_increment.atm.i{{ '%03d' % fh }}.tile6.nc']
     {% endfor %}
 {% endfor %}

--- a/parm/atm/atm_ecen_config.yaml.j2
+++ b/parm/atm/atm_ecen_config.yaml.j2
@@ -32,8 +32,8 @@ data_in:
     - ["{{ COMIN_ATMOS_ANALYSIS }}/{{ APREFIX }}jedi_increment.atm.i{{ '%03d' % fh }}.tile6.nc", "{{ DATA }}/{{ APREFIX }}cubed_sphere_grid_atmi{{ '%03d' % fh }}.tile6.nc"]
 
 {% for imem in range(1,NMEM_ENS+1) %}
-    {% set COM_ATMOS_ANALYSIS_MEM = ROTDIR ~ '/' ~ RUN ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/' ~ ('mem%03d' | format(imem)) ~ '/analysis/atmos' %}
-    - ['{{ COM_ATMOS_ANALYSIS_MEM }}/{{ APREFIX_ENS }}csg_jedi_increment.atm.i{{ '%03d' % fh }}.nc', '{{ DATA }}/{{ 'mem%03d' | format(imem) }}/{{ APREFIX_ENS }}cubed_sphere_grid_atmi{{ '%03d' % fh }}.nc']
+    {% set COMIN_ATMOS_ANALYSIS_MEM = ROTDIR ~ '/' ~ RUN ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/' ~ ('mem%03d' | format(imem)) ~ '/analysis/atmos' %}
+    - ['{{ COMIN_ATMOS_ANALYSIS_MEM }}/{{ APREFIX_ENS }}csg_jedi_increment.atm.i{{ '%03d' % fh }}.nc', '{{ DATA }}/{{ 'mem%03d' | format(imem) }}/{{ APREFIX_ENS }}cubed_sphere_grid_atmi{{ '%03d' % fh }}.nc']
 
 {% endfor %}
 {% endfor %}

--- a/parm/atm/atm_ecen_config.yaml.j2
+++ b/parm/atm/atm_ecen_config.yaml.j2
@@ -32,12 +32,8 @@ data_in:
     - ["{{ COMIN_ATMOS_ANALYSIS }}/{{ APREFIX }}jedi_increment.atm.i{{ '%03d' % fh }}.tile6.nc", "{{ DATA }}/{{ APREFIX }}cubed_sphere_grid_atmi{{ '%03d' % fh }}.tile6.nc"]
 
 {% for imem in range(1,NMEM_ENS+1) %}
-    {% set tmpl_dict = ({ '${ROTDIR}': ROTDIR,
-                         '${RUN}': RUN,
-                         '${YMD}': current_cycle | to_YMD,
-                         '${HH}': current_cycle | strftime('%H'),
-                         '${MEMDIR}': 'mem%03d' | format(imem) }) %}
-    - ['{{ COM_ATMOS_ANALYSIS_TMPL | replace_tmpl(tmpl_dict) }}/{{ APREFIX_ENS }}csg_jedi_increment.atm.i{{ '%03d' % fh }}.nc', '{{ DATA }}/{{ 'mem%03d' | format(imem) }}/{{ APREFIX_ENS }}cubed_sphere_grid_atmi{{ '%03d' % fh }}.nc']
+    {% set ens_anl = ROTDIR ~ '/' ~ RUN ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/' ~ ('mem%03d' | format(imem)) ~ '/analysis/atmos' %}
+    - ['{{ ens_anl }}/{{ APREFIX_ENS }}csg_jedi_increment.atm.i{{ '%03d' % fh }}.nc', '{{ DATA }}/{{ 'mem%03d' | format(imem) }}/{{ APREFIX_ENS }}cubed_sphere_grid_atmi{{ '%03d' % fh }}.nc']
 
 {% endfor %}
 {% endfor %}
@@ -52,16 +48,12 @@ data_out:
     - ['{{ DATA }}/ensemble_recenter.yaml', '{{ COMOUT_CONF }}/{{ APREFIX_ENS }}ensemble_recenter.yaml']
 {% for fh in IAUFHRS %}
     {% for imem in range(1,NMEM_ENS+1) %}
-        {% set tmpl_dict = ({ '${ROTDIR}': ROTDIR,
-                              '${RUN}': RUN,
-                              '${YMD}': current_cycle | to_YMD,
-                              '${HH}': current_cycle | strftime('%H'),
-                              '${MEMDIR}': 'mem%03d' | format(imem) }) %}
-    - ['{{ DATA }}/{{ 'mem%03d' | format(imem) }}/{{ APREFIX_ENS }}cubed_sphere_grid_ratmi{{ '%03d' % fh }}.tile1.nc', '{{ COM_ATMOS_ANALYSIS_TMPL | replace_tmpl(tmpl_dict) }}/{{ APREFIX_ENS }}recentered_jedi_increment.atm.i{{ '%03d' % fh }}.tile1.nc']
-    - ['{{ DATA }}/{{ 'mem%03d' | format(imem) }}/{{ APREFIX_ENS }}cubed_sphere_grid_ratmi{{ '%03d' % fh }}.tile2.nc', '{{ COM_ATMOS_ANALYSIS_TMPL | replace_tmpl(tmpl_dict) }}/{{ APREFIX_ENS }}recentered_jedi_increment.atm.i{{ '%03d' % fh }}.tile2.nc']
-    - ['{{ DATA }}/{{ 'mem%03d' | format(imem) }}/{{ APREFIX_ENS }}cubed_sphere_grid_ratmi{{ '%03d' % fh }}.tile3.nc', '{{ COM_ATMOS_ANALYSIS_TMPL | replace_tmpl(tmpl_dict) }}/{{ APREFIX_ENS }}recentered_jedi_increment.atm.i{{ '%03d' % fh }}.tile3.nc']
-    - ['{{ DATA }}/{{ 'mem%03d' | format(imem) }}/{{ APREFIX_ENS }}cubed_sphere_grid_ratmi{{ '%03d' % fh }}.tile4.nc', '{{ COM_ATMOS_ANALYSIS_TMPL | replace_tmpl(tmpl_dict) }}/{{ APREFIX_ENS }}recentered_jedi_increment.atm.i{{ '%03d' % fh }}.tile4.nc']
-    - ['{{ DATA }}/{{ 'mem%03d' | format(imem) }}/{{ APREFIX_ENS }}cubed_sphere_grid_ratmi{{ '%03d' % fh }}.tile5.nc', '{{ COM_ATMOS_ANALYSIS_TMPL | replace_tmpl(tmpl_dict) }}/{{ APREFIX_ENS }}recentered_jedi_increment.atm.i{{ '%03d' % fh }}.tile5.nc']
-    - ['{{ DATA }}/{{ 'mem%03d' | format(imem) }}/{{ APREFIX_ENS }}cubed_sphere_grid_ratmi{{ '%03d' % fh }}.tile6.nc', '{{ COM_ATMOS_ANALYSIS_TMPL | replace_tmpl(tmpl_dict) }}/{{ APREFIX_ENS }}recentered_jedi_increment.atm.i{{ '%03d' % fh }}.tile6.nc']
+        {% set ens_anl = ROTDIR ~ '/' ~ RUN ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/' ~ ('mem%03d' | format(imem)) ~ '/analysis/atmos' %}
+    - ['{{ DATA }}/{{ 'mem%03d' | format(imem) }}/{{ APREFIX_ENS }}cubed_sphere_grid_ratmi{{ '%03d' % fh }}.tile1.nc', '{{ ens_anl }}/{{ APREFIX_ENS }}recentered_jedi_increment.atm.i{{ '%03d' % fh }}.tile1.nc']
+    - ['{{ DATA }}/{{ 'mem%03d' | format(imem) }}/{{ APREFIX_ENS }}cubed_sphere_grid_ratmi{{ '%03d' % fh }}.tile2.nc', '{{ ens_anl }}/{{ APREFIX_ENS }}recentered_jedi_increment.atm.i{{ '%03d' % fh }}.tile2.nc']
+    - ['{{ DATA }}/{{ 'mem%03d' | format(imem) }}/{{ APREFIX_ENS }}cubed_sphere_grid_ratmi{{ '%03d' % fh }}.tile3.nc', '{{ ens_anl }}/{{ APREFIX_ENS }}recentered_jedi_increment.atm.i{{ '%03d' % fh }}.tile3.nc']
+    - ['{{ DATA }}/{{ 'mem%03d' | format(imem) }}/{{ APREFIX_ENS }}cubed_sphere_grid_ratmi{{ '%03d' % fh }}.tile4.nc', '{{ ens_anl }}/{{ APREFIX_ENS }}recentered_jedi_increment.atm.i{{ '%03d' % fh }}.tile4.nc']
+    - ['{{ DATA }}/{{ 'mem%03d' | format(imem) }}/{{ APREFIX_ENS }}cubed_sphere_grid_ratmi{{ '%03d' % fh }}.tile5.nc', '{{ ens_anl }}/{{ APREFIX_ENS }}recentered_jedi_increment.atm.i{{ '%03d' % fh }}.tile5.nc']
+    - ['{{ DATA }}/{{ 'mem%03d' | format(imem) }}/{{ APREFIX_ENS }}cubed_sphere_grid_ratmi{{ '%03d' % fh }}.tile6.nc', '{{ ens_anl }}/{{ APREFIX_ENS }}recentered_jedi_increment.atm.i{{ '%03d' % fh }}.tile6.nc']
     {% endfor %}
 {% endfor %}

--- a/parm/atm/atm_ens_config.yaml.j2
+++ b/parm/atm/atm_ens_config.yaml.j2
@@ -37,9 +37,10 @@ data_in:
     - '{{ DATA }}/fv3jedi'
     - '{{ DATA }}/crtm'
 {% for imem in range(1,NMEM_ENS+1) %}
+    {% set COMOUT_ATMOS_ANALYSIS_MEM = ROTDIR ~ '/' ~ RUN ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/' ~ ('mem%03d' | format(imem)) ~ '/analysis/atmos' %}
     - '{{ DATA }}/bkg/{{ 'mem%03d' | format(imem) }}'
     - '{{ DATA }}/anl/{{ 'mem%03d' | format(imem) }}'
-    - '{{ ROTDIR }}/{{ RUN }}.{{ current_cycle | to_YMD }}/{{ current_cycle | strftime('%H') }}/{{ 'mem%03d' | format(imem) }}/analysis/atmos'
+    - '{{ COMOUT_ATMOS_ANALYSIS_MEM }}'
 {% endfor %}
 
     copy:

--- a/parm/atm/atm_ens_config.yaml.j2
+++ b/parm/atm/atm_ens_config.yaml.j2
@@ -37,25 +37,16 @@ data_in:
     - '{{ DATA }}/fv3jedi'
     - '{{ DATA }}/crtm'
 {% for imem in range(1,NMEM_ENS+1) %}
-   {% set tmpl_dict = ({ '${ROTDIR}': ROTDIR,
-                         '${RUN}': RUN,
-                         '${YMD}': current_cycle | to_YMD,
-                         '${HH}': current_cycle | strftime('%H'),
-                         '${MEMDIR}': 'mem%03d' | format(imem) }) %}
     - '{{ DATA }}/bkg/{{ 'mem%03d' | format(imem) }}'
     - '{{ DATA }}/anl/{{ 'mem%03d' | format(imem) }}'
-    - '{{ COM_ATMOS_ANALYSIS_TMPL | replace_tmpl(tmpl_dict) }}'
+    - '{{ ROTDIR }}/{{ RUN }}.{{ current_cycle | to_YMD }}/{{ current_cycle | strftime('%H') }}/{{ 'mem%03d' | format(imem) }}/analysis/atmos'
 {% endfor %}
 
     copy:
 {% for imem in range(1,NMEM_ENS+1) %}
-   {% set tmpl_dict = ({ '${ROTDIR}': ROTDIR,
-                         '${RUN}': RUN,
-                         '${YMD}': previous_cycle | to_YMD,
-                         '${HH}': previous_cycle | strftime('%H'),
-                         '${MEMDIR}': 'mem%03d' | format(imem) }) %}
-    - ['{{ COM_ATMOS_HISTORY_TMPL | replace_tmpl(tmpl_dict) }}/{{ GPREFIX_ENS }}csg_atm.f006.nc', '{{ DATA }}/bkg/{{ 'mem%03d' | format(imem) }}/{{ GPREFIX_ENS }}cubed_sphere_grid_atmf006.nc']
-    - ['{{ COM_ATMOS_HISTORY_TMPL | replace_tmpl(tmpl_dict) }}/{{ GPREFIX_ENS }}csg_sfc.f006.nc', '{{ DATA }}/bkg/{{ 'mem%03d' | format(imem) }}/{{ GPREFIX_ENS }}cubed_sphere_grid_sfcf006.nc']
+    {% set ens_hist_prev = ROTDIR ~ '/' ~ RUN ~ '.' ~ (previous_cycle | to_YMD) ~ '/' ~ (previous_cycle | strftime('%H')) ~ '/' ~ ('mem%03d' | format(imem)) ~ '/model/atmos/history' %}
+    - ['{{ ens_hist_prev }}/{{ GPREFIX_ENS }}csg_atm.f006.nc', '{{ DATA }}/bkg/{{ 'mem%03d' | format(imem) }}/{{ GPREFIX_ENS }}cubed_sphere_grid_atmf006.nc']
+    - ['{{ ens_hist_prev }}/{{ GPREFIX_ENS }}csg_sfc.f006.nc', '{{ DATA }}/bkg/{{ 'mem%03d' | format(imem) }}/{{ GPREFIX_ENS }}cubed_sphere_grid_sfcf006.nc']
 {% endfor %}
 
 {% filter indent(width=4) %}
@@ -75,10 +66,6 @@ data_out:
     - ['{{ DATA }}/atmensanlfv3inc.yaml', '{{ COMOUT_CONF }}/{{ APREFIX_ENS }}atmensanlfv3inc.yaml']
     - ['{{ DATA }}/anl/{{ APREFIX_ENS }}cubed_sphere_grid_atmanl.ensmean.nc', '{{ COMOUT_ATMOS_ANALYSIS_ENS }}/{{ APREFIX_ENS }}csg_ensmean_jedi_analysis.atm.a006.nc']
 {% for imem in range(1,NMEM_ENS+1) %}
-   {% set tmpl_dict = ({ '${ROTDIR}': ROTDIR,
-                         '${RUN}': RUN,
-                         '${YMD}': current_cycle | to_YMD,
-                         '${HH}': current_cycle | strftime('%H'),
-                         '${MEMDIR}': 'mem%03d' | format(imem) }) %}
-    - ['{{ DATA }}/anl/{{ 'mem%03d' | format(imem) }}/{{ APREFIX_ENS }}cubed_sphere_grid_atminc.nc', '{{ COM_ATMOS_ANALYSIS_TMPL | replace_tmpl(tmpl_dict) }}/{{ APREFIX_ENS }}csg_jedi_increment.atm.i006.nc']
+    {% set ens_anl = ROTDIR ~ '/' ~ RUN ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/' ~ ('mem%03d' | format(imem)) ~ '/analysis/atmos' %}
+    - ['{{ DATA }}/anl/{{ 'mem%03d' | format(imem) }}/{{ APREFIX_ENS }}cubed_sphere_grid_atminc.nc', '{{ ens_anl }}/{{ APREFIX_ENS }}csg_jedi_increment.atm.i006.nc']
 {% endfor %}

--- a/parm/atm/atm_ens_config.yaml.j2
+++ b/parm/atm/atm_ens_config.yaml.j2
@@ -44,9 +44,9 @@ data_in:
 
     copy:
 {% for imem in range(1,NMEM_ENS+1) %}
-    {% set ens_hist_prev = ROTDIR ~ '/' ~ RUN ~ '.' ~ (previous_cycle | to_YMD) ~ '/' ~ (previous_cycle | strftime('%H')) ~ '/' ~ ('mem%03d' | format(imem)) ~ '/model/atmos/history' %}
-    - ['{{ ens_hist_prev }}/{{ GPREFIX_ENS }}csg_atm.f006.nc', '{{ DATA }}/bkg/{{ 'mem%03d' | format(imem) }}/{{ GPREFIX_ENS }}cubed_sphere_grid_atmf006.nc']
-    - ['{{ ens_hist_prev }}/{{ GPREFIX_ENS }}csg_sfc.f006.nc', '{{ DATA }}/bkg/{{ 'mem%03d' | format(imem) }}/{{ GPREFIX_ENS }}cubed_sphere_grid_sfcf006.nc']
+    {% set COMIN_ATMOS_ANALYSIS_MEM = ROTDIR ~ '/' ~ RUN ~ '.' ~ (previous_cycle | to_YMD) ~ '/' ~ (previous_cycle | strftime('%H')) ~ '/' ~ ('mem%03d' | format(imem)) ~ '/model/atmos/history' %}
+    - ['{{ COMIN_ATMOS_ANALYSIS_MEM }}/{{ GPREFIX_ENS }}csg_atm.f006.nc', '{{ DATA }}/bkg/{{ 'mem%03d' | format(imem) }}/{{ GPREFIX_ENS }}cubed_sphere_grid_atmf006.nc']
+    - ['{{ COMIN_ATMOS_ANALYSIS_MEM }}/{{ GPREFIX_ENS }}csg_sfc.f006.nc', '{{ DATA }}/bkg/{{ 'mem%03d' | format(imem) }}/{{ GPREFIX_ENS }}cubed_sphere_grid_sfcf006.nc']
 {% endfor %}
 
 {% filter indent(width=4) %}
@@ -66,6 +66,6 @@ data_out:
     - ['{{ DATA }}/atmensanlfv3inc.yaml', '{{ COMOUT_CONF }}/{{ APREFIX_ENS }}atmensanlfv3inc.yaml']
     - ['{{ DATA }}/anl/{{ APREFIX_ENS }}cubed_sphere_grid_atmanl.ensmean.nc', '{{ COMOUT_ATMOS_ANALYSIS_ENS }}/{{ APREFIX_ENS }}csg_ensmean_jedi_analysis.atm.a006.nc']
 {% for imem in range(1,NMEM_ENS+1) %}
-    {% set ens_anl = ROTDIR ~ '/' ~ RUN ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/' ~ ('mem%03d' | format(imem)) ~ '/analysis/atmos' %}
-    - ['{{ DATA }}/anl/{{ 'mem%03d' | format(imem) }}/{{ APREFIX_ENS }}cubed_sphere_grid_atminc.nc', '{{ ens_anl }}/{{ APREFIX_ENS }}csg_jedi_increment.atm.i006.nc']
+    {% set COMOUT_ATMOS_ANALYSIS_MEM = ROTDIR ~ '/' ~ RUN ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/' ~ ('mem%03d' | format(imem)) ~ '/analysis/atmos' %}
+    - ['{{ DATA }}/anl/{{ 'mem%03d' | format(imem) }}/{{ APREFIX_ENS }}cubed_sphere_grid_atminc.nc', '{{ COMOUT_ATMOS_ANALYSIS_MEM }}/{{ APREFIX_ENS }}csg_jedi_increment.atm.i006.nc']
 {% endfor %}

--- a/parm/marine/marine_ecen_config.yaml.j2
+++ b/parm/marine/marine_ecen_config.yaml.j2
@@ -22,8 +22,8 @@ data_in:
     copy_req:
 {% for imem in range(1,NMEM_ENS+1) %}
     {% set memchar = 'mem%03d' | format(imem) %}
-    {% set ens_ice_restart = ROTDIR ~ '/enkfgdas.' ~ (previous_cycle | to_YMD) ~ '/' ~ (previous_cycle | strftime('%H')) ~ '/' ~ memchar ~ '/model/ice/restart' %}
-    - ['{{ ens_ice_restart }}/{{ cice_rst_date }}.cice_model.res.nc', '{{ DATA }}/ens/cice_model.res.{{ imem | string }}.nc']
+    {% set COMIN_ICE_RESTART_PREV_MEM = ROTDIR ~ '/enkfgdas.' ~ (previous_cycle | to_YMD) ~ '/' ~ (previous_cycle | strftime('%H')) ~ '/' ~ memchar ~ '/model/ice/restart' %}
+    - ['{{ COMIN_ICE_RESTART_PREV_MEM }}/{{ cice_rst_date }}.cice_model.res.nc', '{{ DATA }}/ens/cice_model.res.{{ imem | string }}.nc']
 {% endfor %}
 
 {% filter indent(width=4) %}
@@ -34,34 +34,34 @@ data_in:
 
 data_out:
     mkdir:
-    {% set ensstat_ocn_anl = ROTDIR ~ '/' ~ RUN ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/ensstat/analysis/ocean' %}
-    {% set ensstat_ice_anl = ROTDIR ~ '/' ~ RUN ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/ensstat/analysis/ice' %}
-    - '{{ ensstat_ocn_anl }}'
-    - '{{ ensstat_ice_anl }}'
+    {% set COMOUT_OCEAN_ENSTAT_ANALYSIS = ROTDIR ~ '/' ~ RUN ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/ensstat/analysis/ocean' %}
+    {% set COMOUT_ICE_ENSTAT_ANALYSIS = ROTDIR ~ '/' ~ RUN ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/ensstat/analysis/ice' %}
+    - '{{ COMOUT_OCEAN_ENSTAT_ANALYSIS }}'
+    - '{{ COMOUT_ICE_ENSTAT_ANALYSIS }}'
 
 {% for imem in range(1,NMEM_ENS+1) %}
-    {% set mem_ocn_anl = ROTDIR ~ '/' ~ RUN ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/' ~ ('mem%03d' | format(imem)) ~ '/analysis/ocean' %}
-    {% set mem_ice_anl = ROTDIR ~ '/' ~ RUN ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/' ~ ('mem%03d' | format(imem)) ~ '/analysis/ice' %}
-    - '{{ mem_ocn_anl }}'
-    - '{{ mem_ice_anl }}'
+    {% set COMOUT_OCEAN_ANALYSIS_MEM = ROTDIR ~ '/' ~ RUN ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/' ~ ('mem%03d' | format(imem)) ~ '/analysis/ocean' %}
+    {% set COMOUT_ICE_ANALYSIS_MEM = ROTDIR ~ '/' ~ RUN ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/' ~ ('mem%03d' | format(imem)) ~ '/analysis/ice' %}
+    - '{{ COMOUT_OCEAN_ANALYSIS_MEM }}'
+    - '{{ COMOUT_ICE_ANALYSIS_MEM }}'
 {% endfor %}
 
     copy_req:
 
 {% for imem in range(1,NMEM_ENS+1) %}
-    {% set mem_ocn_anl = ROTDIR ~ '/' ~ RUN ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/' ~ ('mem%03d' | format(imem)) ~ '/analysis/ocean' %}
-    {% set mem_ice_anl = ROTDIR ~ '/' ~ RUN ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/' ~ ('mem%03d' | format(imem)) ~ '/analysis/ice' %}
+    {% set COMOUT_OCEAN_ANALYSIS_MEM = ROTDIR ~ '/' ~ RUN ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/' ~ ('mem%03d' | format(imem)) ~ '/analysis/ocean' %}
+    {% set COMOUT_ICE_ANALYSIS_MEM = ROTDIR ~ '/' ~ RUN ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/' ~ ('mem%03d' | format(imem)) ~ '/analysis/ice' %}
 
     # ocean increments are saved as 0..n-1
-    - ['{{ DATA }}/ocn.recenter.ens.{{ (imem-1) | string }}.{{ WINDOW_END | to_isotime }}.PT0S.nc', '{{ mem_ocn_anl }}/{{ APREFIX_ENS }}mom6_increment.i006.nc']
+    - ['{{ DATA }}/ocn.recenter.ens.{{ (imem-1) | string }}.{{ WINDOW_END | to_isotime }}.PT0S.nc', '{{ COMOUT_OCEAN_ANALYSIS_MEM }}/{{ APREFIX_ENS }}mom6_increment.i006.nc']
 
     # ice restarts are saved as 1..n
-    - ['{{ DATA }}/ens/cice_model.res.{{ imem | string }}.nc', '{{ mem_ice_anl }}/{{ cice_rst_date }}.analysis.cice_model.res.nc']
+    - ['{{ DATA }}/ens/cice_model.res.{{ imem | string }}.nc', '{{ COMOUT_ICE_ANALYSIS_MEM }}/{{ cice_rst_date }}.analysis.cice_model.res.nc']
 {% endfor %}
 
-    {% set ensstat_ocn_anl = ROTDIR ~ '/' ~ RUN ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/ensstat/analysis/ocean' %}
-    {% set ensstat_ice_anl = ROTDIR ~ '/' ~ RUN ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/ensstat/analysis/ice' %}
-    - ['{{ DATA }}/ocn.ensvar.incr.{{ WINDOW_END | to_isotime }}.nc', '{{ ensstat_ocn_anl }}/{{ APREFIX_ENS }}bg_ensvar.nc']
-    - ['{{ DATA }}/ice.ensvar.incr.{{ WINDOW_END | to_isotime }}.nc', '{{ ensstat_ice_anl }}/{{ APREFIX_ENS }}bg_ensvar.nc']
-    - ['{{ DATA }}/ocn.ensmean.an.{{ WINDOW_END | to_isotime }}.nc', '{{ ensstat_ocn_anl }}/{{ APREFIX_ENS }}bg_ensmean.nc']
-    - ['{{ DATA }}/ice.ensmean.an.{{ WINDOW_END | to_isotime }}.nc', '{{ ensstat_ice_anl }}/{{ APREFIX_ENS }}bg_ensmean.nc']
+    {% set COMOUT_OCEAN_ANALYSIS_ENSTAT_MEM = ROTDIR ~ '/' ~ RUN ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/ensstat/analysis/ocean' %}
+    {% set COMOUT_ICE_ANALYSIS_ENSTAT_MEM = ROTDIR ~ '/' ~ RUN ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/ensstat/analysis/ice' %}
+    - ['{{ DATA }}/ocn.ensvar.incr.{{ WINDOW_END | to_isotime }}.nc', '{{ COMOUT_OCEAN_ANALYSIS_ENSTAT_MEM }}/{{ APREFIX_ENS }}bg_ensvar.nc']
+    - ['{{ DATA }}/ice.ensvar.incr.{{ WINDOW_END | to_isotime }}.nc', '{{ COMOUT_ICE_ANALYSIS_ENSTAT_MEM }}/{{ APREFIX_ENS }}bg_ensvar.nc']
+    - ['{{ DATA }}/ocn.ensmean.an.{{ WINDOW_END | to_isotime }}.nc', '{{ COMOUT_OCEAN_ANALYSIS_ENSTAT_MEM }}/{{ APREFIX_ENS }}bg_ensmean.nc']
+    - ['{{ DATA }}/ice.ensmean.an.{{ WINDOW_END | to_isotime }}.nc', '{{ COMOUT_ICE_ANALYSIS_ENSTAT_MEM }}/{{ APREFIX_ENS }}bg_ensmean.nc']

--- a/parm/marine/marine_ecen_config.yaml.j2
+++ b/parm/marine/marine_ecen_config.yaml.j2
@@ -22,8 +22,8 @@ data_in:
     copy_req:
 {% for imem in range(1,NMEM_ENS+1) %}
     {% set memchar = 'mem%03d' | format(imem) %}
-    {% set COMIN_ICE_RESTART_PREV_MEM = ROTDIR ~ '/enkfgdas.' ~ (previous_cycle | to_YMD) ~ '/' ~ (previous_cycle | strftime('%H')) ~ '/' ~ memchar ~ '/model/ice/restart' %}
-    - ['{{ COMIN_ICE_RESTART_PREV_MEM }}/{{ cice_rst_date }}.cice_model.res.nc', '{{ DATA }}/ens/cice_model.res.{{ imem | string }}.nc']
+    {% set COMIN_ICE_RESTART_MEM_PREV = ROTDIR ~ '/enkfgdas.' ~ (previous_cycle | to_YMD) ~ '/' ~ (previous_cycle | strftime('%H')) ~ '/' ~ memchar ~ '/model/ice/restart' %}
+    - ['{{ COMIN_ICE_RESTART_MEM_PREV }}/{{ cice_rst_date }}.cice_model.res.nc', '{{ DATA }}/ens/cice_model.res.{{ imem | string }}.nc']
 {% endfor %}
 
 {% filter indent(width=4) %}
@@ -59,9 +59,9 @@ data_out:
     - ['{{ DATA }}/ens/cice_model.res.{{ imem | string }}.nc', '{{ COMOUT_ICE_ANALYSIS_MEM }}/{{ cice_rst_date }}.analysis.cice_model.res.nc']
 {% endfor %}
 
-    {% set COMOUT_OCEAN_ANALYSIS_ENSTAT_MEM = ROTDIR ~ '/' ~ RUN ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/ensstat/analysis/ocean' %}
-    {% set COMOUT_ICE_ANALYSIS_ENSTAT_MEM = ROTDIR ~ '/' ~ RUN ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/ensstat/analysis/ice' %}
-    - ['{{ DATA }}/ocn.ensvar.incr.{{ WINDOW_END | to_isotime }}.nc', '{{ COMOUT_OCEAN_ANALYSIS_ENSTAT_MEM }}/{{ APREFIX_ENS }}bg_ensvar.nc']
-    - ['{{ DATA }}/ice.ensvar.incr.{{ WINDOW_END | to_isotime }}.nc', '{{ COMOUT_ICE_ANALYSIS_ENSTAT_MEM }}/{{ APREFIX_ENS }}bg_ensvar.nc']
-    - ['{{ DATA }}/ocn.ensmean.an.{{ WINDOW_END | to_isotime }}.nc', '{{ COMOUT_OCEAN_ANALYSIS_ENSTAT_MEM }}/{{ APREFIX_ENS }}bg_ensmean.nc']
-    - ['{{ DATA }}/ice.ensmean.an.{{ WINDOW_END | to_isotime }}.nc', '{{ COMOUT_ICE_ANALYSIS_ENSTAT_MEM }}/{{ APREFIX_ENS }}bg_ensmean.nc']
+    {% set COMOUT_OCEAN_ENSTAT_ANALYSIS_MEM = ROTDIR ~ '/' ~ RUN ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/ensstat/analysis/ocean' %}
+    {% set COMOUT_ICE_ENSTAT_ANALYSIS_MEM = ROTDIR ~ '/' ~ RUN ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/ensstat/analysis/ice' %}
+    - ['{{ DATA }}/ocn.ensvar.incr.{{ WINDOW_END | to_isotime }}.nc', '{{ COMOUT_OCEAN_ENSTAT_ANALYSIS_MEM }}/{{ APREFIX_ENS }}bg_ensvar.nc']
+    - ['{{ DATA }}/ice.ensvar.incr.{{ WINDOW_END | to_isotime }}.nc', '{{ COMOUT_ICE_ENSTAT_ANALYSIS_MEM }}/{{ APREFIX_ENS }}bg_ensvar.nc']
+    - ['{{ DATA }}/ocn.ensmean.an.{{ WINDOW_END | to_isotime }}.nc', '{{ COMOUT_OCEAN_ENSTAT_ANALYSIS_MEM }}/{{ APREFIX_ENS }}bg_ensmean.nc']
+    - ['{{ DATA }}/ice.ensmean.an.{{ WINDOW_END | to_isotime }}.nc', '{{ COMOUT_ICE_ENSTAT_ANALYSIS_MEM }}/{{ APREFIX_ENS }}bg_ensmean.nc']

--- a/parm/marine/marine_ecen_config.yaml.j2
+++ b/parm/marine/marine_ecen_config.yaml.j2
@@ -22,12 +22,8 @@ data_in:
     copy_req:
 {% for imem in range(1,NMEM_ENS+1) %}
     {% set memchar = 'mem%03d' | format(imem) %}
-    {% set tmpl_dict = ({ '${ROTDIR}': ROTDIR,
-                          '${RUN}': 'enkfgdas',
-                          '${YMD}': previous_cycle | to_YMD,
-                          '${HH}': previous_cycle | strftime('%H'),
-                          '${MEMDIR}': memchar }) %}
-    - ['{{ COM_ICE_RESTART_TMPL | replace_tmpl(tmpl_dict) }}/{{ cice_rst_date }}.cice_model.res.nc', '{{ DATA }}/ens/cice_model.res.{{ imem | string }}.nc']
+    {% set ens_ice_restart = ROTDIR ~ '/enkfgdas.' ~ (previous_cycle | to_YMD) ~ '/' ~ (previous_cycle | strftime('%H')) ~ '/' ~ memchar ~ '/model/ice/restart' %}
+    - ['{{ ens_ice_restart }}/{{ cice_rst_date }}.cice_model.res.nc', '{{ DATA }}/ens/cice_model.res.{{ imem | string }}.nc']
 {% endfor %}
 
 {% filter indent(width=4) %}
@@ -38,46 +34,34 @@ data_in:
 
 data_out:
     mkdir:
-{% set tmpl_dict = ({ '${ROTDIR}': ROTDIR,
-                      '${RUN}': RUN,
-                      '${YMD}': current_cycle | to_YMD,
-                      '${HH}': current_cycle | strftime('%H'),
-                      '${MEMDIR}': 'ensstat' }) %}
-    - '{{ COM_OCEAN_ANALYSIS_TMPL | replace_tmpl(tmpl_dict) }}'
-    - '{{ COM_ICE_ANALYSIS_TMPL | replace_tmpl(tmpl_dict) }}'
+    {% set ensstat_ocn_anl = ROTDIR ~ '/' ~ RUN ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/ensstat/analysis/ocean' %}
+    {% set ensstat_ice_anl = ROTDIR ~ '/' ~ RUN ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/ensstat/analysis/ice' %}
+    - '{{ ensstat_ocn_anl }}'
+    - '{{ ensstat_ice_anl }}'
 
 {% for imem in range(1,NMEM_ENS+1) %}
-    {% set tmpl_dict = ({ '${ROTDIR}': ROTDIR,
-                          '${RUN}': RUN,
-                          '${YMD}': current_cycle | to_YMD,
-                          '${HH}': current_cycle | strftime('%H'),
-                          '${MEMDIR}': 'mem%03d' | format(imem) }) %}
-    - '{{ COM_OCEAN_ANALYSIS_TMPL | replace_tmpl(tmpl_dict) }}'
-    - '{{ COM_ICE_ANALYSIS_TMPL | replace_tmpl(tmpl_dict) }}'
+    {% set mem_ocn_anl = ROTDIR ~ '/' ~ RUN ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/' ~ ('mem%03d' | format(imem)) ~ '/analysis/ocean' %}
+    {% set mem_ice_anl = ROTDIR ~ '/' ~ RUN ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/' ~ ('mem%03d' | format(imem)) ~ '/analysis/ice' %}
+    - '{{ mem_ocn_anl }}'
+    - '{{ mem_ice_anl }}'
 {% endfor %}
 
     copy_req:
 
 {% for imem in range(1,NMEM_ENS+1) %}
-    {% set tmpl_dict = ({ '${ROTDIR}': ROTDIR,
-                          '${RUN}': RUN,
-                          '${YMD}': current_cycle | to_YMD,
-                          '${HH}': current_cycle | strftime('%H'),
-                          '${MEMDIR}': 'mem%03d' | format(imem) }) %}
+    {% set mem_ocn_anl = ROTDIR ~ '/' ~ RUN ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/' ~ ('mem%03d' | format(imem)) ~ '/analysis/ocean' %}
+    {% set mem_ice_anl = ROTDIR ~ '/' ~ RUN ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/' ~ ('mem%03d' | format(imem)) ~ '/analysis/ice' %}
 
     # ocean increments are saved as 0..n-1
-    - ['{{ DATA }}/ocn.recenter.ens.{{ (imem-1) | string }}.{{ WINDOW_END | to_isotime }}.PT0S.nc', '{{ COM_OCEAN_ANALYSIS_TMPL | replace_tmpl(tmpl_dict) }}/{{ APREFIX_ENS }}mom6_increment.i006.nc']
+    - ['{{ DATA }}/ocn.recenter.ens.{{ (imem-1) | string }}.{{ WINDOW_END | to_isotime }}.PT0S.nc', '{{ mem_ocn_anl }}/{{ APREFIX_ENS }}mom6_increment.i006.nc']
 
     # ice restarts are saved as 1..n
-    - ['{{ DATA }}/ens/cice_model.res.{{ imem | string }}.nc', '{{ COM_ICE_ANALYSIS_TMPL | replace_tmpl(tmpl_dict) }}/{{ cice_rst_date }}.analysis.cice_model.res.nc']
+    - ['{{ DATA }}/ens/cice_model.res.{{ imem | string }}.nc', '{{ mem_ice_anl }}/{{ cice_rst_date }}.analysis.cice_model.res.nc']
 {% endfor %}
 
-{% set tmpl_dict = ({ '${ROTDIR}': ROTDIR,
-                      '${RUN}': RUN,
-                      '${YMD}': current_cycle | to_YMD,
-                      '${HH}': current_cycle | strftime('%H'),
-                      '${MEMDIR}': 'ensstat' }) %}
-    - ['{{ DATA }}/ocn.ensvar.incr.{{ WINDOW_END | to_isotime }}.nc', '{{ COM_OCEAN_ANALYSIS_TMPL | replace_tmpl(tmpl_dict) }}/{{ APREFIX_ENS }}bg_ensvar.nc']
-    - ['{{ DATA }}/ice.ensvar.incr.{{ WINDOW_END | to_isotime }}.nc', '{{ COM_ICE_ANALYSIS_TMPL | replace_tmpl(tmpl_dict) }}/{{ APREFIX_ENS }}bg_ensvar.nc']
-    - ['{{ DATA }}/ocn.ensmean.an.{{ WINDOW_END | to_isotime }}.nc', '{{ COM_OCEAN_ANALYSIS_TMPL | replace_tmpl(tmpl_dict) }}/{{ APREFIX_ENS }}bg_ensmean.nc']
-    - ['{{ DATA }}/ice.ensmean.an.{{ WINDOW_END | to_isotime }}.nc', '{{ COM_ICE_ANALYSIS_TMPL | replace_tmpl(tmpl_dict) }}/{{ APREFIX_ENS }}bg_ensmean.nc']
+    {% set ensstat_ocn_anl = ROTDIR ~ '/' ~ RUN ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/ensstat/analysis/ocean' %}
+    {% set ensstat_ice_anl = ROTDIR ~ '/' ~ RUN ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/ensstat/analysis/ice' %}
+    - ['{{ DATA }}/ocn.ensvar.incr.{{ WINDOW_END | to_isotime }}.nc', '{{ ensstat_ocn_anl }}/{{ APREFIX_ENS }}bg_ensvar.nc']
+    - ['{{ DATA }}/ice.ensvar.incr.{{ WINDOW_END | to_isotime }}.nc', '{{ ensstat_ice_anl }}/{{ APREFIX_ENS }}bg_ensvar.nc']
+    - ['{{ DATA }}/ocn.ensmean.an.{{ WINDOW_END | to_isotime }}.nc', '{{ ensstat_ocn_anl }}/{{ APREFIX_ENS }}bg_ensmean.nc']
+    - ['{{ DATA }}/ice.ensmean.an.{{ WINDOW_END | to_isotime }}.nc', '{{ ensstat_ice_anl }}/{{ APREFIX_ENS }}bg_ensmean.nc']

--- a/parm/marine/marine_ens_config.yaml.j2
+++ b/parm/marine/marine_ens_config.yaml.j2
@@ -38,28 +38,20 @@ data_out:
     - '{{ COMOUT_OCEAN_LETKF }}/diags'
 
 {% for mem in range(1, NMEM_ENS + 1) %}
-    {% set tmpl_dict = {'${ROTDIR}':ROTDIR,
-                       '${RUN}': GDUMP_ENS,
-                       '${YMD}': current_cycle | to_YMD,
-                       '${HH}': current_cycle | strftime('%H'),
-                       '${MEMDIR}':'mem' + '%03d' % mem} %}
-
-    - '{{ COM_OCEAN_LETKF_TMPL | replace_tmpl(tmpl_dict) }}'
-    - '{{ COM_ICE_LETKF_TMPL | replace_tmpl(tmpl_dict) }}'
+    {% set mem_ocn_letkf = ROTDIR ~ '/' ~ GDUMP_ENS ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/mem' ~ '%03d' % mem ~ '/analysis/ocean/letkf' %}
+    {% set mem_ice_letkf = ROTDIR ~ '/' ~ GDUMP_ENS ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/mem' ~ '%03d' % mem ~ '/analysis/ice/letkf' %}
+    - '{{ mem_ocn_letkf }}'
+    - '{{ mem_ice_letkf }}'
 {% endfor %}
 
     copy_req:
 
     # save letkf analysis to comout
 {% for mem in range(1, NMEM_ENS + 1) %}
-    {% set tmpl_dict = {'${ROTDIR}':ROTDIR,
-                       '${RUN}': GDUMP_ENS,
-                       '${YMD}': current_cycle | to_YMD,
-                       '${HH}': current_cycle | strftime('%H'),
-                       '${MEMDIR}':'mem' + '%03d' % mem} %}
-
-    - ['{{ DATA }}/letkf_output/ocn.letkf.ens.{{ mem }}.{{ WINDOW_BEGIN | to_isotime }}.PT3H.nc', '{{ COM_OCEAN_LETKF_TMPL | replace_tmpl(tmpl_dict) }}/{{ APREFIX_ENS }}jedi_analysis.a006.nc']
-    - ['{{ DATA }}/letkf_output/ice.letkf.ens.{{ mem }}.{{ WINDOW_BEGIN | to_isotime }}.PT3H.nc', '{{ COM_ICE_LETKF_TMPL | replace_tmpl(tmpl_dict) }}/{{ APREFIX_ENS }}jedi_analysis.a006.nc']
+    {% set mem_ocn_letkf = ROTDIR ~ '/' ~ GDUMP_ENS ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/mem' ~ '%03d' % mem ~ '/analysis/ocean/letkf' %}
+    {% set mem_ice_letkf = ROTDIR ~ '/' ~ GDUMP_ENS ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/mem' ~ '%03d' % mem ~ '/analysis/ice/letkf' %}
+    - ['{{ DATA }}/letkf_output/ocn.letkf.ens.{{ mem }}.{{ WINDOW_BEGIN | to_isotime }}.PT3H.nc', '{{ mem_ocn_letkf }}/{{ APREFIX_ENS }}jedi_analysis.a006.nc']
+    - ['{{ DATA }}/letkf_output/ice.letkf.ens.{{ mem }}.{{ WINDOW_BEGIN | to_isotime }}.PT3H.nc', '{{ mem_ice_letkf }}/{{ APREFIX_ENS }}jedi_analysis.a006.nc']
 {% endfor %}
 
     # Save LETKF background and analysis mean and variance, mean analysis increment

--- a/parm/marine/marine_ens_config.yaml.j2
+++ b/parm/marine/marine_ens_config.yaml.j2
@@ -38,20 +38,20 @@ data_out:
     - '{{ COMOUT_OCEAN_LETKF }}/diags'
 
 {% for mem in range(1, NMEM_ENS + 1) %}
-    {% set mem_ocn_letkf = ROTDIR ~ '/' ~ GDUMP_ENS ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/mem' ~ '%03d' % mem ~ '/analysis/ocean/letkf' %}
-    {% set mem_ice_letkf = ROTDIR ~ '/' ~ GDUMP_ENS ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/mem' ~ '%03d' % mem ~ '/analysis/ice/letkf' %}
-    - '{{ mem_ocn_letkf }}'
-    - '{{ mem_ice_letkf }}'
+    {% set COMOUT_OCEAN_LETKF_MEM = ROTDIR ~ '/' ~ GDUMP_ENS ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/mem' ~ '%03d' % mem ~ '/analysis/ocean/letkf' %}
+    {% set COMOUT_ICE_LETKF_MEM = ROTDIR ~ '/' ~ GDUMP_ENS ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/mem' ~ '%03d' % mem ~ '/analysis/ice/letkf' %}
+    - '{{ COMOUT_OCEAN_LETKF_MEM }}'
+    - '{{ COMOUT_ICE_LETKF_MEM }}'
 {% endfor %}
 
     copy_req:
 
     # save letkf analysis to comout
 {% for mem in range(1, NMEM_ENS + 1) %}
-    {% set mem_ocn_letkf = ROTDIR ~ '/' ~ GDUMP_ENS ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/mem' ~ '%03d' % mem ~ '/analysis/ocean/letkf' %}
-    {% set mem_ice_letkf = ROTDIR ~ '/' ~ GDUMP_ENS ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/mem' ~ '%03d' % mem ~ '/analysis/ice/letkf' %}
-    - ['{{ DATA }}/letkf_output/ocn.letkf.ens.{{ mem }}.{{ WINDOW_BEGIN | to_isotime }}.PT3H.nc', '{{ mem_ocn_letkf }}/{{ APREFIX_ENS }}jedi_analysis.a006.nc']
-    - ['{{ DATA }}/letkf_output/ice.letkf.ens.{{ mem }}.{{ WINDOW_BEGIN | to_isotime }}.PT3H.nc', '{{ mem_ice_letkf }}/{{ APREFIX_ENS }}jedi_analysis.a006.nc']
+    {% set COMOUT_OCEAN_LETKF_MEM = ROTDIR ~ '/' ~ GDUMP_ENS ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/mem' ~ '%03d' % mem ~ '/analysis/ocean/letkf' %}
+    {% set COMOUT_ICE_LETKF_MEM = ROTDIR ~ '/' ~ GDUMP_ENS ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/mem' ~ '%03d' % mem ~ '/analysis/ice/letkf' %}
+    - ['{{ DATA }}/letkf_output/ocn.letkf.ens.{{ mem }}.{{ WINDOW_BEGIN | to_isotime }}.PT3H.nc', '{{ COMOUT_OCEAN_LETKF_MEM }}/{{ APREFIX_ENS }}jedi_analysis.a006.nc']
+    - ['{{ DATA }}/letkf_output/ice.letkf.ens.{{ mem }}.{{ WINDOW_BEGIN | to_isotime }}.PT3H.nc', '{{ COMOUT_ICE_LETKF_MEM }}/{{ APREFIX_ENS }}jedi_analysis.a006.nc']
 {% endfor %}
 
     # Save LETKF background and analysis mean and variance, mean analysis increment

--- a/parm/marine/marine_ens_stage_bkg.yaml.j2
+++ b/parm/marine/marine_ens_stage_bkg.yaml.j2
@@ -7,14 +7,8 @@
     {% if gmem > NMEM_ENS_MAX %}
         {% set gmem = gmem-NMEM_ENS_MAX %}
     {% endif %}
+    {% set ens_bkg_base = ROTDIR ~ '/' ~ GDUMP_ENS ~ '.' ~ (previous_cycle | to_YMD) ~ '/' ~ (previous_cycle | strftime('%H')) ~ '/mem' ~ '%03d' % gmem %}
 
-    # define variables used in the history template
-    {% set tmpl_dict = {'${ROTDIR}':ROTDIR,
-                        '${RUN}': GDUMP_ENS,
-                        '${YMD}':previous_cycle | to_YMD,
-                        '${HH}':previous_cycle | strftime('%H'),
-                        '${MEMDIR}':'mem' + '%03d' % gmem} %}
-
-- ['{{ COM_OCEAN_HISTORY_TMPL | replace_tmpl(tmpl_dict) }}/{{ GPREFIX_ENS }}inst.f006.nc', '{{ DATAens }}/ens/ocean.{{ mem }}.nc']
-- ['{{ COM_ICE_HISTORY_TMPL | replace_tmpl(tmpl_dict) }}/{{ GPREFIX_ENS }}inst.f006.nc', '{{ DATAens }}/ens/ice.{{ mem }}.nc']
+- ['{{ ens_bkg_base }}/model/ocean/history/{{ GPREFIX_ENS }}inst.f006.nc', '{{ DATAens }}/ens/ocean.{{ mem }}.nc']
+- ['{{ ens_bkg_base }}/model/ice/history/{{ GPREFIX_ENS }}inst.f006.nc', '{{ DATAens }}/ens/ice.{{ mem }}.nc']
 {% endfor %}

--- a/parm/marine/marine_ens_stage_bkg.yaml.j2
+++ b/parm/marine/marine_ens_stage_bkg.yaml.j2
@@ -8,9 +8,9 @@
         {% set gmem = gmem-NMEM_ENS_MAX %}
     {% endif %}
     {% set ens_bkg_base = ROTDIR ~ '/' ~ GDUMP_ENS ~ '.' ~ (previous_cycle | to_YMD) ~ '/' ~ (previous_cycle | strftime('%H')) ~ '/mem' ~ '%03d' % gmem %}
-    {% set COMIN_OCEAN_HISTORY_PREV_MEM = ens_bkg_base ~ '/model/ocean/history' %}
-    {% set COMIN_ICE_HISTORY_PREV_MEM = ens_bkg_base ~ '/model/ice/history' %}
+    {% set COMIN_OCEAN_HISTORY_MEM_PREV = ens_bkg_base ~ '/model/ocean/history' %}
+    {% set COMIN_ICE_HISTORY_MEM_PREV = ens_bkg_base ~ '/model/ice/history' %}
 
-- ['{{ COMIN_OCEAN_HISTORY_PREV_MEM }}/{{ GPREFIX_ENS }}inst.f006.nc', '{{ DATAens }}/ens/ocean.{{ mem }}.nc']
-- ['{{ COMIN_ICE_HISTORY_PREV_MEM }}/{{ GPREFIX_ENS }}inst.f006.nc', '{{ DATAens }}/ens/ice.{{ mem }}.nc']
+- ['{{ COMIN_OCEAN_HISTORY_MEM_PREV }}/{{ GPREFIX_ENS }}inst.f006.nc', '{{ DATAens }}/ens/ocean.{{ mem }}.nc']
+- ['{{ COMIN_ICE_HISTORY_MEM_PREV }}/{{ GPREFIX_ENS }}inst.f006.nc', '{{ DATAens }}/ens/ice.{{ mem }}.nc']
 {% endfor %}

--- a/parm/marine/marine_ens_stage_bkg.yaml.j2
+++ b/parm/marine/marine_ens_stage_bkg.yaml.j2
@@ -8,7 +8,9 @@
         {% set gmem = gmem-NMEM_ENS_MAX %}
     {% endif %}
     {% set ens_bkg_base = ROTDIR ~ '/' ~ GDUMP_ENS ~ '.' ~ (previous_cycle | to_YMD) ~ '/' ~ (previous_cycle | strftime('%H')) ~ '/mem' ~ '%03d' % gmem %}
+    {% set COMIN_OCEAN_HISTORY_PREV_MEM = ens_bkg_base ~ '/model/ocean/history' %}
+    {% set COMIN_ICE_HISTORY_PREV_MEM = ens_bkg_base ~ '/model/ice/history' %}
 
-- ['{{ ens_bkg_base }}/model/ocean/history/{{ GPREFIX_ENS }}inst.f006.nc', '{{ DATAens }}/ens/ocean.{{ mem }}.nc']
-- ['{{ ens_bkg_base }}/model/ice/history/{{ GPREFIX_ENS }}inst.f006.nc', '{{ DATAens }}/ens/ice.{{ mem }}.nc']
+- ['{{ COMIN_OCEAN_HISTORY_PREV_MEM }}/{{ GPREFIX_ENS }}inst.f006.nc', '{{ DATAens }}/ens/ocean.{{ mem }}.nc']
+- ['{{ COMIN_ICE_HISTORY_PREV_MEM }}/{{ GPREFIX_ENS }}inst.f006.nc', '{{ DATAens }}/ens/ice.{{ mem }}.nc']
 {% endfor %}

--- a/parm/snow/snow_ens_config.yaml.j2
+++ b/parm/snow/snow_ens_config.yaml.j2
@@ -43,38 +43,38 @@ data_in:
         {% set gmem = gmem-NMEM_ENS_MAX %}
     {% endif %}
     # Construct per-member restart path for the previous enkfgdas cycle directly.
-    {% set ens_restart = ROTDIR ~ '/enkfgdas.' ~ (previous_cycle | to_YMD) ~ '/' ~ (previous_cycle | strftime('%H')) ~ '/mem' ~ '%03d' % gmem ~ '/model/atmos/restart' %}
+    {% set COMIN_ATMOS_RESTART_PREV_MEM = ROTDIR ~ '/enkfgdas.' ~ (previous_cycle | to_YMD) ~ '/' ~ (previous_cycle | strftime('%H')) ~ '/mem' ~ '%03d' % gmem ~ '/model/atmos/restart' %}
 
     # copy coupler file
-    - ['{{ ens_restart }}/{{ current_cycle | to_fv3time }}.coupler.res', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ current_cycle | to_fv3time }}.coupler.res', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
     # we need to copy them to two places, one serves as the basis for the analysis
-    - ['{{ ens_restart }}/{{ current_cycle | to_fv3time }}.sfc_data.tile1.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
-    - ['{{ ens_restart }}/{{ current_cycle | to_fv3time }}.sfc_data.tile2.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
-    - ['{{ ens_restart }}/{{ current_cycle | to_fv3time }}.sfc_data.tile3.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
-    - ['{{ ens_restart }}/{{ current_cycle | to_fv3time }}.sfc_data.tile4.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
-    - ['{{ ens_restart }}/{{ current_cycle | to_fv3time }}.sfc_data.tile5.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
-    - ['{{ ens_restart }}/{{ current_cycle | to_fv3time }}.sfc_data.tile6.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
-    - ['{{ ens_restart }}/{{ current_cycle | to_fv3time }}.sfc_data.tile1.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
-    - ['{{ ens_restart }}/{{ current_cycle | to_fv3time }}.sfc_data.tile2.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
-    - ['{{ ens_restart }}/{{ current_cycle | to_fv3time }}.sfc_data.tile3.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
-    - ['{{ ens_restart }}/{{ current_cycle | to_fv3time }}.sfc_data.tile4.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
-    - ['{{ ens_restart }}/{{ current_cycle | to_fv3time }}.sfc_data.tile5.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
-    - ['{{ ens_restart }}/{{ current_cycle | to_fv3time }}.sfc_data.tile6.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ current_cycle | to_fv3time }}.sfc_data.tile1.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ current_cycle | to_fv3time }}.sfc_data.tile2.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ current_cycle | to_fv3time }}.sfc_data.tile3.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ current_cycle | to_fv3time }}.sfc_data.tile4.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ current_cycle | to_fv3time }}.sfc_data.tile5.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ current_cycle | to_fv3time }}.sfc_data.tile6.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ current_cycle | to_fv3time }}.sfc_data.tile1.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ current_cycle | to_fv3time }}.sfc_data.tile2.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ current_cycle | to_fv3time }}.sfc_data.tile3.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ current_cycle | to_fv3time }}.sfc_data.tile4.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ current_cycle | to_fv3time }}.sfc_data.tile5.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ current_cycle | to_fv3time }}.sfc_data.tile6.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
     {% if DOIAU %}
         # if using IAU, also need backgrounds copied at the beginning of the window
         # we need to copy them to two places, one serves as the basis for the analysis
-    - ['{{ ens_restart }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile1.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
-    - ['{{ ens_restart }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile2.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
-    - ['{{ ens_restart }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile3.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
-    - ['{{ ens_restart }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile4.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
-    - ['{{ ens_restart }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile5.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
-    - ['{{ ens_restart }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile6.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
-    - ['{{ ens_restart }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile1.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
-    - ['{{ ens_restart }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile2.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
-    - ['{{ ens_restart }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile3.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
-    - ['{{ ens_restart }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile4.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
-    - ['{{ ens_restart }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile5.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
-    - ['{{ ens_restart }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile6.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile1.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile2.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile3.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile4.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile5.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile6.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile1.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile2.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile3.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile4.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile5.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile6.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
     {% endif %}
 {% endfor %}
 
@@ -168,19 +168,19 @@ data_out:
 {% for bkgtime in bkgtimes %}
     {% for imem in range(1, NMEM_ENS+1) %}
         {% set memchar = 'mem%03d' | format(imem) %}
-        {% set snow_anl = ROTDIR ~ '/' ~ RUN ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/' ~ memchar ~ '/analysis/snow' %}
+        {% set COMIN_SNOW_ANALYSIS_MEM = ROTDIR ~ '/' ~ RUN ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/' ~ memchar ~ '/analysis/snow' %}
     # Analysis
     - ['{{ DATA }}/anl/{{ memchar }}/{{ bkgtime | to_fv3time }}.sfc_data.tile1.nc',
-       '{{ snow_anl }}/{{ bkgtime | to_fv3time }}.snow_analysis.sfc_data.tile1.nc']
+       '{{ COMIN_SNOW_ANALYSIS_MEM }}/{{ bkgtime | to_fv3time }}.snow_analysis.sfc_data.tile1.nc']
     - ['{{ DATA }}/anl/{{ memchar }}/{{ bkgtime | to_fv3time }}.sfc_data.tile2.nc',
-       '{{ snow_anl }}/{{ bkgtime | to_fv3time }}.snow_analysis.sfc_data.tile2.nc']
+       '{{ COMIN_SNOW_ANALYSIS_MEM }}/{{ bkgtime | to_fv3time }}.snow_analysis.sfc_data.tile2.nc']
     - ['{{ DATA }}/anl/{{ memchar }}/{{ bkgtime | to_fv3time }}.sfc_data.tile3.nc',
-       '{{ snow_anl }}/{{ bkgtime | to_fv3time }}.snow_analysis.sfc_data.tile3.nc']
+       '{{ COMIN_SNOW_ANALYSIS_MEM }}/{{ bkgtime | to_fv3time }}.snow_analysis.sfc_data.tile3.nc']
     - ['{{ DATA }}/anl/{{ memchar }}/{{ bkgtime | to_fv3time }}.sfc_data.tile4.nc',
-       '{{ snow_anl }}/{{ bkgtime | to_fv3time }}.snow_analysis.sfc_data.tile4.nc']
+       '{{ COMIN_SNOW_ANALYSIS_MEM }}/{{ bkgtime | to_fv3time }}.snow_analysis.sfc_data.tile4.nc']
     - ['{{ DATA }}/anl/{{ memchar }}/{{ bkgtime | to_fv3time }}.sfc_data.tile5.nc',
-       '{{ snow_anl }}/{{ bkgtime | to_fv3time }}.snow_analysis.sfc_data.tile5.nc']
+       '{{ COMIN_SNOW_ANALYSIS_MEM }}/{{ bkgtime | to_fv3time }}.snow_analysis.sfc_data.tile5.nc']
     - ['{{ DATA }}/anl/{{ memchar }}/{{ bkgtime | to_fv3time }}.sfc_data.tile6.nc',
-       '{{ snow_anl }}/{{ bkgtime | to_fv3time }}.snow_analysis.sfc_data.tile6.nc']
+       '{{ COMIN_SNOW_ANALYSIS_MEM }}/{{ bkgtime | to_fv3time }}.snow_analysis.sfc_data.tile6.nc']
     {% endfor %}
 {% endfor %}

--- a/parm/snow/snow_ens_config.yaml.j2
+++ b/parm/snow/snow_ens_config.yaml.j2
@@ -42,44 +42,39 @@ data_in:
     {% if gmem > NMEM_ENS_MAX %}
         {% set gmem = gmem-NMEM_ENS_MAX %}
     {% endif %}
-    # define variables
-    # Declare a dict of search and replace terms to run on each template
-    {% set tmpl_dict = {'${ROTDIR}':ROTDIR,
-                        '${RUN}':'enkfgdas',
-                        '${YMD}':previous_cycle | to_YMD,
-                        '${HH}':previous_cycle | strftime('%H'),
-                        '${MEMDIR}':'mem' + '%03d' % gmem} %}
+    # Construct per-member restart path for the previous enkfgdas cycle directly.
+    {% set ens_restart = ROTDIR ~ '/enkfgdas.' ~ (previous_cycle | to_YMD) ~ '/' ~ (previous_cycle | strftime('%H')) ~ '/mem' ~ '%03d' % gmem ~ '/model/atmos/restart' %}
 
     # copy coupler file
-    - ['{{ COM_ATMOS_RESTART_TMPL | replace_tmpl(tmpl_dict) }}/{{ current_cycle | to_fv3time }}.coupler.res', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
+    - ['{{ ens_restart }}/{{ current_cycle | to_fv3time }}.coupler.res', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
     # we need to copy them to two places, one serves as the basis for the analysis
-    - ['{{ COM_ATMOS_RESTART_TMPL | replace_tmpl(tmpl_dict) }}/{{ current_cycle | to_fv3time }}.sfc_data.tile1.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
-    - ['{{ COM_ATMOS_RESTART_TMPL | replace_tmpl(tmpl_dict) }}/{{ current_cycle | to_fv3time }}.sfc_data.tile2.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
-    - ['{{ COM_ATMOS_RESTART_TMPL | replace_tmpl(tmpl_dict) }}/{{ current_cycle | to_fv3time }}.sfc_data.tile3.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
-    - ['{{ COM_ATMOS_RESTART_TMPL | replace_tmpl(tmpl_dict) }}/{{ current_cycle | to_fv3time }}.sfc_data.tile4.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
-    - ['{{ COM_ATMOS_RESTART_TMPL | replace_tmpl(tmpl_dict) }}/{{ current_cycle | to_fv3time }}.sfc_data.tile5.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
-    - ['{{ COM_ATMOS_RESTART_TMPL | replace_tmpl(tmpl_dict) }}/{{ current_cycle | to_fv3time }}.sfc_data.tile6.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
-    - ['{{ COM_ATMOS_RESTART_TMPL | replace_tmpl(tmpl_dict) }}/{{ current_cycle | to_fv3time }}.sfc_data.tile1.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
-    - ['{{ COM_ATMOS_RESTART_TMPL | replace_tmpl(tmpl_dict) }}/{{ current_cycle | to_fv3time }}.sfc_data.tile2.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
-    - ['{{ COM_ATMOS_RESTART_TMPL | replace_tmpl(tmpl_dict) }}/{{ current_cycle | to_fv3time }}.sfc_data.tile3.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
-    - ['{{ COM_ATMOS_RESTART_TMPL | replace_tmpl(tmpl_dict) }}/{{ current_cycle | to_fv3time }}.sfc_data.tile4.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
-    - ['{{ COM_ATMOS_RESTART_TMPL | replace_tmpl(tmpl_dict) }}/{{ current_cycle | to_fv3time }}.sfc_data.tile5.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
-    - ['{{ COM_ATMOS_RESTART_TMPL | replace_tmpl(tmpl_dict) }}/{{ current_cycle | to_fv3time }}.sfc_data.tile6.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
+    - ['{{ ens_restart }}/{{ current_cycle | to_fv3time }}.sfc_data.tile1.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
+    - ['{{ ens_restart }}/{{ current_cycle | to_fv3time }}.sfc_data.tile2.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
+    - ['{{ ens_restart }}/{{ current_cycle | to_fv3time }}.sfc_data.tile3.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
+    - ['{{ ens_restart }}/{{ current_cycle | to_fv3time }}.sfc_data.tile4.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
+    - ['{{ ens_restart }}/{{ current_cycle | to_fv3time }}.sfc_data.tile5.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
+    - ['{{ ens_restart }}/{{ current_cycle | to_fv3time }}.sfc_data.tile6.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
+    - ['{{ ens_restart }}/{{ current_cycle | to_fv3time }}.sfc_data.tile1.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
+    - ['{{ ens_restart }}/{{ current_cycle | to_fv3time }}.sfc_data.tile2.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
+    - ['{{ ens_restart }}/{{ current_cycle | to_fv3time }}.sfc_data.tile3.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
+    - ['{{ ens_restart }}/{{ current_cycle | to_fv3time }}.sfc_data.tile4.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
+    - ['{{ ens_restart }}/{{ current_cycle | to_fv3time }}.sfc_data.tile5.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
+    - ['{{ ens_restart }}/{{ current_cycle | to_fv3time }}.sfc_data.tile6.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
     {% if DOIAU %}
         # if using IAU, also need backgrounds copied at the beginning of the window
         # we need to copy them to two places, one serves as the basis for the analysis
-    - ['{{ COM_ATMOS_RESTART_TMPL | replace_tmpl(tmpl_dict) }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile1.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
-    - ['{{ COM_ATMOS_RESTART_TMPL | replace_tmpl(tmpl_dict) }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile2.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
-    - ['{{ COM_ATMOS_RESTART_TMPL | replace_tmpl(tmpl_dict) }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile3.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
-    - ['{{ COM_ATMOS_RESTART_TMPL | replace_tmpl(tmpl_dict) }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile4.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
-    - ['{{ COM_ATMOS_RESTART_TMPL | replace_tmpl(tmpl_dict) }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile5.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
-    - ['{{ COM_ATMOS_RESTART_TMPL | replace_tmpl(tmpl_dict) }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile6.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
-    - ['{{ COM_ATMOS_RESTART_TMPL | replace_tmpl(tmpl_dict) }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile1.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
-    - ['{{ COM_ATMOS_RESTART_TMPL | replace_tmpl(tmpl_dict) }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile2.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
-    - ['{{ COM_ATMOS_RESTART_TMPL | replace_tmpl(tmpl_dict) }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile3.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
-    - ['{{ COM_ATMOS_RESTART_TMPL | replace_tmpl(tmpl_dict) }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile4.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
-    - ['{{ COM_ATMOS_RESTART_TMPL | replace_tmpl(tmpl_dict) }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile5.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
-    - ['{{ COM_ATMOS_RESTART_TMPL | replace_tmpl(tmpl_dict) }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile6.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
+    - ['{{ ens_restart }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile1.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
+    - ['{{ ens_restart }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile2.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
+    - ['{{ ens_restart }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile3.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
+    - ['{{ ens_restart }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile4.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
+    - ['{{ ens_restart }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile5.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
+    - ['{{ ens_restart }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile6.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
+    - ['{{ ens_restart }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile1.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
+    - ['{{ ens_restart }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile2.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
+    - ['{{ ens_restart }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile3.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
+    - ['{{ ens_restart }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile4.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
+    - ['{{ ens_restart }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile5.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
+    - ['{{ ens_restart }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile6.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
     {% endif %}
 {% endfor %}
 
@@ -173,23 +168,19 @@ data_out:
 {% for bkgtime in bkgtimes %}
     {% for imem in range(1, NMEM_ENS+1) %}
         {% set memchar = 'mem%03d' | format(imem) %}
-        {% set tmpl_dict = ({ '${ROTDIR}': ROTDIR,
-                              '${RUN}': RUN,
-                              '${YMD}': current_cycle | to_YMD,
-                              '${HH}': current_cycle | strftime('%H'),
-                              '${MEMDIR}': memchar }) %}
+        {% set snow_anl = ROTDIR ~ '/' ~ RUN ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/' ~ memchar ~ '/analysis/snow' %}
     # Analysis
     - ['{{ DATA }}/anl/{{ memchar }}/{{ bkgtime | to_fv3time }}.sfc_data.tile1.nc',
-       '{{ COM_SNOW_ANALYSIS_TMPL | replace_tmpl(tmpl_dict) }}/{{ bkgtime | to_fv3time }}.snow_analysis.sfc_data.tile1.nc']
+       '{{ snow_anl }}/{{ bkgtime | to_fv3time }}.snow_analysis.sfc_data.tile1.nc']
     - ['{{ DATA }}/anl/{{ memchar }}/{{ bkgtime | to_fv3time }}.sfc_data.tile2.nc',
-       '{{ COM_SNOW_ANALYSIS_TMPL | replace_tmpl(tmpl_dict) }}/{{ bkgtime | to_fv3time }}.snow_analysis.sfc_data.tile2.nc']
+       '{{ snow_anl }}/{{ bkgtime | to_fv3time }}.snow_analysis.sfc_data.tile2.nc']
     - ['{{ DATA }}/anl/{{ memchar }}/{{ bkgtime | to_fv3time }}.sfc_data.tile3.nc',
-       '{{ COM_SNOW_ANALYSIS_TMPL | replace_tmpl(tmpl_dict) }}/{{ bkgtime | to_fv3time }}.snow_analysis.sfc_data.tile3.nc']
+       '{{ snow_anl }}/{{ bkgtime | to_fv3time }}.snow_analysis.sfc_data.tile3.nc']
     - ['{{ DATA }}/anl/{{ memchar }}/{{ bkgtime | to_fv3time }}.sfc_data.tile4.nc',
-       '{{ COM_SNOW_ANALYSIS_TMPL | replace_tmpl(tmpl_dict) }}/{{ bkgtime | to_fv3time }}.snow_analysis.sfc_data.tile4.nc']
+       '{{ snow_anl }}/{{ bkgtime | to_fv3time }}.snow_analysis.sfc_data.tile4.nc']
     - ['{{ DATA }}/anl/{{ memchar }}/{{ bkgtime | to_fv3time }}.sfc_data.tile5.nc',
-       '{{ COM_SNOW_ANALYSIS_TMPL | replace_tmpl(tmpl_dict) }}/{{ bkgtime | to_fv3time }}.snow_analysis.sfc_data.tile5.nc']
+       '{{ snow_anl }}/{{ bkgtime | to_fv3time }}.snow_analysis.sfc_data.tile5.nc']
     - ['{{ DATA }}/anl/{{ memchar }}/{{ bkgtime | to_fv3time }}.sfc_data.tile6.nc',
-       '{{ COM_SNOW_ANALYSIS_TMPL | replace_tmpl(tmpl_dict) }}/{{ bkgtime | to_fv3time }}.snow_analysis.sfc_data.tile6.nc']
+       '{{ snow_anl }}/{{ bkgtime | to_fv3time }}.snow_analysis.sfc_data.tile6.nc']
     {% endfor %}
 {% endfor %}

--- a/parm/snow/snow_ens_config.yaml.j2
+++ b/parm/snow/snow_ens_config.yaml.j2
@@ -168,19 +168,19 @@ data_out:
 {% for bkgtime in bkgtimes %}
     {% for imem in range(1, NMEM_ENS+1) %}
         {% set memchar = 'mem%03d' | format(imem) %}
-        {% set COMIN_SNOW_ANALYSIS_MEM = ROTDIR ~ '/' ~ RUN ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/' ~ memchar ~ '/analysis/snow' %}
+        {% set COMOUT_SNOW_ANALYSIS_MEM = ROTDIR ~ '/' ~ RUN ~ '.' ~ (current_cycle | to_YMD) ~ '/' ~ (current_cycle | strftime('%H')) ~ '/' ~ memchar ~ '/analysis/snow' %}
     # Analysis
     - ['{{ DATA }}/anl/{{ memchar }}/{{ bkgtime | to_fv3time }}.sfc_data.tile1.nc',
-       '{{ COMIN_SNOW_ANALYSIS_MEM }}/{{ bkgtime | to_fv3time }}.snow_analysis.sfc_data.tile1.nc']
+       '{{ COMOUT_SNOW_ANALYSIS_MEM }}/{{ bkgtime | to_fv3time }}.snow_analysis.sfc_data.tile1.nc']
     - ['{{ DATA }}/anl/{{ memchar }}/{{ bkgtime | to_fv3time }}.sfc_data.tile2.nc',
-       '{{ COMIN_SNOW_ANALYSIS_MEM }}/{{ bkgtime | to_fv3time }}.snow_analysis.sfc_data.tile2.nc']
+       '{{ COMOUT_SNOW_ANALYSIS_MEM }}/{{ bkgtime | to_fv3time }}.snow_analysis.sfc_data.tile2.nc']
     - ['{{ DATA }}/anl/{{ memchar }}/{{ bkgtime | to_fv3time }}.sfc_data.tile3.nc',
-       '{{ COMIN_SNOW_ANALYSIS_MEM }}/{{ bkgtime | to_fv3time }}.snow_analysis.sfc_data.tile3.nc']
+       '{{ COMOUT_SNOW_ANALYSIS_MEM }}/{{ bkgtime | to_fv3time }}.snow_analysis.sfc_data.tile3.nc']
     - ['{{ DATA }}/anl/{{ memchar }}/{{ bkgtime | to_fv3time }}.sfc_data.tile4.nc',
-       '{{ COMIN_SNOW_ANALYSIS_MEM }}/{{ bkgtime | to_fv3time }}.snow_analysis.sfc_data.tile4.nc']
+       '{{ COMOUT_SNOW_ANALYSIS_MEM }}/{{ bkgtime | to_fv3time }}.snow_analysis.sfc_data.tile4.nc']
     - ['{{ DATA }}/anl/{{ memchar }}/{{ bkgtime | to_fv3time }}.sfc_data.tile5.nc',
-       '{{ COMIN_SNOW_ANALYSIS_MEM }}/{{ bkgtime | to_fv3time }}.snow_analysis.sfc_data.tile5.nc']
+       '{{ COMOUT_SNOW_ANALYSIS_MEM }}/{{ bkgtime | to_fv3time }}.snow_analysis.sfc_data.tile5.nc']
     - ['{{ DATA }}/anl/{{ memchar }}/{{ bkgtime | to_fv3time }}.sfc_data.tile6.nc',
-       '{{ COMIN_SNOW_ANALYSIS_MEM }}/{{ bkgtime | to_fv3time }}.snow_analysis.sfc_data.tile6.nc']
+       '{{ COMOUT_SNOW_ANALYSIS_MEM }}/{{ bkgtime | to_fv3time }}.snow_analysis.sfc_data.tile6.nc']
     {% endfor %}
 {% endfor %}

--- a/parm/snow/snow_ens_config.yaml.j2
+++ b/parm/snow/snow_ens_config.yaml.j2
@@ -43,38 +43,38 @@ data_in:
         {% set gmem = gmem-NMEM_ENS_MAX %}
     {% endif %}
     # Construct per-member restart path for the previous enkfgdas cycle directly.
-    {% set COMIN_ATMOS_RESTART_PREV_MEM = ROTDIR ~ '/enkfgdas.' ~ (previous_cycle | to_YMD) ~ '/' ~ (previous_cycle | strftime('%H')) ~ '/mem' ~ '%03d' % gmem ~ '/model/atmos/restart' %}
+    {% set COMIN_ATMOS_RESTART_MEM_PREV = ROTDIR ~ '/enkfgdas.' ~ (previous_cycle | to_YMD) ~ '/' ~ (previous_cycle | strftime('%H')) ~ '/mem' ~ '%03d' % gmem ~ '/model/atmos/restart' %}
 
     # copy coupler file
-    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ current_cycle | to_fv3time }}.coupler.res', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_MEM_PREV }}/{{ current_cycle | to_fv3time }}.coupler.res', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
     # we need to copy them to two places, one serves as the basis for the analysis
-    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ current_cycle | to_fv3time }}.sfc_data.tile1.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
-    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ current_cycle | to_fv3time }}.sfc_data.tile2.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
-    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ current_cycle | to_fv3time }}.sfc_data.tile3.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
-    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ current_cycle | to_fv3time }}.sfc_data.tile4.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
-    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ current_cycle | to_fv3time }}.sfc_data.tile5.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
-    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ current_cycle | to_fv3time }}.sfc_data.tile6.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
-    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ current_cycle | to_fv3time }}.sfc_data.tile1.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
-    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ current_cycle | to_fv3time }}.sfc_data.tile2.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
-    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ current_cycle | to_fv3time }}.sfc_data.tile3.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
-    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ current_cycle | to_fv3time }}.sfc_data.tile4.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
-    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ current_cycle | to_fv3time }}.sfc_data.tile5.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
-    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ current_cycle | to_fv3time }}.sfc_data.tile6.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_MEM_PREV }}/{{ current_cycle | to_fv3time }}.sfc_data.tile1.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_MEM_PREV }}/{{ current_cycle | to_fv3time }}.sfc_data.tile2.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_MEM_PREV }}/{{ current_cycle | to_fv3time }}.sfc_data.tile3.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_MEM_PREV }}/{{ current_cycle | to_fv3time }}.sfc_data.tile4.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_MEM_PREV }}/{{ current_cycle | to_fv3time }}.sfc_data.tile5.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_MEM_PREV }}/{{ current_cycle | to_fv3time }}.sfc_data.tile6.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_MEM_PREV }}/{{ current_cycle | to_fv3time }}.sfc_data.tile1.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_MEM_PREV }}/{{ current_cycle | to_fv3time }}.sfc_data.tile2.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_MEM_PREV }}/{{ current_cycle | to_fv3time }}.sfc_data.tile3.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_MEM_PREV }}/{{ current_cycle | to_fv3time }}.sfc_data.tile4.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_MEM_PREV }}/{{ current_cycle | to_fv3time }}.sfc_data.tile5.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_MEM_PREV }}/{{ current_cycle | to_fv3time }}.sfc_data.tile6.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
     {% if DOIAU %}
         # if using IAU, also need backgrounds copied at the beginning of the window
         # we need to copy them to two places, one serves as the basis for the analysis
-    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile1.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
-    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile2.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
-    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile3.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
-    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile4.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
-    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile5.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
-    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile6.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
-    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile1.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
-    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile2.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
-    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile3.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
-    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile4.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
-    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile5.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
-    - ['{{ COMIN_ATMOS_RESTART_PREV_MEM }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile6.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_MEM_PREV }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile1.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_MEM_PREV }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile2.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_MEM_PREV }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile3.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_MEM_PREV }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile4.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_MEM_PREV }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile5.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_MEM_PREV }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile6.nc', '{{ DATA }}/bkg/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_MEM_PREV }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile1.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_MEM_PREV }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile2.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_MEM_PREV }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile3.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_MEM_PREV }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile4.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_MEM_PREV }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile5.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
+    - ['{{ COMIN_ATMOS_RESTART_MEM_PREV }}/{{ WINDOW_BEGIN | to_fv3time }}.sfc_data.tile6.nc', '{{ DATA }}/anl/mem{{ '%03d' % mem }}/']
     {% endif %}
 {% endfor %}
 

--- a/test/aero/global-workflow/jjob_var_init.sh
+++ b/test/aero/global-workflow/jjob_var_init.sh
@@ -26,7 +26,11 @@ export COM_TOP=$ROTDIR
 
 # Set GFS COM paths
 source "${HOMEglobal}/ush/preamble.sh"
-source "${HOMEglobal}/dev/parm/config/gfs/config.com"
+# COM_*_TMPL must match the canonical source in dev/workflow/com_paths.py
+# shellcheck disable=SC2016
+export COM_OBS_TMPL='${ROTDIR}/${RUN}.${YMD}/${HH}/obs'
+# shellcheck disable=SC2016
+export COM_ATMOS_RESTART_TMPL='${ROTDIR}/${RUN}.${YMD}/${HH}/${MEMDIR}/model/atmos/restart'
 
 # Detect machine
 source "${HOMEglobal}/ush/detect_machine.sh"

--- a/test/atm/global-workflow/jjob_ens_init.sh
+++ b/test/atm/global-workflow/jjob_ens_init.sh
@@ -28,7 +28,15 @@ export ACCOUNT=da-cpu
 # Set GFS COM paths
 export STRICT="NO"
 source "${HOMEglobal}/ush/preamble.sh"
-source "${HOMEglobal}/dev/parm/config/gfs/config.com"
+# COM_*_TMPL must match the canonical source in dev/workflow/com_paths.py
+# shellcheck disable=SC2016
+export COM_OBS_TMPL='${ROTDIR}/${RUN}.${YMD}/${HH}/obs'
+# shellcheck disable=SC2016
+export COM_ATMOS_ANALYSIS_TMPL='${ROTDIR}/${RUN}.${YMD}/${HH}/${MEMDIR}/analysis/atmos'
+# shellcheck disable=SC2016
+export COM_ATMOS_HISTORY_TMPL='${ROTDIR}/${RUN}.${YMD}/${HH}/${MEMDIR}/model/atmos/history'
+# shellcheck disable=SC2016
+export COM_ATMOS_RESTART_TMPL='${ROTDIR}/${RUN}.${YMD}/${HH}/${MEMDIR}/model/atmos/restart'
 
 # Detect machine
 source "${HOMEglobal}/ush/detect_machine.sh"

--- a/test/atm/global-workflow/jjob_ens_init_split.sh
+++ b/test/atm/global-workflow/jjob_ens_init_split.sh
@@ -28,7 +28,13 @@ export ACCOUNT=da-cpu
 # Set GFS COM paths
 export STRICT="NO"
 source "${HOMEglobal}/ush/preamble.sh"
-source "${HOMEglobal}/dev/parm/config/gfs/config.com"
+# COM_*_TMPL must match the canonical source in dev/workflow/com_paths.py
+# shellcheck disable=SC2016
+export COM_OBS_TMPL='${ROTDIR}/${RUN}.${YMD}/${HH}/obs'
+# shellcheck disable=SC2016
+export COM_ATMOS_ANALYSIS_TMPL='${ROTDIR}/${RUN}.${YMD}/${HH}/${MEMDIR}/analysis/atmos'
+# shellcheck disable=SC2016
+export COM_ATMOS_HISTORY_TMPL='${ROTDIR}/${RUN}.${YMD}/${HH}/${MEMDIR}/model/atmos/history'
 
 # Detect machine
 source "${HOMEglobal}/ush/detect_machine.sh"

--- a/test/atm/global-workflow/jjob_var_init.sh
+++ b/test/atm/global-workflow/jjob_var_init.sh
@@ -28,7 +28,13 @@ export ACCOUNT=da-cpu
 # Set GFS COM paths
 export STRICT="NO"
 source "${HOMEglobal}/ush/preamble.sh"
-source "${HOMEglobal}/dev/parm/config/gfs/config.com"
+# COM_*_TMPL must match the canonical source in dev/workflow/com_paths.py
+# shellcheck disable=SC2016
+export COM_OBS_TMPL='${ROTDIR}/${RUN}.${YMD}/${HH}/obs'
+# shellcheck disable=SC2016
+export COM_ATMOS_ANALYSIS_TMPL='${ROTDIR}/${RUN}.${YMD}/${HH}/${MEMDIR}/analysis/atmos'
+# shellcheck disable=SC2016
+export COM_ATMOS_HISTORY_TMPL='${ROTDIR}/${RUN}.${YMD}/${HH}/${MEMDIR}/model/atmos/history'
 
 # Detect machine
 source "${HOMEglobal}/ush/detect_machine.sh"

--- a/ush/soca/run_jjobs.py
+++ b/ush/soca/run_jjobs.py
@@ -173,8 +173,11 @@ class JobCard:
         print(f"RUN: {self.RUN}")
 
         # setup COM variables
-        self.f.write("source ${HOMEglobal}/dev/parm/config/gfs/config.com\n")
+        # COM_*_TMPL must match the canonical source in dev/workflow/com_paths.py
         self.f.write("source ${HOMEglobal}/ush/preamble.sh\n")
+        self.f.write("export COM_OCEAN_HISTORY_TMPL='${ROTDIR}/${RUN}.${YMD}/${HH}/${MEMDIR}/model/ocean/history'\n")
+        self.f.write("export COM_ICE_HISTORY_TMPL='${ROTDIR}/${RUN}.${YMD}/${HH}/${MEMDIR}/model/ice/history'\n")
+        self.f.write("export COM_ICE_RESTART_TMPL='${ROTDIR}/${RUN}.${YMD}/${HH}/${MEMDIR}/model/ice/restart'\n")
         self.precom('COM_OCEAN_HISTORY_PREV', 'COM_OCEAN_HISTORY_TMPL')
         self.precom('COM_ICE_HISTORY_PREV', 'COM_ICE_HISTORY_TMPL')
         self.precom('COM_ICE_RESTART_PREV', 'COM_ICE_RESTART_TMPL')


### PR DESCRIPTION
# Description

- `config.com` is a legacy configuration mechanism that should be completely removed from the GDASApp. Currently, it is still referenced in:

1. GDASApp: Configuration lookup and initialization

# Companion PRs
- Ref [#5068](https://github.com/NOAA-EMC/global-workflow/pull/5068)

# Issues

- Resolves [#5068](https://github.com/NOAA-EMC/global-workflow/pull/5068)


# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmsnowDA <!-- JEDI snow cycled DA !-->
- [ ] C96_gcafs_cycled <!-- JEDI aerosol cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [ ] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_ufsgsi_hybatmDA <!-- JEDI atm Var with GSI EnKF cycled DA !-->
- [ ] C48_ufsenkf_atmDA <!-- JEDI atm EnKF cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
