### PR TITLE
Replace airTemperature with airTemperatureAt2M

### DIFF
--- a/parm/jcb-gdas/observations/atmosphere/prepbufr_adpsfc.yaml.j2
+++ b/parm/jcb-gdas/observations/atmosphere/prepbufr_adpsfc.yaml.j2
@@ -414,7 +414,7 @@
   # TEMPORARY: REJECT ALL T OBS
   - filter: RejectList
     filter variables:
-    - name: airTemperature
+    - name: airTemperatureAt2M
   # End of Filters 
 
 


### PR DESCRIPTION
# Description

Replace `airTemperature` in the following section of `parm/jcb-gdas/observations/atmosphere/prepbufr_adpsfc.yaml.j2`
```
   # TEMPORARY: REJECT ALL T OBS
   - filter: RejectList
     filter variables:
    - name: airTemperature
   # End of Filters 
```
with `airTemperatureAt2M`

# Companion PRs

None

# Issues

None

# Automated CI tests to run in Global Workflow
<!-- Which Global Workflow CI tests are required to adequately test this PR? -->
- [ ] atm_jjob <!-- JEDI atm single cycle DA !-->
- [ ] C96C48_ufs_hybatmDA <!-- JEDI atm cycled DA !-->
- [ ] C96C48_hybatmsnowDA <!-- JEDI snow cycled DA !-->
- [ ] C96_gcafs_cycled <!-- JEDI aerosol cycled DA !-->
- [ ] C48mx500_3DVarAOWCDA <!-- JEDI low-res marine 3DVar cycled DA  !-->
- [ ] C48mx500_hybAOWCDA <!-- JEDI marine hybrid envar cycled DA !-->
- [ ] C96C48_ufsgsi_hybatmDA <!-- JEDI atm Var with GSI EnKF cycled DA !-->
- [ ] C48_ufsenkf_atmDA <!-- JEDI atm EnKF cycled DA !-->
- [ ] C96C48_hybatmDA <!-- GSI atm cycled DA !-->
