### PR TITLE
refine sfc pressure yamls to reject out-of-type obs.

### DIFF
--- a/parm/jcb-gdas/observations/atmosphere/prepbufr_adpsfc.yaml.j2
+++ b/parm/jcb-gdas/observations/atmosphere/prepbufr_adpsfc.yaml.j2
@@ -417,7 +417,7 @@
   # TEMPORARY: REJECT ALL T OBS
   - filter: RejectList
     filter variables:
-    - name: airTemperatureAt2M
+    - name: airTemperature
   # End of Filters 
 
 

--- a/parm/jcb-gdas/observations/atmosphere/prepbufr_adpsfc.yaml.j2
+++ b/parm/jcb-gdas/observations/atmosphere/prepbufr_adpsfc.yaml.j2
@@ -55,6 +55,15 @@
   ###############################################
 
   obs prior filters:
+  - filter: RejectList
+    udescriptor: obs_type_check_ps
+    filter variables:
+    - name: stationPressure
+    where:
+    - variable:
+        name: ObsType/stationPressure
+      is_not_in: 181, 187
+
   # Initial Error Assignments for SFC Observations 
   - filter: Perform Action
     filter variables:
@@ -404,6 +413,11 @@
       is_not_in: 0, 1
     action:
       name: reject
+ 
+  # TEMPORARY: REJECT ALL T OBS
+  - filter: RejectList
+    filter variables:
+    - name: airTemperatureAt2M
   # End of Filters 
 
 

--- a/parm/jcb-gdas/observations/atmosphere/prepbufr_adpupa.yaml.j2
+++ b/parm/jcb-gdas/observations/atmosphere/prepbufr_adpupa.yaml.j2
@@ -38,6 +38,15 @@
   # Observation Prior Filters (QC)
   # ------------------------------
   obs prior filters:
+  - filter: RejectList
+    udescriptor: obs_type_check_ps
+    filter variables:
+    - name: stationPressure
+    where:
+    - variable:
+        name: ObsType/stationPressure
+      is_not_in: 120
+
   # Initial Error Assignments for SFC Observations 
   - filter: Perform Action
     filter variables:

--- a/parm/jcb-gdas/observations/atmosphere/prepbufr_adpupa.yaml.j2
+++ b/parm/jcb-gdas/observations/atmosphere/prepbufr_adpupa.yaml.j2
@@ -44,7 +44,7 @@
     - name: stationPressure
     where:
     - variable:
-        name: ObsType/stationPressure
+        name: ObsType/pressure
       is_not_in: 120
 
   # Initial Error Assignments for SFC Observations 

--- a/parm/jcb-gdas/observations/atmosphere/prepbufr_sfcshp.yaml.j2
+++ b/parm/jcb-gdas/observations/atmosphere/prepbufr_sfcshp.yaml.j2
@@ -38,6 +38,16 @@
   # Observation Prior Filters (QC)
   # ------------------------------
   obs prior filters:
+
+  - filter: RejectList
+    udescriptor: obs_type_check_ps
+    filter variables:
+    - name: stationPressure
+    where:
+    - variable:
+        name: ObsType/stationPressure
+      is_not_in: 180
+
   # Initial Error Assignments for SFC Observations 
   - filter: Perform Action
     filter variables:


### PR DESCRIPTION
# Description

<!-- Enter PR description here. -->

# Companion PRs

<!-- Enter links to any companion PRs here. -->

# Issues

<!-- Enter any issues referenced or resolved by this PR here. Use keywords "Resolves" or "Refs".
Resolves #1234
Refs #4321
Refs NOAA-EMC/repo#5678
-->

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmsnowDA <!-- JEDI snow cycled DA !-->
- [ ] C96_gcafs_cycled <!-- JEDI aerosol cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [ ] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_ufsgsi_hybatmDA <!-- JEDI atm Var with GSI EnKF cycled DA !-->
- [ ] C48_ufsenkf_atmDA <!-- JEDI atm EnKF cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
